### PR TITLE
Genuine-price: all-category extraction fixes + Zyte no-fab hardening

### DIFF
--- a/app/services/algolia_service.py
+++ b/app/services/algolia_service.py
@@ -455,6 +455,26 @@ def _catalog_hit_fields(
     return {"title": title, "url": url, "in_stock": in_stock}
 
 
+def _overlap_score(p_words: set, surface: str) -> float:
+    """Fraction of query words present in `surface`, CONCATENATION-tolerant.
+
+    The plain `len(p_words & t_words) / len(p_words)` floor wrongly drops a
+    genuine hit when the index collapses a multi-word model name into one token:
+    "Air Force 1" -> "AIRFORCE" makes only 1 of 4 query words match (0.25), even
+    though the hit already PASSES strict_title_match + numbers_match. Here a query
+    word counts as matched when it is a whole token OR a substring of the
+    concatenated, separator-free surface ("air"/"force" both ⊂ "airforce..."),
+    so the redundant overlap floor stops vetoing correct hits. No-fab is intact:
+    the stronger gates (strict_title_match, numbers_match, counterfeit/accessory)
+    still reject wrong models/brands before this score is ever consulted."""
+    if not p_words:
+        return 0.0
+    t_words = normalize_words(surface)
+    tnorm = "".join(t_words)
+    matched = sum(1 for w in p_words if w in t_words or (w and w in tnorm))
+    return matched / len(p_words)
+
+
 def _catalog_match_hit(
     hits: List[Dict[str, Any]], product_name: str, store: Dict[str, Any]
 ) -> Optional[Dict[str, Any]]:
@@ -480,8 +500,7 @@ def _catalog_match_hit(
             continue
         if not strict_title_match(product_name, surface):
             continue
-        t_words = normalize_words(surface)
-        score = (len(p_words & t_words) / len(p_words)) if p_words else 0.0
+        score = _overlap_score(p_words, surface)
         if score < 0.4:
             continue
         # Require a positive price (in the pinned currency) before considering.
@@ -530,8 +549,7 @@ def _match_algolia_hit(
             continue
         if not strict_title_match(product_name, surface):
             continue
-        t_words = normalize_words(surface)
-        score = (len(p_words & t_words) / len(p_words)) if p_words else 0.0
+        score = _overlap_score(p_words, surface)
         if score < 0.4:
             continue
         # Require a genuine BHD price before considering the hit a candidate.

--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -2315,10 +2315,36 @@ def numbers_match(product_name: str, title: str) -> bool:
     return bool(product_numbers & title_numbers)
 
 
+def _collapse_concentration(text: str) -> str:
+    """Replace any spelled-out fragrance concentration phrase with its canonical
+    token (e.g. "eau de toilette" -> "edt", "eau de parfum" -> "edp") so the
+    word-presence matcher treats abbreviation variants as equal. Defined once and
+    reused by `strict_title_match`; `_CONCENTRATION_PATTERNS` is module-level and
+    fully bound by call time. No-op on text without a concentration phrase."""
+    if not text:
+        return text or ""
+    out = text
+    for pat, label in _CONCENTRATION_PATTERNS:
+        out = pat.sub(label, out)
+    return out
+
+
 def strict_title_match(product_name: str, title: str) -> bool:
-    """Key words from the product name must appear in the shopping title."""
+    """Key words from the product name must appear in the shopping title.
+
+    Concentration-aware: a designer-fragrance PDP often spells the concentration
+    differently than the query ("Eau de Toilette" vs "EDT"). Both sides are
+    normalized via the same `_CONCENTRATION_PATTERNS` map BEFORE the word-presence
+    loop, so abbreviation variants compare equal — e.g. the query
+    "Dior Sauvage Eau de Toilette 100ml" now matches the genuine alhajis PDP
+    "Dior Sauvage Edt M 100Ml" (both collapse to the "edt" token). No-fab is
+    preserved: a DIFFERENT concentration ("Eau de Parfum" vs "EDT") still fails,
+    because the labels differ.
+    """
     if is_counterfeit_listing(title):
         return False
+    product_name = _collapse_concentration(product_name)
+    title = _collapse_concentration(title)
     title_normalized = title.lower().replace("-", "")
     key_words = [
         w.replace("-", "") for w in product_name.lower().split()

--- a/app/services/serper_service.py
+++ b/app/services/serper_service.py
@@ -2,6 +2,7 @@
 Serper Service - Web search via Serper API (Google Search)
 Enhanced for structured product data extraction
 """
+import asyncio
 import os
 import httpx
 import logging
@@ -240,19 +241,30 @@ async def search_product_prices(
             f"[SHOPPING_QUERY_CLEAN] before={original_product!r} after={product!r}"
         )
 
-    primary = await _do_serper_shopping(product, gl=country)
-    primary_shopping = primary.get("shopping", []) or []
-    if primary_shopping:
-        return {
-            "shopping": primary_shopping,
-            "organic": [],
-            "query": product,
-            "shopping_region": country,
-        }
-
-    # GCC fallback to gl=us — only when primary is empty AND country is GCC.
+    # genuine-BH starvation fix (2026-06-27) — for a GCC country, fire the gl=country
+    # primary AND the gl=us fallback CONCURRENTLY rather than sequentially. Google has
+    # NO Bahrain shopping feed, so the gl=bh primary returns 0 essentially every time
+    # and the gl=us fallback was ALWAYS reached — but it ran ~3s AFTER the dead gl=bh
+    # call, stealing budget the downstream 15s genuine-BH curl fan_out needs. Running
+    # them in parallel reclaims that ~3s. Selection is UNCHANGED: prefer gl=country
+    # items when present (genuine local feed), else the gl=us fallback (powers the
+    # USD->BHD conversion + parks the converted_fallback). Net Serper calls are the
+    # same as before for the empty-primary path (the dominant GCC case); only WHEN the
+    # second call fires changes (concurrent, not serial). Non-GCC countries keep the
+    # single-call, no-fallback behaviour byte-for-byte.
     if country in _GCC_COUNTRIES:
-        fallback = await _do_serper_shopping(product, gl="us")
+        primary, fallback = await asyncio.gather(
+            _do_serper_shopping(product, gl=country),
+            _do_serper_shopping(product, gl="us"),
+        )
+        primary_shopping = primary.get("shopping", []) or []
+        if primary_shopping:
+            return {
+                "shopping": primary_shopping,
+                "organic": [],
+                "query": product,
+                "shopping_region": country,
+            }
         fallback_shopping = fallback.get("shopping", []) or []
         if fallback_shopping:
             return {
@@ -269,6 +281,16 @@ async def search_product_prices(
             "shopping_region": "us_fallback",
         }
 
+    # Non-GCC primary — single call, no gl=us fallback.
+    primary = await _do_serper_shopping(product, gl=country)
+    primary_shopping = primary.get("shopping", []) or []
+    if primary_shopping:
+        return {
+            "shopping": primary_shopping,
+            "organic": [],
+            "query": product,
+            "shopping_region": country,
+        }
     # Non-GCC primary returned empty — no fallback, just echo the primary
     # region tag so callers know we tried.
     return {

--- a/app/services/source_router.py
+++ b/app/services/source_router.py
@@ -645,6 +645,36 @@ def get_jsonapi_sources_for_category(category: str) -> List[Source]:
     ]
 
 
+def get_curl_pagescrape_sources_for_category(category: str) -> List[Source]:
+    """Genuine-BH orphan-row fix (2026-06-27) — Bahrain-tier PLAIN curl /
+    JSON-LD sources for `category`, in registry order.
+
+    These are the catalog rows that map to NO direct per-domain adapter
+    (mechanism "" or "curl", genuine_method "page_scrape_jsonld" — e.g.
+    sporter.com / drnutrition.com / matgarbahrain.com / healbahrain.com).
+    The consolidation script (build_source_registry_data._mechanism_and_flags)
+    emits ~199 such live rows (47 bahrain-tier), but UNTIL THIS SELECTOR they
+    had no consumer except the limit-capped Serper `site:` discovery — the
+    supplement branch (which never runs that discovery) reached NONE of them.
+
+    A row qualifies on mechanism ("" or "curl"), bahrain tier, and category —
+    the same predicate `_bahrain_discovery_only_sources` uses, minus the
+    Shopify/Algolia exclusions (already excluded by the is_shopify/is_algolia
+    guards). The caller curls/attributes the source's apex domain. Returns a
+    (possibly empty) list — never raises. Bahrain-tier only (every bahrain
+    literal + catalog row is BHD, so a hit on these is genuine BHD).
+    """
+    return [
+        s
+        for s in SOURCE_REGISTRY
+        if (s.mechanism or "") in ("", "curl")
+        and s.tier == "bahrain"
+        and not s.is_shopify
+        and not s.is_algolia
+        and (not s.categories or category in s.categories)
+    ]
+
+
 def get_sitemap_sources_for_category(category: str) -> List[Source]:
     """Source-intelligence (2026-06-23) — Bahrain-tier sitemap/curl sources for
     `category`, in registry order. Discovery via the store's OWN sitemap (an

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -4162,7 +4162,7 @@ class StructuredComparisonService:
             try:
                 from app.services.zyte_service import fetch_zyte_price, ZYTE_STORES
                 for _zdomain in ZYTE_STORES:
-                    _zp = await fetch_zyte_price(_zdomain, full_name, currency, category)
+                    _zp = await fetch_zyte_price(_zdomain, full_name, currency, category, brand=brand)
                     if _zp and _zp.get("amount", 0) > 0:
                         set_cached(cache_key, _zp, price_cache_ttl(_zp))
                         self._save_price_to_db(cache_key, brand, name, variant, region, _zp)

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -863,10 +863,12 @@ from app.services.source_router import (
     is_non_pdp_listing_url,
     rewrite_to_bh_locale,
     is_render_only_domain,
+    get_sources_for_category,
     get_shopify_sources_for_category,
     get_algolia_sources_for_category,
     get_sitemap_sources_for_category,
     get_jsonapi_sources_for_category,
+    get_curl_pagescrape_sources_for_category,
     # BH/GCC source-build (2026-06-25) — the 6 new $0 direct-fetch selectors.
     get_woo_sources_for_category,
     get_salla_sources_for_category,
@@ -892,6 +894,46 @@ from app.services.sitemap_discovery_service import (
     sitemap_domains_now_built,
     sitemap_unbuilt_domains,
 )
+
+
+# Direct-adapter mechanisms that SHORT-CIRCUIT the price cascade BEFORE the Serper
+# `site:` discovery wave. A bahrain-tier source with one of these mechanisms (or the
+# is_shopify/is_algolia flags) is reached by a $0 direct fetch, not by discovery — so
+# its existence does NOT mean discovery will be wasted, but it also doesn't NEED the
+# discovery prefetch. A bahrain-tier price source with NONE of these is a plain
+# page-scrape source (e.g. gcc.luluhypermarket.com, talabat.com) reachable ONLY via
+# the Serper `site:` discovery cascade.
+_DIRECT_ADAPTER_MECHANISMS = frozenset({
+    "shopify", "algolia", "sitemap", "curl", "json_api",
+    "woo_store_json", "salla_api", "occ_rest", "magento_graphql",
+    "unbxd", "rest_json",
+})
+
+
+def _bahrain_discovery_only_sources(category: str) -> list:
+    """Genuine-BH starvation fix (2026-06-27) — bahrain-tier PRICE sources for
+    `category` that are reachable ONLY via the Serper `site:` discovery cascade
+    (plain page-scrape, e.g. gcc.luluhypermarket.com / talabat.com), i.e. NOT a
+    Shopify/Algolia/sitemap/jsonapi/woo/salla/occ/magento/unbxd/rest_json direct
+    adapter. These never short-circuit before discovery, so when one exists the
+    discovery prefetch is genuinely USED (never wasted) and must fire concurrently
+    with serper_shopping rather than be suppressed by an unrelated direct adapter's
+    presence. Returns a (possibly empty) list — never raises."""
+    try:
+        sources = get_sources_for_category(category, usage="price")
+    except Exception:  # noqa: BLE001 — registry read must never break the price race
+        return []
+    out = []
+    for s in sources:
+        if getattr(s, "tier", "") != "bahrain":
+            continue
+        if getattr(s, "is_shopify", False) or getattr(s, "is_algolia", False):
+            continue
+        if (getattr(s, "mechanism", "") or "") in _DIRECT_ADAPTER_MECHANISMS:
+            continue
+        out.append(s)
+    return out
+
 
 SERPER_API_KEY = os.getenv("SERPER_API_KEY")
 
@@ -4231,18 +4273,49 @@ class StructuredComparisonService:
         # fire, the tasks are CANCELLED below (no orphans — L5.3). This changes
         # WHEN discovery is fetched, NEVER the selection (the same results feed
         # the same _harvest/fan_out/_select_best).
-        # S3 #34 BUDGET BOUND (team-lead gate, option b) — SKIP the speculative
-        # prefetch when this category has Shopify-json OR Algolia direct sources.
-        # Those sources SHORT-CIRCUIT before discovery (fragrances=alhajis Shopify,
-        # fashion=6thStreet Algolia), so the 4 prefetched Serper calls would be
-        # ALREADY SPENT (they finish in ~1-2s, inside shopping's 5.9s) before the
-        # cancel fires = wasted (~+30% Serper on those ~8/20 smoke20 queries).
-        # Electronics has NO Shopify/Algolia sources → prefetch still fires (the
-        # latency-critical category that needs it; iPhone verified <15s after).
+        # S3 #34 BUDGET BOUND (team-lead gate, option b) — the speculative discovery
+        # prefetch costs ~4 Serper calls, so it must only fire when it's actually
+        # USED (escalation reaches the discovery cascade), not wasted by an earlier
+        # short-circuit. The ORIGINAL gate skipped it whenever the category had ANY
+        # Shopify/Algolia direct source, on the assumption those always short-circuit
+        # before discovery. That assumption broke after the BH/GCC catalog build
+        # (2026-06-25): grocery's Shopify sources are NICHE health/organic stores
+        # (ibsouq/livewell/smartnutr/hmmba) that almost NEVER carry a mainstream item
+        # like Nutella, and electronics GAINED Shopify rows (shopalmoayyed/sonyworld)
+        # too — so a non-niche product never short-circuits on them, yet their mere
+        # existence DISABLED the genuine-BH Lulu discovery prefetch, forcing it to run
+        # SERIALLY after the ~6-12s shopping wait and time out under the 15s cap.
+        # FIX (genuine-BH starvation, 2026-06-27): fire the discovery prefetch when
+        # the category has bahrain-tier price sources reachable ONLY via the Serper
+        # `site:` discovery cascade — plain page-scrape sources (mechanism "", e.g.
+        # gcc.luluhypermarket.com / talabat) that are NOT a direct adapter, AS LONG AS
+        # the category has NO Algolia source. The distinction matters:
+        #   * Algolia (6thStreet/goldenscent) short-circuits on ANY genuine hit, so a
+        #     category with an Algolia source CAN waste the ~4 prefetch Serper calls
+        #     when Algolia carries the product — keep suppressing it there (preserves
+        #     the pinned budget invariant; the dominant short-circuit case).
+        #   * Shopify BH rows are almost all RESELLERS (asgharali, shopalmoayyed) +
+        #     niche stores (ibsouq/livewell) — a reseller hit is PARKED, not short-
+        #     circuited, so discovery runs anyway; and grocery's niche Shopify stores
+        #     almost never carry a mainstream item (Nutella), so they never short-
+        #     circuit either. Their mere existence must NOT disable the genuine-BH
+        #     Lulu discovery prefetch (the bug: grocery + electronics both have such
+        #     Shopify rows now, starving the Lulu curl under the 15s cap).
+        # So: fire when (no Shopify AND no Algolia) [original] OR (no Algolia AND has
+        # a discovery-only BH source). The discovery tasks are cancelled on any
+        # genuine short-circuit, so this only MOVES the calls earlier (concurrent
+        # with shopping) for the Shopify-reseller / discovery-only categories.
+        _has_discovery_only_bh_sources = bool(
+            _bahrain_discovery_only_sources(category)
+        )
+        _has_algolia = bool(get_algolia_sources_for_category(category))
         _pf_eligible = (
             not is_supplement and ENABLE_PAGE_SCRAPE
-            and not get_shopify_sources_for_category(category)
-            and not get_algolia_sources_for_category(category)
+            and not _has_algolia
+            and (
+                not get_shopify_sources_for_category(category)
+                or _has_discovery_only_bh_sources
+            )
         )
         _prefetched_discovery: List[Tuple[str, Any]] = []
         if _pf_eligible:
@@ -4301,13 +4374,18 @@ class StructuredComparisonService:
         # genuine-BHD storefront adapters. UNLIKE the Shopify/Algolia prefetch
         # above, these are DELIBERATELY NOT `not is_supplement`-gated: bolo and
         # nasser both COVER supplements (bolo=supplements/makeup/skincare,
-        # nasser=supplements/skincare/makeup/haircare/fragrances), so a supplement
-        # compare MUST be able to reach them. The non-supplement escalation block
-        # consumes them via `_prefetched_direct["sitemap"/"jsonapi"]`; the
-        # supplement branch consumes the SAME futures in its explicit Stage-1.5
-        # (between iHerb and pharmacy). Both are $0 (own sitemap/API — no Serper,
-        # no render), so speculating them costs nothing on the rare miss query
-        # (the cancel below just drops a couple of free HTTP GETs).
+        # nasser=supplements/skincare/makeup/haircare/fragrances), so the prefetch
+        # FIRES on a supplement compare too (zero waste — cancelled on a miss).
+        # CORRECTION (2026-06-27): the NON-supplement escalation block consumes
+        # them via `_consume_adapter_prefetch()` (`_prefetched_direct["sitemap"/
+        # "jsonapi"/...]`). The SUPPLEMENT branch does NOT call
+        # `_consume_adapter_prefetch` — it has its own Stage-1/2/3 (iHerb →
+        # pharmacy → page-scrape known retailers) and reaches bolo/nasser + the
+        # catalog curl/JSON-LD supplement sources via Stage-3 page-scrape +
+        # CDE-2 retailer attribution over the bahrain `known_supplement_retailers`
+        # set (registry-derived; see Stage-3). A pre-run cancel just drops the
+        # speculative $0 GETs. (The earlier note claiming a supplement Stage-1.5
+        # consume of these futures was stale — no such consume exists.)
         _sitemap_sources_pf = get_sitemap_sources_for_category(category)
         _jsonapi_sources_pf = get_jsonapi_sources_for_category(category)
         # BH/GCC source-build (2026-06-25) — the 6 new $0 direct-fetch adapters.
@@ -5349,6 +5427,29 @@ class StructuredComparisonService:
 
             # --- Stage 3: page-scrape known supplement/pharmacy PDPs (bounded ~3s) ---
             known_supplement_retailers = {"iherb.com", "bn.boots.com", "bolo.bh", "amazon.com", "noon.com"}
+            # Genuine-BH orphan-row fix (2026-06-27) — the supplement branch never
+            # runs the Serper `site:` discovery cascade, so the bahrain-tier curl/
+            # JSON-LD catalog supplement sources (sporter.com / drnutrition.com /
+            # matgarbahrain.com / healbahrain.com / ymhonlinepharmacy.com.bh /
+            # lilyorganicsbh.com / mumzworld.com — all status=live, currency=BHD,
+            # genuine page_scrape_jsonld, curl-200 verified live: sporter 56.39 /
+            # drnutrition 12.44 BHD) had NO consumer here. Admit them so (a) Stage-3
+            # page-scrape curls their PDP when bh_organic surfaces it (genuine BHD),
+            # and (b) the CDE-2 deterministic retailer attribution
+            # (_match_bh_organic_retailer) labels a Tier-2 GPT-organic price as a real
+            # local_bhd retailer instead of pending. Registry-derived (no hardcoded
+            # drift) + gated by ENABLE_BH_GCC_CATALOG_SOURCES (the selector returns []
+            # with the flag OFF → byte-identical to today). $0: no new Serper, no
+            # render — only curls/attributes links Serper already returned. No-fab
+            # preserved: attribution still requires a deterministic brand+name token
+            # match, and Stage-3 only scrapes a real curled price.
+            try:
+                for _cs in get_curl_pagescrape_sources_for_category("supplements"):
+                    _csd = (_cs.domain or "").replace("www.", "").strip().lower()
+                    if _csd:
+                        known_supplement_retailers.add(_csd)
+            except Exception:  # noqa: BLE001 — registry read must never break pricing
+                pass
             if ENABLE_PAGE_SCRAPE:
                 async def _page_scrape_supplement_stage():
                     for item in (iherb_organic + bh_organic)[:5]:

--- a/app/services/zyte_service.py
+++ b/app/services/zyte_service.py
@@ -13,28 +13,36 @@ the off-clock seed/warmer (scripts/seed_zyte_luxury.py), never on the request
 path. The live cascade serves the genuine BHD price the seed wrote to the cache.
 
 Genuine method ``zyte_render_bhd``. FRAGRANCE/BEAUTY-scoped (the fils-fix assumes
-a plausible price < 1000 BHD). Strict-match no-fab (sephora doesn't stock every
-brand — a "Creed Aventus" search returns makeup, which MUST be rejected, not
-shipped as a wrong price). Budget-aware (records Zyte usage). NEVER raises.
+a plausible price < 1000 BHD). Strict-match no-fab via a HARD product-identity
+gate (sephora doesn't stock every brand — a "Creed Aventus" search returns makeup,
+and a flanker like "Black Opium Over Red" or a near-name like "Ombre Nomade" must
+be rejected, not shipped as a wrong price). NOT yet metered in api_budget_service;
+instead a terminal billing 4xx (401/402/403) trips a per-run kill-switch so a
+suspended/over-limit account is not hammered for the rest of a seed run. NEVER
+raises.
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 import os
+import re
+import unicodedata
 import urllib.parse
 from typing import Any, Dict, List, Optional
 
 import httpx
 
 from app.services.price_service import (
-    strict_title_match,
     numbers_match,
     variant_mismatch,
     is_counterfeit_listing,
     is_accessory,
     is_price_showable,
     normalize_words,
+    extract_concentration,
+    _CONCENTRATION_PATTERNS,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,6 +50,131 @@ logger = logging.getLogger(__name__)
 ZYTE_API_URL = "https://api.zyte.com/v1/extract"
 _TIMEOUT = float(os.getenv("ZYTE_TIMEOUT", "100"))
 _GENUINE_METHOD = "zyte_render_bhd"
+
+# Concentration-word tokens — excluded from the "extra tokens" penalty so a plain
+# "Oud Wood - Eau de Parfum" is NOT scored worse than "Oud Wood Parfum" just for
+# carrying the (expected) concentration words. Mirrors extract_concentration's
+# vocabulary.
+_CONCENTRATION_TOKENS = frozenset({
+    "eau", "de", "parfum", "toilette", "cologne", "edp", "edt", "edc",
+    "extrait", "intense", "fraiche", "perfume",
+})
+
+# Default concentration preference when the QUERY does not state one. EDP and EDT
+# are CO-FLAGSHIP (both the everyday wearable a brand+name query means) — the pricier
+# niche Parfum/Extrait rank well below. This fixes "Tom Ford Oud Wood" mis-matching
+# the Parfum (158) over the EDP (77). EDP and EDT TIE on purpose: between them the
+# canonical bottle is brand-specific (Sauvage/Black Opium are EDP-iconic; Acqua di
+# Gio/CK One are EDT-iconic), so the tie is broken by sephora's own relevance
+# ranking (metadata.probability) rather than a wrong fixed EDP>EDT bias. Higher =
+# preferred.
+_CONCENTRATION_PREFERENCE = {
+    "EDP": 0.30,
+    "EDT": 0.30,
+    "EDC": 0.20,
+    "Eau Fraiche": 0.18,
+    "Parfum": 0.10,
+    "Parfum Intense": 0.10,
+    "Extrait": 0.05,
+}
+
+# Non-bottle FORM phrases. sephora's productList for a fragrance search also
+# surfaces gift sets, body sprays/mists, deodorants, candles, etc. — a DIFFERENT
+# product form whose price must not be attributed to the fragrance bottle (e.g.
+# "Oud Wood - All Over Body Spray" 41 BHD, "Oud Wood Eau de Parfum Set" 119 BHD).
+# Rejected unless the QUERY itself asks for that form. "spray" alone is NOT here
+# (a normal EDP bottle is titled "Eau de Parfum Spray").
+_NON_BOTTLE_PHRASES = (
+    "body spray", "body mist", "hair mist", "body lotion", "body cream",
+    "body oil", "shower gel", "deodorant", "gift set", "discovery set",
+    "travel set", "candle", "refill", "miniature", "rollerball",
+    "roll-on", "roll on",
+)
+
+
+def _is_wrong_form(query_lc: str, title_lc: str, q_words: set, t_words: set) -> bool:
+    """True iff the candidate title is a NON-BOTTLE product form the query did
+    not ask for (gift set / body spray / deodorant / candle …)."""
+    for phrase in _NON_BOTTLE_PHRASES:
+        if phrase in title_lc and phrase not in query_lc:
+            return True
+    # A trailing/standalone "Set" token = a gift/bundle SKU (e.g. "… Parfum Set").
+    if "set" in t_words and "set" not in q_words:
+        return True
+    return False
+
+
+# --- product-identity gate + account kill-switch (no-fab hardening 2026-06-26) ---
+# A terminal billing 4xx (401/402/403) sets this so the rest of a seed RUN stops
+# issuing paid Zyte renders against a suspended / over-limit account (fragile-trial
+# protection — the prior account was suspended at its spending limit). Per-process.
+_ACCOUNT_DEAD = False
+
+
+def reset_account_state() -> None:
+    """Test/seed hook — clear the per-run account-dead kill-switch."""
+    global _ACCOUNT_DEAD
+    _ACCOUNT_DEAD = False
+
+
+# Size tokens ("100ml", "3.4 oz") are NOT product identity — stripped before the
+# identity comparison (size fairness is handled downstream).
+_SIZE_TOKEN_RE = re.compile(r"\b\d+(?:\.\d+)?\s*(?:ml|fl\s*oz|oz)\b", re.I)
+
+# Form/packaging words that are NOT product identity. The form GATE rejects the
+# real non-bottle forms first; these are defense-in-depth so a stray suffix (a lone
+# "Spray" on a normal EDP bottle) doesn't break identity equality.
+_FORM_TOKENS = frozenset({
+    "set", "spray", "mist", "deodorant", "candle", "refill", "miniature",
+    "lotion", "cream", "gel", "oil", "balm", "shower", "body", "hair", "travel",
+})
+
+
+def _fold(s: str) -> str:
+    """Lowercase + strip diacritics so an accented sephora title matches a
+    plain-ASCII query and vice versa: "Acqua di Giò" → "acqua di gio", "Lancôme" →
+    "lancome", "Hermès" → "hermes". Without this the identity gate falsely PENDS a
+    genuine listing whose only difference is an accent (live-observed: sephora's
+    "Acqua di Giò Eau de Toilette" rejected for query "Acqua di Gio")."""
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", (s or "").lower())
+        if not unicodedata.combining(c)
+    )
+
+
+def _identity_tokens(text: str, brand: str = "") -> set:
+    """PRODUCT-IDENTITY tokens of `text`: its words (DIACRITIC-FOLDED) minus the
+    brand, the concentration PHRASE (so "eau de parfum"/"parfum intense" go but a
+    standalone product word like the "intense" in "Dior Homme Intense" STAYS), size
+    tokens, form words, and sub-3-char noise. Two listings are the SAME product iff
+    their identity sets are EQUAL — the no-fab gate that rejects a flanker ("Black
+    Opium Over Red" -> {black,opium,over,red}), a near-name ("Ombre Nomade" vs
+    "Ombre Leather"), and a base shipped for a flanker query ("Dior Homme" {homme}
+    vs "Dior Homme Intense" {homme,intense}). Phrase-based concentration stripping
+    (the price_service patterns) keeps "intense" as identity unless it is the
+    "parfum intense" concentration."""
+    if not text:
+        return set()
+    stripped = _fold(text)
+    for pat, _label in _CONCENTRATION_PATTERNS:
+        stripped = pat.sub(" ", stripped)
+    stripped = _SIZE_TOKEN_RE.sub(" ", stripped)
+    words = normalize_words(stripped)
+    brand_words = normalize_words(_fold(brand))
+    return {w for w in (words - brand_words - _FORM_TOKENS) if len(w) > 2}
+
+
+def _concentration_bonus(q_conc: Optional[str], t_conc: Optional[str]) -> float:
+    """Scoring bonus for a candidate's concentration.
+
+    - Query states a concentration → the matching candidate gets the bonus, an
+      unstated-title candidate gets 0 (kept on benefit-of-doubt, ranked below an
+      exact match); a mismatched explicit concentration is rejected upstream.
+    - Query unspecified → prefer the flagship wearable concentration (EDP > EDT …)
+      so a brand+name query lands on the EDP, not the pricier Parfum/Extrait."""
+    if q_conc:
+        return 0.30 if t_conc == q_conc else 0.0
+    return _CONCENTRATION_PREFERENCE.get(t_conc or "", 0.0)
 
 # Per-store config: apex domain -> {search URL template, currency}. The search
 # productList extraction returns matching PDPs + prices in one Zyte call.
@@ -87,39 +220,94 @@ def normalize_bhd_amount(raw: Any) -> Optional[float]:
 
 
 async def _zyte_extract(url: str, body: Dict[str, Any]) -> Optional[dict]:
-    """ONE Zyte API extraction with geolocation=BH. Returns the parsed JSON or
-    None on any failure (no key / non-200 / transport). Never raises."""
+    """ONE Zyte API extraction with geolocation=BH, with bounded retry on TRANSIENT
+    failures (transport error / HTTP 429 / 5xx). A 4xx (auth/billing/not-found) is
+    TERMINAL — never retried (a suspended account or bad key would just burn the
+    retry budget). Returns the parsed JSON or None. Never raises.
+
+    Retry knobs (env, read fresh): ZYTE_RETRIES (total attempts, default 2),
+    ZYTE_RETRY_BACKOFF (seconds between attempts, default 2.0; 0 in tests)."""
     auth = _auth_header()
     if not auth:
         return None
-    try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.post(
-                ZYTE_API_URL,
-                headers={"Authorization": auth},
-                json={"url": url, "geolocation": "BH", **body},
-            )
-    except Exception as exc:  # noqa: BLE001 — a fetch error is a miss, never a crash
-        logger.warning("[ZYTE] extract failed for %s: %s", url, exc)
+    attempts = max(1, int(os.getenv("ZYTE_RETRIES", "2")))
+    backoff = float(os.getenv("ZYTE_RETRY_BACKOFF", "2.0"))
+    for attempt in range(1, attempts + 1):
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                resp = await client.post(
+                    ZYTE_API_URL,
+                    headers={"Authorization": auth},
+                    json={"url": url, "geolocation": "BH", **body},
+                )
+        except Exception as exc:  # noqa: BLE001 — a fetch error is a miss, never a crash
+            logger.warning("[ZYTE] transport error for %s (attempt %d/%d): %s",
+                           url, attempt, attempts, exc)
+            if attempt < attempts and backoff > 0:
+                await asyncio.sleep(backoff)
+            continue
+        if resp.status_code == 200:
+            try:
+                return resp.json()
+            except Exception:  # noqa: BLE001
+                return None
+        # 429 / 5xx = transient (rate-limit / Zyte hiccup) → retry. Any other 4xx
+        # (401 bad key, 402/403 billing/suspended, 404) = terminal → stop now.
+        if resp.status_code == 429 or resp.status_code >= 500:
+            logger.info("[ZYTE] HTTP %s (transient) for %s (attempt %d/%d)",
+                        resp.status_code, url, attempt, attempts)
+            if attempt < attempts and backoff > 0:
+                await asyncio.sleep(backoff)
+            continue
+        # An account-level terminal status (401 bad key, 402/403 billing/suspended)
+        # means EVERY further render this run will also fail → trip the per-run
+        # kill-switch so the seed loop stops hammering a dead/over-limit account
+        # (a suspended-account 403 protects the single call; this protects the run).
+        if resp.status_code in (401, 402, 403):
+            global _ACCOUNT_DEAD
+            _ACCOUNT_DEAD = True
+            logger.warning("[ZYTE] account-level HTTP %s — disabling Zyte for the rest of this run",
+                           resp.status_code)
+        logger.info("[ZYTE] HTTP %s (terminal) for %s: %s",
+                    resp.status_code, url, resp.text[:160])
         return None
-    if resp.status_code != 200:
-        logger.info("[ZYTE] HTTP %s for %s: %s", resp.status_code, url, resp.text[:120])
-        return None
-    try:
-        return resp.json()
-    except Exception:  # noqa: BLE001
-        return None
+    return None
 
 
-def _match_product(products: List[Dict[str, Any]], product_name: str) -> Optional[Dict[str, Any]]:
-    """Best STRICT title match among Zyte products, or None. Same no-fab gates as
-    every other adapter so a wrong-brand hit (sephora returns makeup for a "Creed
-    Aventus" search) is REJECTED, never shipped as the query's price."""
+def _match_product(
+    products: List[Dict[str, Any]], product_name: str, brand: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Best STRICT identity match among Zyte products, or None. No-fab gates so a
+    wrong-brand hit (sephora returns makeup for "Creed Aventus"), a flanker, or a
+    near-name is REJECTED, never shipped as the query's price.
+
+    Gates (2026-06-26 hardening):
+      (1) FORM gate — gift sets / body sprays / deodorants / candles are a different
+          product form and are dropped (their price ≠ the bottle's).
+      (2) HARD PRODUCT-IDENTITY gate — the candidate's identity tokens
+          (_identity_tokens: brand + concentration phrase + size + form stripped)
+          must EQUAL the query's. This is BRAND-AWARE (sephora omits the brand from
+          titles, so a "Marc Jacobs Daisy" query matches a "Daisy - Eau de Toilette"
+          title) yet rejects:
+            • a flanker — "Black Opium Over Red" ({black,opium,over,red}) ≠
+              "YSL Black Opium" ({black,opium});
+            • a near-name — "Ombre Nomade" ≠ "Tom Ford Ombre Leather";
+            • a base shipped for a flanker query — "Dior Homme" ({homme}) ≠
+              "Dior Homme Intense" ({homme,intense}).
+          (Replaces a loose 0.5 distinctive-overlap that admitted all three.)
+      (3) CONCENTRATION precision — an explicit query concentration must match
+          (mismatch rejected); among identity-equal candidates an unspecified query
+          prefers the flagship EDP/EDT over the pricier Parfum/Extrait (Oud Wood →
+          77 EDP, not 158 Parfum). Ties broken by Zyte's metadata.probability.
+    """
     if not products:
         return None
-    p_words = normalize_words(product_name)
-    if not p_words:
+    q_ident = _identity_tokens(product_name, brand)
+    if not q_ident:
         return None
+    p_words = normalize_words(product_name)
+    query_lc = product_name.lower()
+    q_conc = extract_concentration(product_name)
     best: Optional[Dict[str, Any]] = None
     best_score = -1.0
     for product in products:
@@ -137,19 +325,27 @@ def _match_product(products: List[Dict[str, Any]], product_name: str) -> Optiona
         if normalize_bhd_amount(product.get("price")) is None:
             continue
         t_words = normalize_words(name)
-        # BRAND-IMPLIED-BY-SEARCH relaxation: sephora's productList titles OMIT the
-        # brand ("Oud Wood - Eau de Parfum", not "Tom Ford Oud Wood …") because the
-        # search already scoped the brand — so strict_title_match (which requires
-        # EVERY query word, incl. the brand) wrongly rejects the right product.
-        # Instead require the DISTINCTIVE product tokens present (overlap >= 0.5,
-        # which rejects a wrong-brand result whose overlap is ~0, e.g. a "Creed
-        # Aventus" search returning makeup), and prefer the title with the FEWEST
-        # EXTRA tokens so the plain "Eau de Parfum" beats the "… Set"/gift SKU.
-        overlap = len(p_words & t_words) / len(p_words)
-        if overlap < 0.5:
+        if _is_wrong_form(query_lc, name.lower(), p_words, t_words):
             continue
-        extra = len(t_words - p_words)
-        score = overlap - 0.1 * extra
+        # (2) HARD identity equality — same product or pend. No partial-overlap,
+        # no extra-token flanker, no missing-token base.
+        if _identity_tokens(name, brand) != q_ident:
+            continue
+        # (3) concentration: reject an EXPLICIT mismatch; rank by preference.
+        t_conc = extract_concentration(name)
+        if q_conc and t_conc and t_conc != q_conc:
+            continue
+        prob = 0.0
+        meta = product.get("metadata")
+        if isinstance(meta, dict):
+            try:
+                prob = float(meta.get("probability") or 0.0)
+            except (TypeError, ValueError):
+                prob = 0.0
+        # extra non-concentration tokens (≈0 after the identity gate) + concentration
+        # preference + Zyte confidence as the final deterministic tiebreak.
+        non_conc_extra = len((t_words - p_words) - _CONCENTRATION_TOKENS)
+        score = _concentration_bonus(q_conc, t_conc) - 0.1 * non_conc_extra + 0.001 * prob
         if score > best_score:
             best = product
             best_score = score
@@ -158,26 +354,49 @@ def _match_product(products: List[Dict[str, Any]], product_name: str) -> Optiona
 
 async def fetch_zyte_price(
     domain: str, product_name: str, currency: str = "BHD", category: str = "fragrances",
+    brand: str = "",
 ) -> Optional[Dict[str, Any]]:
     """Genuine BHD price for an Akamai-walled luxury store via Zyte render, or None.
 
     OFF-CLOCK only (gated by ENABLE_ZYTE_RENDER). Searches the store via Zyte
-    productList, strict-matches the product (no-fab), fils-normalizes the BHD
-    amount, and returns a ``source_method="zyte_render_bhd"`` price dict
-    (is_price_showable + content-safety gated) or None on any miss / wrong-match /
-    error. NEVER raises."""
+    productList, strict-matches the product (no-fab, brand+concentration-aware),
+    fils-normalizes the BHD amount, and returns a ``source_method="zyte_render_bhd"``
+    price dict (is_price_showable + content-safety gated) or None on any miss /
+    wrong-match / error. ``brand`` (when known) drives the brand-aware overlap so a
+    multi-word brand whose name sephora omits from the title still matches. NEVER
+    raises."""
     if not _enabled():
+        return None
+    # Per-run kill-switch: once an account-level terminal status (401/402/403) has
+    # been seen this run, every further render would also fail — stop issuing paid
+    # Zyte calls (protects a fragile/suspended trial across a 20-product seed loop).
+    if _ACCOUNT_DEAD:
+        logger.info("[ZYTE] account disabled this run (prior terminal 4xx) — skipping %s", product_name)
         return None
     store = ZYTE_STORES.get((domain or "").replace("www.", "").strip().lower())
     if not store:
         return None
 
     search_url = store["search"].format(q=urllib.parse.quote(product_name))
-    data = await _zyte_extract(search_url, {"productList": True})
-    if not data:
-        return None
-    products = (data.get("productList") or {}).get("products") or []
-    hit = _match_product(products, product_name)
+    # Retry an EMPTY (200-but-no-products) result — those are transient on sephora
+    # (the 2 Mugler/Paco empties in the seed). A None from _zyte_extract is terminal
+    # (auth/billing/exhausted transport retries) → stop immediately.
+    empty_retries = max(1, int(os.getenv("ZYTE_EMPTY_RETRIES", "2")))
+    backoff = float(os.getenv("ZYTE_RETRY_BACKOFF", "2.0"))
+    products: List[Dict[str, Any]] = []
+    for attempt in range(1, empty_retries + 1):
+        data = await _zyte_extract(search_url, {"productList": True})
+        if data is None:
+            return None
+        products = (data.get("productList") or {}).get("products") or []
+        if products:
+            break
+        logger.info("[ZYTE] empty productList for '%s' @ %s (attempt %d/%d)",
+                    product_name, domain, attempt, empty_retries)
+        if attempt < empty_retries and backoff > 0:
+            await asyncio.sleep(backoff)
+
+    hit = _match_product(products, product_name, brand)
     if not hit:
         logger.info("[ZYTE] no strict match for '%s' @ %s (%d candidates)",
                     product_name, domain, len(products))

--- a/docs/plans/2026-06-26-render-rotation-and-zyte-tuning-plan.md
+++ b/docs/plans/2026-06-26-render-rotation-and-zyte-tuning-plan.md
@@ -1,0 +1,78 @@
+# Plan — Serper/Scrape.do rotation + Zyte render-tier tuning (2026-06-26)
+
+Continues the genuine-price work. Prod `main` @ `dcf1734` (BH/GCC catalog ACTIVE,
+Zyte tier shipped dormant). Three providers were dead/degrading; new keys supplied
+this session.
+
+## Provider state (verified this session)
+| Provider | Old state | New key | Local-verified |
+|---|---|---|---|
+| Serper | depleted (`44e3b202`, 2645/2200) | `7de9c750…` | ✅ HTTP 200, fresh credits, counter absent (key-scoped) |
+| Scrape.do | dead (401) | `963772…` | ⏳ A/B running (does `super`+`geoCode=bh` crack sephora Akamai?) |
+| Zyte | **account suspended** (403 billing) | `e3374b…` (NEW account) | ⏳ A/B running (new key live?) |
+
+Key facts:
+- Serper counter + burn sentinel are **key-scoped** → the new key auto-starts fresh;
+  no reset needed. Stale sentinels for dead keys (`05d552d7`/`44e3b202`/`696e4e57`)
+  to be DEL'd for hygiene during deploy.
+- Zyte/live-path is **gated OFF** (`ENABLE_ZYTE_RENDER` unset on Railway) → the
+  render-tier never touches the 15s request clock; the off-clock seed writes the
+  cache, live serves cache-first. So **Zyte needs NO Railway var** — only local.
+
+## Step 1 — Serper rotation (restores specs/reviews/images + non-render prices)
+- [x] `.env` synced to `7de9c750…`
+- [x] new key liveness verified (direct probe)
+- [ ] **Railway** (needs `railway login`): `railway variables --set "SERPER_API_KEY=…" --service web` → `railway redeploy --service web`
+- [ ] DEL stale `budget:serper:burn_alert_fired:{05d552d7,44e3b202,696e4e57}` (hygiene)
+- [ ] verify: cold prod `GET /api/v1/text/prices/iPhone+15+Pro?nocache=true` → Serper-live (real retailers, not `estimated`)
+
+## Step 2 — Scrape.do rotation + render-provider A/B  ✅ DECIDED
+- [x] `.env` synced to `963772…`
+- [x] **A/B run** (`scripts/ab_render_providers.py`): Oud Wood → Zyte 77 (33.5s) AND
+  Scrape.do super 77 via page_scrape (14.4s, 200, cost=25) → **Scrape.do super DOES
+  crack sephora's Akamai wall**. But: Black Opium → Scrape.do 502 (transient); Dior →
+  Scrape.do only had the search page (no price). Zyte returned structured prices in
+  one call.
+- [x] **RENDER PROVIDER DECISION: Zyte stays the sephora render provider.** Zyte does
+  search→match→price in ONE call; Scrape.do can only render a URL you give it (no
+  search) → a Scrape.do-only sephora path needs a separate PDP-URL discovery step.
+  Scrape.do `super` is a proven BACKUP + the right tool for FUTURE render sources where
+  we already have PDP URLs (namshi/Carrefour catalogs); at 25 credits/req on 900/mo
+  (~36/mo) it is budget-tight for bulk seeding.
+- [ ] **Railway** (needs `railway login`): `railway variables --set "SCRAPEDO_API_TOKEN=…" --service web` → redeploy (restores the existing Tier-1.5d page-render fallback for non-walled retailers — independent of the sephora decision)
+
+## Step 3 — Zyte matcher fixes + no-fab HARDENING (CODE DONE, 33/33 tests green) + re-seed
+Adversarial review Workflow (`wf_5211466b-4ee`) found REAL no-fab leaks (verify phase
+rate-limited → dispatcher-gated the 18 findings from the transcript). The loose 0.5
+overlap admitted flankers + near-names + bases. Replaced with a HARD identity gate.
+- [x] concentration precision (EDP>Parfum; explicit-mismatch reject) — live-verified Oud Wood 77 not 158
+- [x] **HARD product-identity gate** (`_identity_tokens` equality; brand+concentration-phrase+size+form stripped) — rejects flanker ("Black Opium Over Red"), near-name ("Ombre Nomade" vs "Ombre Leather"), base-for-flanker ("Dior Homme" vs "Dior Homme Intense")
+- [x] form gate (sets/body-sprays) + transient-empty retry + terminal-4xx no-retry
+- [x] **account-dead kill-switch** on 401/402/403 (fragile-trial protection: stops a 20-product seed loop hammering a suspended account) + honest docstring
+- [x] `metadata.probability` deterministic tiebreak; `brand=` wired through the live cascade
+- [x] 10 new no-fab/kill-switch regression tests (flanker-only→pend, near-name→pend, base→pend, wrong-brand-fragrance-list→pend, 402-terminal, kill-switch-stops-run, empty-twice→pend, probability tiebreak)
+- **EMPIRICAL (live Zyte diag):** Dior Sauvage / Marc Jacobs Daisy / Viktor Rolf Flowerbomb = **sephora COVERAGE gap** — sephora.me returns makeup recommendations (overlap 0.0), the matcher correctly pends. NOT a matcher bug; NOT fixable by query reformulation (tested name-only + with-concentration). The lever for these is MORE walled sources (deferred), not tuning.
+- [x] adversarial review Workflow VERIFY+RE-REVIEW re-ran (sequential, survived the burst): original findings all fixed/dismissed (13); the re-review on the hardened code found mostly no-fab-SAFE coverage edges + 1 real wiring gap (seed didn't reset the kill-switch → FIXED) + diacritic over-strictness (caught empirically first → FIXED with NFKD folding) + EDT-canonical (FIXED via EDP=EDT tie + probability tiebreak → Acqua di Gio picks the canonical EDT 44)
+- [x] **re-seed DONE** (final matcher): corrected Oud Wood 77 (was 158), Black Orchid 55.5 (was 81.5), Acqua di Gio 44 EDT (diacritic-fix recovery), Good Girl 38 + Black Opium 85 (flankers flushed), Tobacco Vanille 77, Lost Cherry 100.5, Versace 50.5, Paco 40.5, Lancôme 51; **honest pends** (sephora carries only flankers): Libre, Mon Paris, Born In Roma, Mugler Alien, Prada Luna Rossa, + the Dior×3/MarcJacobs/V&R sephora-coverage gap
+- [x] **prod-verified** (cached compare, no nocache): Oud Wood **77.0** + Black Orchid **55.5** via `zyte_render_bhd` cached=True — corrected genuine luxury prices LIVE in prod (served from shared cache via the already-deployed genuine method; no code deploy needed)
+- [ ] **comm zero-regression gate** (branch-only-NEW == []) — RE-RUNNING (first run's extraction was buggy); + smoke20 vs `54b603e8` (needs prod Serper = railway login) before committing the (live-path-dormant) code to main
+
+### KEY OUTCOME — genuine luxury BHD prices are LIVE + no-fab-correct
+The hardening's net effect: the old loose matcher had cached **flankers** (Black Opium "Over Red", Good Girl/Born-In-Roma/Libre/Mon-Paris variants) and the **wrong concentration** (Oud Wood/Black Orchid Parfum). The hardened matcher flushed all of these → correct prices or honest pends. **Trade-off: correctness over coverage** (more luxury pends now; the lever for higher coverage is MORE walled sources, not matcher tuning).
+
+### Size blind spot (documented follow-up, not no-fab)
+The Zyte matcher strips size from identity, so among same-concentration listings it picks sephora's most-relevant which may be a non-standard size (Black Opium 85 may be 150ml). Right product + right concentration; size is reconciled downstream at compare-time. A size-aware Zyte tier is a future enhancement.
+
+### Deferred (documented, not built)
+- name-only search-variant fallback (#4) — probe showed it doesn't help Dior/the tested set; doubles Zyte calls (budget); revisit with more budget
+- full api_budget_service Zyte metering (#3) — off-clock + manually bounded; kill-switch covers the acute risk
+- per-brand canonical-concentration map (#6) — Acqua di Gio EDT vs EDP "which legit variant"; verify empirically on re-seed
+
+## Step 4 — Mobile-app comparison (ONLY after 1–3 verified)
+- Fresh compares on the iPhone across electronics / fragrance / supplements / makeup;
+  inspect the REAL result content (prices/specs/reviews/images/scoring) — not a glance.
+- Decide whether to build the full Zyte render-tier bundle (off-clock cron + more walled sites).
+
+## Gates before any deploy
+- comm zero-regression (`branch-only-NEW == []`)
+- smoke20 vs baseline `54b603e8` (winner ≥ 0.50, factual held)

--- a/scripts/ab_render_providers.py
+++ b/scripts/ab_render_providers.py
@@ -1,0 +1,105 @@
+"""A/B: Zyte vs Scrape.do(super+geoCode=bh) as the luxury render provider.
+
+For each luxury product it (1) runs the NEW Zyte key's productList search on
+sephora.me (structured BHD price), then (2) renders the SAME sephora PDP via
+Scrape.do super+geoCode=bh and extracts a price from the HTML (JSON-LD/OG). It
+reports, per product and provider: success / price / latency / cost / whether the
+Akamai wall blocked it — so we can decide which provider the render-tier uses.
+
+Burns Zyte + Scrape.do credits (a few each). Run:  python -m scripts.ab_render_providers
+"""
+from __future__ import annotations
+
+import os
+
+# Render config (off-clock): enable Zyte, enable Scrape.do super+BH geo, raise timeouts.
+os.environ["ENABLE_ZYTE_RENDER"] = "true"
+os.environ.setdefault("ZYTE_TIMEOUT", "100")
+os.environ["SCRAPEDO_SUPER"] = "true"
+os.environ["SCRAPEDO_GEOCODE"] = "bh"
+os.environ["SCRAPEDO_TIMEOUT"] = os.getenv("AB_SCRAPEDO_TIMEOUT", "70")
+
+from dotenv import load_dotenv
+load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"), override=True)
+
+import asyncio
+import time
+import urllib.parse
+
+import app.services.zyte_service as Z
+from app.services import scrapedo_service as SD
+from app.services.price_service import extract_price_from_html
+
+SD.reset_super_flags_cache()  # re-read SCRAPEDO_SUPER/geoCode set above
+
+# (brand, full query) — sephora-carried designer luxury.
+PRODUCTS = [
+    ("Tom Ford", "Tom Ford Oud Wood"),
+    ("YSL", "YSL Black Opium"),
+    ("Dior", "Dior Sauvage"),
+]
+
+
+async def zyte_probe(brand: str, query: str):
+    t0 = time.perf_counter()
+    store = Z.ZYTE_STORES["sephora.me"]
+    url = store["search"].format(q=urllib.parse.quote(query))
+    data = await Z._zyte_extract(url, {"productList": True})
+    dt = time.perf_counter() - t0
+    if not data:
+        return {"ok": False, "why": "empty/error extract", "dt": dt, "pdp": None}
+    products = (data.get("productList") or {}).get("products") or []
+    hit = Z._match_product(products, query, brand)
+    if not hit:
+        return {"ok": False, "why": f"no match ({len(products)} cands)", "dt": dt, "pdp": None}
+    amt = Z.normalize_bhd_amount(hit.get("price"))
+    return {"ok": amt is not None, "price": amt, "title": hit.get("name"),
+            "pdp": hit.get("url"), "dt": dt, "why": ""}
+
+
+async def scrapedo_probe(query: str, pdp_url: str | None):
+    """Render the PDP (preferred, has JSON-LD) — fall back to the search URL."""
+    target = pdp_url or Z.ZYTE_STORES["sephora.me"]["search"].format(q=urllib.parse.quote(query))
+    t0 = time.perf_counter()
+    html, status, cost = await SD.render_page_with_status(target)
+    dt = time.perf_counter() - t0
+    info = {"status": status, "cost": cost, "dt": dt, "target": target}
+    if not html:
+        info.update({"ok": False, "why": f"no html (status {status})"})
+        return info
+    blocked = any(s in html for s in ("AkamaiGHost", "Access Denied", "Reference&#32;#", "Pardon Our Interruption"))
+    info["html_kb"] = len(html) // 1024
+    info["blocked"] = blocked
+    price = extract_price_from_html(html, query, "BHD", "sephora.me", target)
+    if price and price.get("amount"):
+        info.update({"ok": True, "price": price["amount"], "method": price.get("source_method"),
+                     "cur": price.get("currency")})
+    else:
+        info.update({"ok": False, "why": "no price in html" + (" (AKAMAI BLOCK)" if blocked else "")})
+    return info
+
+
+async def main():
+    print(f"Zyte key: {(os.getenv('ZYTE_API_KEY') or '')[:6]}…   "
+          f"Scrape.do token: {(os.getenv('SCRAPEDO_API_TOKEN') or '')[:6]}…   "
+          f"super={SD._super_enabled()}\n")
+    for brand, query in PRODUCTS:
+        print(f"{'='*78}\n{query!r}")
+        z = await zyte_probe(brand, query)
+        if z["ok"]:
+            print(f"  ZYTE      OK   {z['price']:.3f} BHD  ({z['dt']:.1f}s)  {z.get('title')!r}")
+        else:
+            print(f"  ZYTE      FAIL {z['why']}  ({z['dt']:.1f}s)")
+        sd = await scrapedo_probe(query, z.get("pdp"))
+        if sd["ok"]:
+            print(f"  SCRAPE.DO OK   {sd['price']} {sd.get('cur')} via {sd.get('method')}  "
+                  f"({sd['dt']:.1f}s, {sd.get('html_kb')}KB, cost={sd['cost']}, status={sd['status']})")
+        else:
+            print(f"  SCRAPE.DO FAIL {sd['why']}  "
+                  f"({sd['dt']:.1f}s, status={sd['status']}, cost={sd['cost']}, "
+                  f"blocked={sd.get('blocked')}, kb={sd.get('html_kb')})")
+            print(f"            target={sd['target']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/diag_zyte_match.py
+++ b/scripts/diag_zyte_match.py
@@ -1,0 +1,131 @@
+"""Zyte match-tuning RECON — dump the real sephora.me candidate lists + per-gate
+verdicts for the products that PENDED in the seed, so the matcher fixes are driven
+by ground truth (not guessed). Read-only diagnostic; does NOT write the cache.
+
+For each (brand, name, variant) it runs the SAME Zyte productList search the seed
+runs, then for every returned candidate prints: title, raw price, fils-normalized
+price, and pass/fail for each no-fab gate (counterfeit / accessory / numbers /
+variant / amount / brand-aware overlap / concentration), plus what the CURRENT
+_match_product picks. Then it shows what a BRAND-AWARE + concentration-aware
+scorer would pick, side by side.
+
+Run:  python -m scripts.diag_zyte_match
+Needs ENABLE_ZYTE_RENDER + ZYTE_API_KEY (set below / from .env). Burns Zyte credits
+(one productList extract per product — ~16 here).
+"""
+from __future__ import annotations
+
+import os
+
+os.environ["ENABLE_ZYTE_RENDER"] = "true"
+os.environ.setdefault("ZYTE_TIMEOUT", "100")
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(override=False)
+except Exception:
+    pass
+
+import asyncio
+import urllib.parse
+
+from app.services import zyte_service as Z
+from app.services.price_service import (
+    is_counterfeit_listing,
+    is_accessory,
+    numbers_match,
+    variant_mismatch,
+    normalize_words,
+    extract_concentration,
+)
+
+# The pended / mis-matched products from the seed (Tom Ford pairs included for the
+# concentration-precision case). brand kept separate so we can test brand-aware
+# overlap.
+PRODUCTS = [
+    ("Dior", "Sauvage", None),
+    ("Dior", "Homme Intense", None),
+    ("Dior", "Miss Dior", None),
+    ("Marc Jacobs", "Daisy", None),
+    ("Viktor Rolf", "Flowerbomb", None),
+    ("Mugler", "Alien", None),
+    ("Paco Rabanne", "1 Million", None),
+    ("Tom Ford", "Oud Wood", None),          # concentration case: EDP 77 vs Parfum 158
+    ("YSL", "Black Opium", None),            # known-good control
+]
+
+
+def _brand_tokens(brand: str) -> set:
+    return normalize_words(brand or "")
+
+
+def _gate_report(product_name: str, brand: str, prod: dict) -> str:
+    name = (prod.get("name") or "").strip()
+    raw = prod.get("price")
+    norm = Z.normalize_bhd_amount(raw)
+    p_words = normalize_words(product_name)
+    t_words = normalize_words(name)
+    brand_w = _brand_tokens(brand)
+    # current overlap (all query words incl. brand)
+    cur_overlap = (len(p_words & t_words) / len(p_words)) if p_words else 0.0
+    # brand-aware overlap (distinctive product tokens only)
+    distinctive = p_words - brand_w
+    ba_overlap = (len(distinctive & t_words) / len(distinctive)) if distinctive else 0.0
+    extra = len(t_words - p_words)
+    q_conc = extract_concentration(product_name)
+    t_conc = extract_concentration(name)
+    gates = []
+    gates.append("CF" if is_counterfeit_listing(name) else "cf")
+    gates.append("ACC" if is_accessory(name) else "acc")
+    gates.append("num" if numbers_match(product_name, name) else "NUM!")
+    gates.append("var!" if variant_mismatch(product_name, name) else "var")
+    gates.append(f"amt={norm}")
+    return (
+        f"      [{' '.join(gates)}] cur_ov={cur_overlap:.2f} ba_ov={ba_overlap:.2f} "
+        f"extra={extra} conc:q={q_conc}/t={t_conc}\n"
+        f"      title={name!r}  raw={raw}"
+    )
+
+
+async def diag_one(brand: str, name: str, variant):
+    full = f"{brand} {name} {variant or ''}".strip()
+    print(f"\n{'='*78}\nQUERY: {full!r}")
+    store = Z.ZYTE_STORES["sephora.me"]
+    search_url = store["search"].format(q=urllib.parse.quote(full))
+    data = await Z._zyte_extract(search_url, {"productList": True})
+    if not data:
+        print("  !! Zyte returned NO DATA (empty extract / error) — transient-fail candidate")
+        return
+    products = (data.get("productList") or {}).get("products") or []
+    print(f"  {len(products)} candidates returned:")
+    for prod in products[:12]:
+        if not isinstance(prod, dict):
+            continue
+        print(_gate_report(full, brand, prod))
+    cur_pick = Z._match_product(products, full, brand)
+    print(f"  _match_product (brand-aware) picks: "
+          f"{(cur_pick or {}).get('name')!r} @ {(cur_pick or {}).get('price')}")
+
+
+async def main():
+    if not os.getenv("ZYTE_API_KEY"):
+        print("ZYTE_API_KEY not set — aborting")
+        return
+    import sys
+    # CLI: "Brand|Name" args override the default list (conserves Zyte credits).
+    argv = sys.argv[1:]
+    products = PRODUCTS
+    if argv:
+        products = []
+        for a in argv:
+            b, _, n = a.partition("|")
+            products.append((b.strip(), n.strip(), None))
+    for brand, name, variant in products:
+        try:
+            await diag_one(brand, name, variant)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ERROR for {brand} {name}: {exc}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/seed_zyte_luxury.py
+++ b/scripts/seed_zyte_luxury.py
@@ -92,11 +92,20 @@ async def main() -> Dict[str, int]:
     if not os.getenv("ZYTE_API_KEY"):
         logger.warning("[seed_zyte] ZYTE_API_KEY not set — nothing to seed")
         return {"genuine": 0, "pending": 0}
+    import sys
+    # Clear the per-run Zyte account-dead kill-switch at the START of each seed run
+    # so a repeated IN-PROCESS invocation (a future cron/warmer) is not silently
+    # disabled by a terminal 4xx from a prior run after the account has recovered.
+    from app.services.zyte_service import reset_account_state
+    reset_account_state()
+    # CLI: explicit "Brand X vs Brand Y" pair args override the full gold-set
+    # (a TARGETED re-seed conserves a fragile Zyte trial).
+    pairs = sys.argv[1:] or LUXURY_PAIRS
     from app.services.structured_comparison_service import get_comparison_service
     svc = get_comparison_service()
-    logger.info("[seed_zyte] seeding %d luxury pairs into the price cache (off-clock Zyte)…", len(LUXURY_PAIRS))
+    logger.info("[seed_zyte] seeding %d luxury pairs into the price cache (off-clock Zyte)…", len(pairs))
     totals = {"genuine": 0, "pending": 0}
-    for pair in LUXURY_PAIRS:
+    for pair in pairs:
         t = await _seed_one(svc, pair)
         totals["genuine"] += t["genuine"]
         totals["pending"] += t["pending"]

--- a/tests/test_algolia_service.py
+++ b/tests/test_algolia_service.py
@@ -153,6 +153,65 @@ def test_match_picks_best_overlap_among_candidates():
     assert "Elixir" in matched["name"]  # better word overlap than plain Sauvage
 
 
+def test_strict_title_match_concentration_aware():
+    """Fix (A): strict_title_match collapses spelled-out fragrance concentrations
+    to their canonical token, so an EDT query matches an 'Edt' PDP even though
+    the words 'eau'/'toilette' are absent. The exact captured real alhajis case."""
+    from app.services.price_service import strict_title_match
+    q = "Dior Sauvage Eau de Toilette 100ml"
+    t = "Dior Sauvage Edt M 100Ml"
+    assert strict_title_match(q, t) is True
+    # No-fab: a DIFFERENT concentration (EDP) must still be rejected.
+    assert strict_title_match(q, "Dior Sauvage Eau de Parfum 100ml") is False
+    # Symmetric: abbreviated query vs spelled-out title also matches.
+    assert strict_title_match(
+        "Dior Sauvage EDP 100ml", "Dior Sauvage Eau de Parfum 100Ml"
+    ) is True
+
+
+def test_overlap_score_concatenation_tolerant():
+    """Concatenated multi-word model names must not fail the overlap floor.
+    The index collapses 'Air Force 1' -> 'AIRFORCE', so the plain set-overlap is
+    1/4=0.25 (< 0.4) — the NEW concatenation-tolerant score is 0.75."""
+    import app.services.algolia_service as alg
+    from app.services.price_service import normalize_words
+    p_words = normalize_words("Nike Air Force 1")
+    surface = "Nike AIRFORCE Color Block Lace-Up Sneakers"
+    assert alg._overlap_score(p_words, surface) >= 0.4
+    # Old computation would have dropped it:
+    assert (len(p_words & normalize_words(surface)) / len(p_words)) < 0.4
+
+
+def test_match_accepts_concatenated_air_force_one():
+    """The exact captured real 6thStreet Air Force 1 hit (32.0 BHD) is accepted
+    after the concatenation-tolerant overlap fix. It already passes
+    strict_title_match + numbers_match; only the redundant overlap floor dropped
+    it. No-fab held: Air Max / Winflo still fail strict_title_match."""
+    import app.services.algolia_service as alg
+    hits = [
+        {"name": "AIRFORCE Color Block Lace-Up Sneakers", "brand_name": "Nike",
+         "price": [{"BHD": {"default": 32.0, "default_formated": "BHD 32.000"}}],
+         "url": "https://en-bh.6thstreet.com/buy-nike-airforce.html",
+         "in_stock": True},
+    ]
+    matched = alg._match_algolia_hit(hits, "Nike Air Force 1")
+    assert matched is not None
+    assert alg._parse_algolia_price(matched) == 32.0
+
+
+def test_match_concatenation_tolerance_still_rejects_wrong_model():
+    """No-fab: the concatenation tolerance does NOT loosen wrong-model rejection.
+    'Nike Air Max 90' must not match a 'Nike Air Force 1' query (strict_title_match
+    drops it — 'force' absent — before overlap is ever consulted)."""
+    import app.services.algolia_service as alg
+    hits = [
+        {"name": "Air Max 90 Sneakers", "brand_name": "Nike",
+         "price": [{"BHD": {"default": 45.0}}], "url": "u", "in_stock": True},
+    ]
+    matched = alg._match_algolia_hit(hits, "Nike Air Force 1")
+    assert matched is None
+
+
 # ---------------------------------------------------------------------------
 # fetch_algolia_price — orchestrator (config harvest → query → match → price)
 # ---------------------------------------------------------------------------

--- a/tests/test_cascade_parallel.py
+++ b/tests/test_cascade_parallel.py
@@ -206,6 +206,96 @@ async def test_prefetch_SKIPPED_when_algolia_sources_exist():
 
 
 # ===========================================================================
+# Genuine-BH starvation fix (2026-06-27) — the discovery prefetch must FIRE for
+# categories whose genuine-BH price comes from a discovery-only source (Lulu) even
+# when the category ALSO has (reseller / niche) Shopify sources, so the genuine
+# curl fan_out isn't starved under the 15s _PRICE_RACE_TIMEOUT cap.
+# ===========================================================================
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("category", ["grocery", "electronics"])
+async def test_prefetch_FIRES_for_shopify_category_with_lulu_discovery(category):
+    """Genuine-BH starvation regression: grocery + electronics both now have
+    bahrain-tier Shopify rows in the registry (niche health stores / reseller
+    storefronts) — but their GENUINE BHD price comes from gcc.luluhypermarket.com,
+    a discovery-only source (no direct adapter). The Shopify rows DON'T short-
+    circuit for a mainstream item, so the speculative discovery prefetch MUST fire
+    concurrently with serper_shopping (not be suppressed by the Shopify rows'
+    existence) or the Lulu curl fan_out is starved past the 15s cap.
+
+    Uses the REAL registry (no source patches) so it pins the actual gate against
+    a registry drift. ENABLE_BH_GCC_CATALOG_SOURCES is irrelevant here — Lulu +
+    the Shopify rows are present as literals in either flag state."""
+    import app.services.structured_comparison_service as scs
+    svc = scs.get_comparison_service()
+    ssc = "app.services.structured_comparison_service"
+
+    async def conv_shopping(*a, **k):
+        # Converted Tier-1 → parked, escalation fires → discovery consumed.
+        return {"shopping": [{"title": "x", "source": "y", "price": "1", "link": "z"}],
+                "organic": [], "shopping_region": "us_fallback"}
+
+    def fake_extract(name, items, cur, shopping_region=None):
+        return {"amount": 50.0, "currency": "BHD", "original_currency": "USD",
+                "retailer": "Foo", "source_method": "converted_usd", "retailer_score": 0.5}
+
+    search_calls = {"n": 0}
+    async def count_search(*a, **k):
+        search_calls["n"] += 1
+        return {"organic": []}
+
+    async def fake_fan(*a, **k):
+        return {"best": None, "alternates": [], "cancelled_count": 0, "elapsed_seconds": 0.1}
+
+    with patch(f"{ssc}.search_product_prices", new=AsyncMock(side_effect=conv_shopping)), \
+         patch(f"{ssc}.extract_price_from_shopping", side_effect=fake_extract), \
+         patch(f"{ssc}._should_escalate_price_scrape", return_value=True), \
+         patch(f"{ssc}.fan_out_price_lookup", new=AsyncMock(side_effect=fake_fan)), \
+         patch(f"{ssc}.search_web", new=AsyncMock(side_effect=count_search)), \
+         patch(f"{ssc}.get_cached", return_value=None), \
+         patch(f"{ssc}.set_cached", return_value=True), \
+         patch("app.services.product_data_service.get_cached_price", new=AsyncMock(return_value=None)), \
+         patch.object(svc, "_save_price_to_db"):
+        await svc._get_price(brand="Test", name="Item", variant=None,
+                             region="bahrain", search_query="Test Item",
+                             nocache=True, category=category)
+
+    assert search_calls["n"] >= 1, (
+        f"discovery prefetch did NOT fire for {category} — the genuine-BH Lulu curl "
+        f"is starved (gate wrongly suppressed by the category's Shopify rows)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_serper_gcc_shopping_calls_fire_concurrently():
+    """Genuine-BH starvation regression: serper_service.search_product_prices runs
+    the gl=bh primary and gl=us fallback CONCURRENTLY for a GCC country (reclaiming
+    the ~3s the old serial fallback stole from the genuine-BH curl fan_out). With
+    each shopping call taking 1s, the total must be ~1s (parallel), not ~2s (serial).
+    Selection still prefers gl=bh — here gl=bh is empty so gl=us wins."""
+    from app.services import serper_service
+
+    async def slow_shopping(product, gl="bh"):
+        await asyncio.sleep(1.0)
+        if gl == "us":
+            return {"shopping": [{"title": "x", "price": "$10"}]}
+        return {"shopping": []}  # gl=bh empty (the real-world BH case)
+
+    with patch.object(serper_service, "SERPER_API_KEY", "test-key"), \
+         patch.object(serper_service, "_do_serper_shopping", side_effect=slow_shopping):
+        t0 = time.monotonic()
+        result = await serper_service.search_product_prices("iPhone 16", country="bh")
+        elapsed = time.monotonic() - t0
+
+    assert result.get("shopping_region") == "us_fallback"
+    assert len(result["shopping"]) == 1
+    assert elapsed < 1.6, (
+        f"gl=bh + gl=us shopping calls ran SERIALLY ({elapsed:.2f}s) — must be "
+        f"concurrent (~1s); the serial fallback steals budget from the curl fan_out"
+    )
+
+
+# ===========================================================================
 # Invariant pins — these MUST still hold after the parallelization (team-lead's
 # 4 PRESERVE invariants). Parallelizing the FETCH must not change the SELECTION.
 # ===========================================================================

--- a/tests/test_hotfix_shopping_query_clean.py
+++ b/tests/test_hotfix_shopping_query_clean.py
@@ -105,8 +105,13 @@ class TestSearchProductPricesIntegration:
             "Apple iPhone 16 price", country="bh"
         )
 
-        # Cleaned query must hit Serper, not the dirty one.
-        assert observed_queries == [("Apple iPhone 16", "bh")]
+        # Cleaned query must hit Serper, not the dirty one. (As of the 2026-06-27
+        # genuine-BH starvation fix the gl=bh + gl=us calls fire CONCURRENTLY for a
+        # GCC country, so order is non-deterministic and gl=us may also fire — assert
+        # the cleaned product string reached EVERY Serper call and gl=bh was made.)
+        assert observed_queries, "no Serper shopping call fired"
+        assert all(p == "Apple iPhone 16" for p, _gl in observed_queries)
+        assert ("Apple iPhone 16", "bh") in observed_queries
         # Output query field also reflects cleaned form (helpful for
         # downstream cache keys).
         assert result["query"] == "Apple iPhone 16"
@@ -130,8 +135,11 @@ class TestSearchProductPricesIntegration:
             "iPhone 16 Pro Max", country="bh"
         )
 
-        # No mutation — Pro/Max preserved.
-        assert observed_queries == [("iPhone 16 Pro Max", "bh")]
+        # No mutation — Pro/Max preserved. (Concurrent gl=bh + gl=us as of the
+        # 2026-06-27 starvation fix: assert no mutation on every fired call.)
+        assert observed_queries, "no Serper shopping call fired"
+        assert all(p == "iPhone 16 Pro Max" for p, _gl in observed_queries)
+        assert ("iPhone 16 Pro Max", "bh") in observed_queries
 
     @pytest.mark.asyncio
     async def test_us_fallback_uses_cleaned_query(self, monkeypatch):
@@ -157,11 +165,13 @@ class TestSearchProductPricesIntegration:
             country="bh",
         )
 
-        # Both calls saw the cleaned string.
-        assert observed_queries == [
+        # Both calls saw the cleaned string. (Order is non-deterministic since the
+        # 2026-06-27 starvation fix fires gl=bh + gl=us concurrently — assert as a
+        # set, not an ordered list.)
+        assert set(observed_queries) == {
             ("Apple iPhone 16", "bh"),
             ("Apple iPhone 16", "us"),
-        ]
+        }
         assert result["shopping_region"] == "us_fallback"
         assert len(result["shopping"]) == 1
 

--- a/tests/test_serper_gcc_fallback.py
+++ b/tests/test_serper_gcc_fallback.py
@@ -80,17 +80,27 @@ async def test_gl_bh_empty_triggers_us_fallback(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_gl_bh_with_results_skips_fallback(monkeypatch):
-    """When primary gl=bh returns items, no fallback fires."""
+async def test_gl_bh_with_results_prefers_primary(monkeypatch):
+    """Genuine-BH starvation fix (2026-06-27): the gl=bh primary and gl=us
+    fallback now fire CONCURRENTLY for GCC countries (reclaiming the ~3s the old
+    serial fallback stole from the downstream genuine-BH curl fan_out). SELECTION
+    is unchanged — when gl=bh returns items they are PREFERRED (genuine local feed)
+    and the shopping_region stays 'bh'; the gl=us result is ignored. In production
+    gl=bh effectively never returns items (Google has no Bahrain shopping feed —
+    see module docstring), so the concurrent second call is a near-zero net cost."""
     monkeypatch.setattr(serper_service, "SERPER_API_KEY", "test-key")
     bh_full = _mock_response(200, {"shopping": [
         {"title": "iPhone 16 from BH merchant", "price": "BHD 200", "source": "noon.com"},
     ]})
-    ctx, calls = _patch_httpx_sequence([bh_full])
+    us_full = _mock_response(200, {"shopping": [
+        {"title": "iPhone 16 US", "price": "$529.00", "source": "Walmart"},
+    ]})
+    ctx, calls = _patch_httpx_sequence([bh_full, us_full])
     with ctx:
         result = await serper_service.search_product_prices("iPhone 16", country="bh")
-    assert calls["n"] == 1, "no fallback when primary has results"
+    # Both calls now fire concurrently (no serial skip), but gl=bh wins selection.
     assert len(result["shopping"]) == 1
+    assert result["shopping"][0]["title"] == "iPhone 16 from BH merchant"
     assert result.get("shopping_region") == "bh"
 
 

--- a/tests/test_shopify_cascade_wiring_l13.py
+++ b/tests/test_shopify_cascade_wiring_l13.py
@@ -49,11 +49,23 @@ def _force_escalation(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_shopify_hit_short_circuits_before_serper(monkeypatch, clean_service):
-    """A confident Shopify /products.json hit returns the BHD price and the
-    Serper site: discovery (`search_web`) is NEVER called.
+    """A confident OFFICIAL Shopify /products.json hit returns the BHD price and
+    the Serper discovery RESULTS are never consumed (fan_out never runs).
 
     S3: short-circuit ONLY when the Shopify domain IS the official/authoritative
-    domain for the brand (here get_official_domain → shopalmoayyed.com)."""
+    domain for the brand (here get_official_domain → shopalmoayyed.com).
+
+    NOTE (2026-06-27 genuine-BH starvation fix): electronics now FIRES the
+    speculative discovery prefetch concurrently with serper_shopping (electronics
+    has discovery-only BH sources like gcc.luluhypermarket.com whose genuine price
+    the dominant electronics query — iPhone/Samsung/Sony, with no official BH
+    Shopify store — depends on). On the rare OFFICIAL-Shopify hit (Super General →
+    shopalmoayyed) those speculative `search_web` calls are CANCELLED via
+    `_cancel_prefetched_discovery()` before their results are used — so the budget
+    cost is bounded and the SELECTION is unchanged: the official Shopify price
+    still wins and the fan_out race never runs. The invariant this pins is now
+    "the discovery results are not CONSUMED" (fan_out not called), not "search_web
+    is never fired"."""
     from app.services import structured_comparison_service as scs_mod
 
     _force_escalation(monkeypatch)
@@ -71,7 +83,8 @@ async def test_shopify_hit_short_circuits_before_serper(monkeypatch, clean_servi
     fetch_mock = AsyncMock(return_value=shopify_price)
     monkeypatch.setattr(scs_mod, "fetch_shopify_price", fetch_mock)
 
-    # Tripwires: Serper discovery + fan_out must NOT run on an OFFICIAL hit.
+    # Tripwire: the fan_out race (which CONSUMES discovery results) must NOT run on
+    # an OFFICIAL Shopify hit — the short-circuit returns before it.
     search_web_mock = AsyncMock(return_value={"organic": []})
     fan_out_mock = AsyncMock(return_value={"best": None})
     monkeypatch.setattr(scs_mod, "search_web", search_web_mock)
@@ -88,7 +101,8 @@ async def test_shopify_hit_short_circuits_before_serper(monkeypatch, clean_servi
     assert result["currency"] == "BHD"
     assert result["source_method"] == "shopify_json"
     assert fetch_mock.await_count >= 1
-    search_web_mock.assert_not_called()
+    # SELECTION invariant: the discovery results are never consumed — the official
+    # Shopify hit short-circuits before the fan_out race.
     fan_out_mock.assert_not_called()
 
 

--- a/tests/test_supplement_branch_genuine.py
+++ b/tests/test_supplement_branch_genuine.py
@@ -364,6 +364,96 @@ class TestCde2DeterministicAttribution:
 
 
 # ---------------------------------------------------------------------------
+# 5b. Genuine-BH orphan-row fix (2026-06-27) — the supplement branch admits the
+#     bahrain-tier curl/JSON-LD CATALOG supplement sources (sporter.com,
+#     drnutrition.com, …) into `known_supplement_retailers` when the catalog flag
+#     is ON, so a Tier-2 GPT-organic price tied to one of them via a matched
+#     bh_organic snippet is attributed local_bhd instead of pending. With the flag
+#     OFF (the default) those domains are NOT admitted → dormancy preserved.
+# ---------------------------------------------------------------------------
+
+class TestCatalogSupplementSourceAttribution:
+    def test_cde2_attributes_catalog_supplement_domain_when_flag_on(self, service):
+        """POSITIVE (flag ON): iHerb organic empty; bh_organic has an item whose
+        link domain is a CATALOG bahrain-tier supplement source (sporter.com — NOT
+        in the base known_supplement_retailers, NOT in PHARMACY_DOMAINS) whose
+        title token-matches the product; extract_price returns amount+retailer=None
+        → CDE-2 relabels it local_bhd attributed to Sporter. This is the exact
+        ON-Whey pending miss the orphan-row fix converts."""
+        from app.services.price_service import is_price_showable
+
+        full_name = "Optimum Nutrition Gold Standard Whey"
+        gpt_price = {"amount": 27.5, "currency": "BHD", "retailer": None}
+        service._parked_price = {}
+        bh_item = {
+            "title": "Optimum Nutrition Gold Standard 100% Whey 2lb",
+            "link": "https://www.sporter.com/en-bh/optimum-nutrition-gold-standard-whey/",
+            "snippet": "Buy Optimum Nutrition Gold Standard Whey in Bahrain",
+        }
+        seam = {
+            "fetch_iherb_price": AsyncMock(return_value=None),
+            "fetch_pharmacy_price": AsyncMock(return_value=None),
+            "fetch_page_price": AsyncMock(return_value=None),
+            "extract_price": AsyncMock(return_value=(dict(gpt_price), {"prompt_tokens": 0, "completion_tokens": 0})),
+            "search_web": _routed_search_web(iherb_organic=[], bh_organic=[bh_item]),
+        }
+        with patch.dict(os.environ, {"ENABLE_BH_GCC_CATALOG_SOURCES": "true"}):
+            # Reload the registry so the catalog rows (sporter.com) are present.
+            import importlib
+            import app.services.source_router as _sr
+            importlib.reload(_sr)
+            try:
+                result = _run_get_price_isolated(
+                    service, "Optimum Nutrition", "Gold Standard Whey", None,
+                    "bahrain", full_name, "supplements", seam_overrides=seam,
+                )
+            finally:
+                # Restore the default (flag-OFF) registry for sibling tests.
+                with patch.dict(os.environ, {"ENABLE_BH_GCC_CATALOG_SOURCES": ""}):
+                    importlib.reload(_sr)
+        assert result.get("source_method") == "local_bhd"
+        assert (result.get("retailer") or "").lower().startswith("sporter")
+        assert result.get("url") == bh_item["link"]
+        assert is_price_showable(full_name, result) is True
+        assert full_name in service._parked_price
+
+    def test_cde2_does_not_attribute_catalog_domain_when_flag_off(self, service):
+        """NEGATIVE / dormancy (flag OFF, the default): the SAME sporter.com
+        bh_organic item is NOT a known retailer (catalog rows not loaded) → CDE-2
+        cannot attribute, the price keeps its honest gpt_organic_extract label and
+        pends. Proves the fix is gated and introduces no flag-OFF behavior change."""
+        from app.services.price_service import is_price_showable
+
+        full_name = "Optimum Nutrition Gold Standard Whey"
+        gpt_price = {"amount": 27.5, "currency": "BHD", "retailer": None}
+        service._parked_price = {}
+        bh_item = {
+            "title": "Optimum Nutrition Gold Standard 100% Whey 2lb",
+            "link": "https://www.sporter.com/en-bh/optimum-nutrition-gold-standard-whey/",
+            "snippet": "Buy Optimum Nutrition Gold Standard Whey in Bahrain",
+        }
+        seam = {
+            "fetch_iherb_price": AsyncMock(return_value=None),
+            "fetch_pharmacy_price": AsyncMock(return_value=None),
+            "fetch_page_price": AsyncMock(return_value=None),
+            "extract_price": AsyncMock(return_value=(dict(gpt_price), {"prompt_tokens": 0, "completion_tokens": 0})),
+            "search_web": _routed_search_web(iherb_organic=[], bh_organic=[bh_item]),
+        }
+        with patch.dict(os.environ, {"ENABLE_BH_GCC_CATALOG_SOURCES": ""}):
+            import importlib
+            import app.services.source_router as _sr
+            importlib.reload(_sr)
+            result = _run_get_price_isolated(
+                service, "Optimum Nutrition", "Gold Standard Whey", None,
+                "bahrain", full_name, "supplements", seam_overrides=seam,
+            )
+        assert result.get("source_method") == "gpt_organic_extract"
+        assert not result.get("retailer")
+        assert is_price_showable(full_name, result) is False
+        assert full_name not in service._parked_price
+
+
+# ---------------------------------------------------------------------------
 # 6. Sub-stage wait_for bounds — a hung stage is bypassed, chain proceeds
 # ---------------------------------------------------------------------------
 

--- a/tests/test_zyte_service.py
+++ b/tests/test_zyte_service.py
@@ -40,6 +40,40 @@ def _mock_zyte(payload):
 def _enable(monkeypatch):
     monkeypatch.setenv("ENABLE_ZYTE_RENDER", "true")
     monkeypatch.setenv("ZYTE_API_KEY", "test-key")
+    monkeypatch.setenv("ZYTE_RETRY_BACKOFF", "0")  # no real sleeps in retry tests
+    zs.reset_account_state()  # clear the per-run kill-switch (module global) each test
+    yield
+    zs.reset_account_state()
+
+
+def _plist(products):
+    """A Zyte productList payload shaped like a real sephora.me search response."""
+    return {"productList": {"products": products}}
+
+
+def _resp(status, payload=None, text=""):
+    r = MagicMock()
+    r.status_code = status
+    r.json = MagicMock(return_value=payload or {})
+    r.text = text
+    return r
+
+
+def _mock_calls(responses):
+    """(factory, post_mock) — patch httpx.AsyncClient with `factory`; post_mock's
+    side_effect cycles `responses` and is shared across AsyncClient() calls so its
+    call_count proves exactly how many Zyte requests were made (retries included)."""
+    post = AsyncMock(side_effect=list(responses))
+
+    def factory(*a, **k):
+        client = MagicMock()
+        client.post = post
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=client)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    return MagicMock(side_effect=factory), post
 
 
 # --- fils-fix --------------------------------------------------------------
@@ -61,7 +95,7 @@ def test_normalize_bhd_fils_fix(raw, expected):
 async def test_sephora_oud_wood_genuine_bhd(monkeypatch):
     payload = _load("sephora_productlist_oud_wood")
     with patch("httpx.AsyncClient", _mock_zyte(payload)):
-        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood Eau de Parfum")
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood Eau de Parfum", brand="Tom Ford")
     assert out is not None, "should match the Oud Wood EDP"
     assert out["source_method"] == "zyte_render_bhd"
     assert out["currency"] == "BHD"
@@ -112,3 +146,320 @@ async def test_unknown_domain(monkeypatch):
     with patch("httpx.AsyncClient", _mock_zyte({"productList": {"products": []}})):
         out = await zs.fetch_zyte_price("random-store.com", "Tom Ford Oud Wood")
     assert out is None
+
+
+# === match-tuning (2026-06-26) ============================================
+
+# (b) concentration precision — an UNSPECIFIED query prefers the flagship EDP
+# over the pricier Parfum. Uses the REAL captured Oud Wood candidate list
+# (EDP 77 / body-spray 41 / Parfum 158 / set 119).
+
+@pytest.mark.asyncio
+async def test_oud_wood_unspecified_prefers_edp_not_parfum():
+    payload = _load("sephora_productlist_oud_wood")
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is not None
+    # v1 picked the 158 Parfum (fewest-extra tiebreak); must now pick the 77 EDP.
+    assert out["amount"] == pytest.approx(77.0), "unspecified query → flagship EDP, not Parfum/spray/set"
+
+
+@pytest.mark.asyncio
+async def test_oud_wood_explicit_edp_still_77():
+    """The pre-existing explicit-concentration path is preserved."""
+    payload = _load("sephora_productlist_oud_wood")
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood Eau de Parfum", brand="Tom Ford")
+    assert out is not None and out["amount"] == pytest.approx(77.0)
+
+
+@pytest.mark.asyncio
+async def test_explicit_concentration_rejects_mismatch():
+    # Query asks EDP; only a Parfum is offered → reject (never ship a wrong concentration).
+    payload = _plist([
+        {"name": "Oud Wood Parfum", "price": "158000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/oud-wood-parfum/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood Eau de Parfum", brand="Tom Ford")
+    assert out is None
+
+
+# (a) brand-aware overlap — sephora OMITS the (multi-word) brand from the title.
+# v1 divided overlap by all query words incl. the brand → collapsed below 0.5.
+
+@pytest.mark.asyncio
+async def test_multiword_brand_marc_jacobs_daisy():
+    payload = _plist([
+        {"name": "Daisy - Eau de Toilette", "price": "29000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/daisy-edt/P1"},
+        {"name": "Daisy Dream - Eau de Toilette", "price": "31000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/daisy-dream/P2"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Marc Jacobs Daisy", brand="Marc Jacobs")
+    assert out is not None, "brand-aware overlap must match a brand-omitted title"
+    assert out["amount"] == pytest.approx(29.0), "plain 'Daisy' beats the 'Daisy Dream' flanker"
+
+
+@pytest.mark.asyncio
+async def test_multiword_brand_viktor_rolf_flowerbomb():
+    payload = _plist([
+        {"name": "Flowerbomb - Eau de Parfum", "price": "45000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/flowerbomb/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Viktor Rolf Flowerbomb", brand="Viktor Rolf")
+    assert out is not None and out["amount"] == pytest.approx(45.0)
+
+
+@pytest.mark.asyncio
+async def test_brand_aware_still_rejects_wrong_brand():
+    """Brand-awareness must NOT loosen no-fab: a wrong-brand result still rejects."""
+    payload = _plist([
+        {"name": "Addict - Shine Lipstick", "price": "23000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/addict/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Creed Aventus", brand="Creed")
+    assert out is None
+
+
+# (c) form gate — non-bottle forms never ship as the bottle's price.
+
+@pytest.mark.asyncio
+async def test_form_gate_rejects_set_and_body_spray():
+    payload = _plist([
+        {"name": "Oud Wood Eau de Parfum Set", "price": "119000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/set/P1"},
+        {"name": "Oud Wood - All Over Body Spray", "price": "41000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/spray/P2"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is None, "only non-bottle forms offered → pend honestly"
+
+
+# (c) retry — a transient EMPTY recovers; a terminal 4xx (suspended) does NOT retry.
+
+@pytest.mark.asyncio
+async def test_empty_productlist_then_recovers():
+    empty = _resp(200, {"productList": {"products": []}})
+    full = _resp(200, _load("sephora_productlist_oud_wood"))
+    factory, post = _mock_calls([empty, full])
+    with patch("httpx.AsyncClient", factory):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is not None and out["amount"] == pytest.approx(77.0)
+    assert post.call_count == 2, "empty result is retried once and recovers"
+
+
+@pytest.mark.asyncio
+async def test_suspended_403_is_terminal_no_retry():
+    factory, post = _mock_calls([_resp(403, {}, text="account-suspended")])
+    with patch("httpx.AsyncClient", factory):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is None
+    assert post.call_count == 1, "a 4xx (billing/suspended) is terminal — never retried"
+
+
+@pytest.mark.asyncio
+async def test_transient_5xx_is_retried():
+    err = _resp(503, {}, text="upstream")
+    full = _resp(200, _load("sephora_productlist_oud_wood"))
+    factory, post = _mock_calls([err, full])
+    with patch("httpx.AsyncClient", factory):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is not None and out["amount"] == pytest.approx(77.0)
+    assert post.call_count == 2, "5xx is transient → retried"
+
+
+# === no-fab hardening (2026-06-26 adversarial review) ======================
+# The hard product-identity gate must PEND (return None) rather than ship a
+# flanker / near-name / base when the exact product is absent.
+
+@pytest.mark.asyncio
+async def test_flanker_only_pends():
+    # The live A/B matched 'Black Opium Over Red' for 'YSL Black Opium'. With only
+    # the flanker present the matcher must PEND, not ship the flanker's price.
+    payload = _plist([
+        {"name": "Black Opium Over Red - Eau de Parfum", "price": "57000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/black-opium-over-red/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "YSL Black Opium", brand="YSL")
+    assert out is None, "a flanker with extra identity tokens must not ship as the standard"
+
+
+@pytest.mark.asyncio
+async def test_standard_beats_flanker_when_both_present():
+    payload = _plist([
+        {"name": "Black Opium Over Red - Eau de Parfum", "price": "57000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/over-red/P1"},
+        {"name": "Black Opium - Eau de Parfum", "price": "51000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/black-opium/P2"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "YSL Black Opium", brand="YSL")
+    assert out is not None and out["amount"] == pytest.approx(51.0), "standard bottle wins, flanker rejected"
+
+
+@pytest.mark.asyncio
+async def test_near_name_rejected():
+    # 'Ombre Nomade' (Louis Vuitton) must NOT match 'Tom Ford Ombre Leather'.
+    payload = _plist([
+        {"name": "Ombre Nomade - Eau de Parfum", "price": "95000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/ombre-nomade/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Ombre Leather", brand="Tom Ford")
+    assert out is None, "1-of-2-token near-name must pend, not ship"
+
+
+@pytest.mark.asyncio
+async def test_base_not_shipped_for_flanker_query():
+    # 'Dior Homme' base must NOT be shipped for a 'Dior Homme Intense' query.
+    payload = _plist([
+        {"name": "Homme - Eau de Toilette", "price": "33000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/dior-homme/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Dior Homme Intense", brand="Dior")
+    assert out is None, "the base ('intense' missing) must pend for an Intense query"
+
+
+@pytest.mark.asyncio
+async def test_wrong_brand_fragrance_list_pends():
+    # The dominant real failure: search returns OTHER-BRAND fragrances (each a valid
+    # bottle at a plausible price) — the identity gate is the load-bearing no-fab.
+    payload = _plist([
+        {"name": "Bleu de Chanel - Eau de Parfum", "price": "52000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/bleu/P1"},
+        {"name": "Acqua di Gio - Eau de Toilette", "price": "44000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/adg/P2"},
+        {"name": "Y - Eau de Parfum", "price": "41000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/y/P3"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Dior Sauvage", brand="Dior")
+    assert out is None, "no Sauvage in a list of other-brand fragrances → pend"
+
+
+@pytest.mark.asyncio
+async def test_brand_repeated_in_title_still_matches():
+    # sephora is inconsistent — sometimes the title KEEPS the brand. Identity must
+    # still match (brand stripped from both sides).
+    payload = _plist([
+        {"name": "Tom Ford Oud Wood - Eau de Parfum", "price": "77000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/oud-wood/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is not None and out["amount"] == pytest.approx(77.0)
+
+
+@pytest.mark.asyncio
+async def test_probability_breaks_identity_ties():
+    # Two identity-equal, same-concentration candidates → Zyte's metadata.probability
+    # is the deterministic tiebreak (not Zyte return order).
+    payload = _plist([
+        {"name": "Libre - Eau de Parfum", "price": "60000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/libre-a/P1", "metadata": {"probability": 0.40}},
+        {"name": "Libre - Eau de Parfum", "price": "42000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/libre-b/P2", "metadata": {"probability": 0.95}},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "YSL Libre", brand="YSL")
+    assert out is not None and out["amount"] == pytest.approx(42.0), "higher-probability listing wins the tie"
+
+
+# --- account kill-switch (fragile-trial protection) -----------------------
+
+@pytest.mark.asyncio
+async def test_402_terminal_no_retry_and_trips_killswitch():
+    factory, post = _mock_calls([_resp(402, {}, text="payment required")])
+    with patch("httpx.AsyncClient", factory):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is None
+    assert post.call_count == 1, "402 (billing) is terminal — never retried"
+    assert zs._ACCOUNT_DEAD is True, "402 trips the per-run kill-switch"
+
+
+@pytest.mark.asyncio
+async def test_killswitch_stops_subsequent_calls_in_run():
+    # First product 403s (suspended) → kill-switch trips; the next product must NOT
+    # issue any Zyte POST (protects a 20-product seed loop from hammering a dead acct).
+    factory, post = _mock_calls([_resp(403, {}, text="account-suspended")])
+    with patch("httpx.AsyncClient", factory):
+        out1 = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+        out2 = await zs.fetch_zyte_price("sephora.me", "YSL Black Opium", brand="YSL")
+    assert out1 is None and out2 is None
+    assert post.call_count == 1, "second product short-circuited by the kill-switch (no POST)"
+
+
+@pytest.mark.asyncio
+async def test_diacritic_folding_matches_accented_title():
+    # Live-observed false pend: sephora writes "Acqua di Giò" (accented) but the query
+    # is "Acqua di Gio" — without diacritic folding the identity sets differ and the
+    # genuine EDT is wrongly rejected.
+    payload = _plist([
+        {"name": "Acqua di Giò Eau de Toilette", "price": "44000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/adg-edt/P1", "metadata": {"probability": 0.97}},
+        {"name": "Acqua di Giò Profondo Eau de Parfum", "price": "46000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/profondo/P2", "metadata": {"probability": 0.95}},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Giorgio Armani Acqua di Gio", brand="Giorgio Armani")
+    assert out is not None, "accented 'Giò' must fold to 'gio' and match"
+    assert out["amount"] == pytest.approx(44.0), "the standard EDT, not the Profondo flanker"
+
+
+@pytest.mark.asyncio
+async def test_edp_edt_tie_broken_by_probability():
+    # EDP and EDT are co-flagship (tie); sephora's relevance (probability) decides —
+    # for an EDT-iconic brand the EDT outranks the co-listed EDP.
+    payload = _plist([
+        {"name": "Acqua di Gio Eau de Parfum", "price": "66000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/adg-edp/P1", "metadata": {"probability": 0.80}},
+        {"name": "Acqua di Gio Eau de Toilette", "price": "44000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/adg-edt/P2", "metadata": {"probability": 0.97}},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Giorgio Armani Acqua di Gio", brand="Giorgio Armani")
+    assert out is not None and out["amount"] == pytest.approx(44.0), "higher-relevance EDT wins the EDP/EDT tie"
+
+
+@pytest.mark.asyncio
+async def test_edp_still_beats_parfum_when_unspecified():
+    # The Oud Wood fix must survive the EDP/EDT tie change: EDP ≫ Parfum.
+    payload = _plist([
+        {"name": "Oud Wood Parfum", "price": "158000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/parfum/P1", "metadata": {"probability": 0.97}},
+        {"name": "Oud Wood - Eau de Parfum", "price": "77000.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/edp/P2", "metadata": {"probability": 0.90}},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is not None and out["amount"] == pytest.approx(77.0), "EDP beats Parfum even with lower probability"
+
+
+@pytest.mark.asyncio
+async def test_explicit_conc_query_keeps_no_concentration_title():
+    # Benefit-of-doubt arm: an EXPLICIT-concentration query must still MATCH a genuine
+    # candidate whose sephora title OMITS the concentration suffix (t_conc None → kept).
+    payload = _plist([
+        {"name": "Black Orchid", "price": "55500.0", "currency": "BHD",
+         "url": "https://www.sephora.me/bh-en/p/black-orchid/P1"},
+    ])
+    with patch("httpx.AsyncClient", _mock_zyte(payload)):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Black Orchid Eau de Parfum", brand="Tom Ford")
+    assert out is not None and out["amount"] == pytest.approx(55.5), "unstated-concentration title kept on benefit-of-doubt"
+
+
+@pytest.mark.asyncio
+async def test_empty_twice_pends_with_bounded_calls():
+    empty = _resp(200, {"productList": {"products": []}})
+    factory, post = _mock_calls([empty, empty])
+    with patch("httpx.AsyncClient", factory):
+        out = await zs.fetch_zyte_price("sephora.me", "Tom Ford Oud Wood", brand="Tom Ford")
+    assert out is None, "two empties → pend, never a guess"
+    assert post.call_count == 2, "empty-retry budget honored (ZYTE_EMPTY_RETRIES=2), not infinite"


### PR DESCRIPTION
## Summary
Two gated, comm-green commits that materially raise genuine Bahrain BHD price coverage + correctness.

### 1. All-category genuine-price extraction fixes (135e21c)
Found+fixed via an all-category work-test-fix-improve Workflow probing the REAL Serper Bahrain data: every probed product (8, all categories) HAD genuine BHD available, yet 6/8 returned estimated/wrong/pending. Three systemic bugs, all $0 (no render):
- Matcher over-strict — strict_title_match rejected EDT != "eau de toilette" (now concentration-normalizes both sides); Algolia overlap floor rejected AIRFORCE != "air force 1" (_overlap_score concatenation-tolerant). No-fab intact. -> Dior Sauvage estimated->genuine 46.0 BHD (live-verified); Nike AF1.
- Latency starvation — sequential gl=bh->gl=us Serper wasted ~6s so the genuine-BH curl timed out and converted_usd won; now gl=bh+gl=us fire concurrently (same net calls for the empty-BH path) + discovery prefetch no longer suppressed by niche Shopify rows when a discovery-only BH source (Lulu/talabat) exists. -> iPhone 15 Pro converted->genuine 399.99 BHD (Lulu); Nutella->genuine.
- 199 dead-wired catalog rows — mechanism='' had no selector, so 47 bahrain-tier genuine-BHD sources (sporter/drnutrition/...) were never fetched. New get_curl_pagescrape_sources_for_category + supplement Stage-3 wiring, gated by ENABLE_BH_GCC_CATALOG_SOURCES (byte-identical flag-OFF). -> ON Whey pending->genuine BHD; unlocks ~199 dormant sources all-category.

### 2. Zyte render-tier no-fab hardening (c50f05c, live-path-dormant)
Hard product-identity gate (replaces a loose overlap that shipped flankers/near-names), concentration precision (EDP/EDT co-flagship + probability tiebreak), diacritic folding, per-run account kill-switch. Re-seeded luxury cache flushed of flanker/wrong-concentration prices (Oud Wood 158->77, Black Orchid 81.5->55.5, Acqua di Gio 44 EDT) - prod-verified cached.

## Verification
- comm zero-regression gate GREEN: BASE 46 failed / BRANCH 46 failed, branch-only-NEW EMPTY; +33 tests (7900->7933 passed).
- Dior Sauvage conversion independently live-verified (page_scrape_jsonld, estimated=False).
- All diffs dispatcher-reviewed; no-fab preserved; render changes are $0.

## Post-merge plan
Railway auto-deploys on merge (~90s). Then: smoke20 vs 54b603e8 + Sentry error check; rollback if winner < 0.50 / factual drops / new 5xx.

## Deferred
CeraVe skincare (bn.boots site: fallback) diagnosed, not yet built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)