### PR TITLE
fix(content-safety): flatten value_context dict before L3 join (QA Ga…

### DIFF
--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -851,11 +851,19 @@ class StructuredComparisonService:
             # L3 output moderation (spec sec 5.2). Joined verdict text + product
             # names + top review excerpts → omni-moderation-latest. Fails OPEN
             # on API exception (Build Principle #4). $0 — no _track_cost bump.
+            # value_context is a per-product dict ({product_0, product_1} per
+            # extraction_service.py:519). Flatten to a string before joining
+            # — empty dicts are falsy and filtered by `filter(None,...)`, but
+            # non-empty dicts pass through and crash str.join with
+            # "expected str instance, dict found".
+            _vc = comparison.get("value_context", "")
+            if isinstance(_vc, dict):
+                _vc = " ".join(str(v) for v in _vc.values() if v)
             _l3_text = " ".join(filter(None, [
                 comparison.get("winner_declaration", ""),
                 comparison.get("winner_reason", ""),
                 comparison.get("key_tradeoff", ""),
-                comparison.get("value_context", ""),
+                _vc,
                 *product_names,
                 *[
                     (h.get("text") if isinstance(h, dict) else str(h))
@@ -1214,11 +1222,16 @@ class StructuredComparisonService:
             # events (specs/prices/reviews/scores/verdict) have already
             # reached the client; frontend treats `complete` with
             # success=false as the terminal refusal regardless of priors.
+            # value_context is a per-product dict — flatten before joining
+            # (see sync path comment above for the join-crash repro).
+            _vc = comparison.get("value_context", "")
+            if isinstance(_vc, dict):
+                _vc = " ".join(str(v) for v in _vc.values() if v)
             _l3_text = " ".join(filter(None, [
                 comparison.get("winner_declaration", ""),
                 comparison.get("winner_reason", ""),
                 comparison.get("key_tradeoff", ""),
-                comparison.get("value_context", ""),
+                _vc,
                 *product_names,
                 *[
                     (h.get("text") if isinstance(h, dict) else str(h))


### PR DESCRIPTION
…te 5.3 RED)

QA found production regression on every successful compare:
  HTTP 400 'sequence item 3: expected str instance, dict found'

value_context is a per-product dict ({product_0, product_1}) per extraction_service.py:519, not a string. The L3 output-moderation text assembly used str.join() over a list that included comparison['value_context'] directly. filter(None, ...) drops empty dicts (falsy) but non-empty dicts pass through and crash str.join.

Fix at both call sites (sync + streaming, lines 854 + 1217): coerce value_context to a flat string before the join — preserve dict values joined by spaces so the moderation surface still includes both products' value-context text.

Both empty-dict and legacy-string shapes still work (back-compat). Locally verified with 4 edge cases:
  - Non-empty dict (prod failure repro): joins all values cleanly
  - Empty dict: filtered as before
  - Dict with None/empty-string values: filtered cleanly
  - Legacy string shape (defensive): passes through unchanged

Failure mode not caught by unit tests: test_content_safety_service.py exercises moderate_output(text: str) directly with string inputs. The crash only fires when compare_from_text reaches L3 with a real GPT-4o-mini verdict response containing a populated value_context dict — a path requiring a live verdict ($-burning live_unit test).

Per QA suggestion, a future test_content_safety_service.py addition that mocks moderate_output's INPUT path (not just output) with a value_context-shaped verdict dict would pin this regression.

QA loop-back per cross-QA matrix sec 4.1.