### PR TITLE
Wave 1: genuine-price warmer gate machinery (GATE-FIRST, warmer stays OFF)

### DIFF
--- a/app/services/product_data_service.py
+++ b/app/services/product_data_service.py
@@ -29,6 +29,19 @@ GENUINE_PRICE_DB_TTL = timedelta(
 )
 
 
+def _title_persist_enabled() -> bool:
+    """Persist + rehydrate the resolved listing title on the L2 product_prices
+    cache. Default OFF -> byte-identical pre-033 behavior (no `title` in the
+    insert, no `title` in the returned dict). Flip ON only AFTER migration 033
+    lands (adds the nullable `title` column); a flag-ON write before the column
+    exists would error the fire-and-forget insert (swallowed), and a flag-ON read
+    would degrade the L2 hit to a miss (get_cached_price swallows it) — never a
+    crash, but the correct order is migration-then-flag."""
+    return _os.getenv("ENABLE_PRICE_TITLE_PERSIST", "").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+
+
 def _price_row_fresh(source_method: Optional[str], age: timedelta) -> bool:
     """True iff a stored price row of `age` is still fresh for its source_method.
 
@@ -98,9 +111,12 @@ async def get_cached_price(product_key: str, region: str) -> Optional[Dict[str, 
     """Fetch latest price from DB if fresher than 24h."""
     try:
         client = get_admin_supabase_client()
+        cols = "amount, currency, retailer, url, source_method, estimated, fetched_at"
+        if _title_persist_enabled():
+            cols += ", title"
         response = (
             client.table("product_prices")
-            .select("amount, currency, retailer, url, source_method, estimated, fetched_at")
+            .select(cols)
             .eq("product_key", product_key)
             .eq("region", region)
             .order("fetched_at", desc=True)
@@ -116,7 +132,7 @@ async def get_cached_price(product_key: str, region: str) -> Optional[Dict[str, 
         age = datetime.now(timezone.utc) - fetched_at
         if not _price_row_fresh(row.get("source_method"), age):
             return None
-        return {
+        result = {
             "amount": float(row["amount"]) if row["amount"] is not None else None,
             "currency": row["currency"],
             "retailer": row["retailer"],
@@ -124,6 +140,11 @@ async def get_cached_price(product_key: str, region: str) -> Optional[Dict[str, 
             "source_method": row["source_method"],
             "estimated": row["estimated"] or False,
         }
+        # Rehydrate the persisted title so the L2-served price is SKU-verifiable
+        # (a None title = a legacy/flag-OFF row, treated exactly as pre-033).
+        if _title_persist_enabled() and row.get("title"):
+            result["title"] = row["title"]
+        return result
     except Exception as e:
         logger.debug(f"L2 price miss for {product_key}/{region}: {e}")
         return None
@@ -136,7 +157,7 @@ async def save_price(
     """Append a price row (keeps history)."""
     try:
         client = get_admin_supabase_client()
-        client.table("product_prices").insert({
+        row = {
             "product_key": product_key,
             "brand": brand,
             "name": name,
@@ -149,7 +170,13 @@ async def save_price(
             "source_method": price_data.get("source_method"),
             "estimated": price_data.get("estimated", False),
             "fetched_at": datetime.now(timezone.utc).isoformat(),
-        }).execute()
+        }
+        # Persist the resolved listing title so a rehydrated L2 price stays
+        # SKU-verifiable (usable_exact_genuine KPI + should_cache_price). Gated
+        # so pre-033 (no column) writes are byte-identical.
+        if _title_persist_enabled():
+            row["title"] = price_data.get("title")
+        client.table("product_prices").insert(row).execute()
     except Exception as e:
         logger.warning(f"Failed to save price for {product_key}/{region}: {e}")
 

--- a/docs/investigations/2026-06-30-warmer-kpi-result.md
+++ b/docs/investigations/2026-06-30-warmer-kpi-result.md
@@ -1,0 +1,35 @@
+# Wave-1 gate result — warmed usable_exact_genuine KPI (RED)
+
+**Date:** 2026-07-01 · **Method:** off-clock warm of the 18-product KPI truth set (`scripts/warm_kpi_truth.py`, `PRICE_RACE_TIMEOUT=60`) against the shared prod cache, then a cache sweep + `should_cache_price` reproduction. Serper: healthy (paid key live).
+
+## Verdict: GATE RED — warmer stays OFF
+
+| Category | usable_exact_genuine (warmed) | gate ≥0.85 |
+|---|---|---|
+| electronics | **1/6 (0.17)** | ❌ |
+| fragrances | **0/6 (0.00)** | ❌ |
+| fashion | **0/6 (0.00)** | ❌ |
+| **overall** | **1/18 (0.06)** | ❌ |
+
+Only **1/18** warmed products cached a usable price (Samsung Galaxy S24 Ultra 256GB → `page_scrape_jsonld`, in-stock, PDP URL, identity). The other 17 were **correctly refused** by the fail-closed `should_cache_price` (PR #9).
+
+## Why the 17 didn't cache — the precise diagnosis
+
+The warmer machinery works; the cascade's *resolutions* fail `should_cache_price`'s (correct) requirements — title/name identity + a valid **PDP** URL + confirmed in-stock + exact match:
+
+1. **Listing / search URLs, not PDPs.** Genuine `local_bhd` prices from sharafdg arrive with search URLs (`https://bahrain.sharafdg.com/?s=iPhone+15+128GB&post_type=product`); `converted_usd` arrives with `google.com/search?...` URLs. `_is_listing_url` → `should_cache_price` rejects (a search page is not a verifiable PDP). Reproduced: Samsung S24 256GB → `converted_usd 144.59`, google-search URL, `should_cache_price=False`.
+2. **`converted_usd` frequently wins the race** (not a genuine-BH method → KPI-not-usable) — e.g. Levis 501.
+3. **`gpt_organic_extract`** (not in `GENUINE_BH_SOURCE_METHODS`) for iPad, MacBook, Switch, Nike, Ray-Ban → not usable.
+4. **No title/name identity** on the returned price (the resolved dict often has neither `title` nor `name` after selection) → fails the identity gate.
+5. **In-stock=False** for several fragrances/fashion (Acqua di Gio, La Vie Est Belle, Tommy) → not usable.
+6. **Non-determinism.** The same query resolves to a genuine PDP on one run and a converted/listing result on the next (Samsung: `local_bhd 426.22` in the warm run, `converted_usd 144.59` on re-resolve). The warmer can't reliably land the cacheable variant.
+
+## What this means
+
+- **The gate-first design WORKED.** An unguarded warmer would have cached 17 low-quality/listing-URL prices (the pre-PR9 poisoning). The fail-closed `should_cache_price` refused them and cached only the 1 correct genuine PDP — exactly the safety the gate is for. **Activating the warmer now would put genuine prices on ~6% of the cold path — not worth the Serper spend.**
+- **The blocker is UPSTREAM source quality, not warmer machinery:** the genuine-price cascade must yield a **PDP URL + title + a deterministic genuine match** for `should_cache_price` to accept it. That is the catalog-adapter / render-tier / discovery-integration work (Shopify/Woo/Salla PDP endpoints, the deferred render-tier, deterministic source ordering) — a separate epic, tracked in the BH/GCC source work.
+- **Warmer stays OFF** (`ENABLE_PRICE_CACHE_WARMER` unchanged). The Wave-1 gate machinery + safety fixes (PR #12) remain valid and mergeable; they are what MEASURED this cleanly.
+
+## Prod-cache impact of this run
+
+The off-clock warm wrote exactly **1 correct genuine price** (Samsung S24 Ultra 256GB) to the shared cache — a legitimate entry (correct SKU, PDP URL), left to TTL out. The 17 rejected resolutions wrote nothing (no pollution) — a live proof that `should_cache_price` fail-closed holds.

--- a/docs/investigations/2026-06-30-warmer-recon.md
+++ b/docs/investigations/2026-06-30-warmer-recon.md
@@ -77,3 +77,21 @@ This note is the deliverable of Wave-1 Task 1. It reshapes the plan: several leg
 **GATED terminal actions (need explicit user GO + a healthy paid Serper key):**
 - **Task 6/warm real sample + measure KPI** — writes to the SHARED prod cache + burns paid Serper. Requires isolated-cache OR accept+purge-after.
 - **Task 7/flip `ENABLE_PRICE_CACHE_WARMER`** — prod activation, iff per-category KPI ≥85% ∧ parity proven ∧ clean cache ∧ sweep+comm green.
+
+---
+
+## 7. Adversarial coverage sweep — findings + dispositions (`wf_b806ccdd-467`)
+
+5 parallel adversaries, each reproducing through the runtime. Dispatcher-gated:
+
+| Finding | Sev | Disposition |
+|---|---|---|
+| Budget guard used the free-tier-calibrated lifetime counter (`get_remaining`/`has_budget('serper')`, ceiling 2200) → would PERMANENTLY disable the warmer on a healthy paid key past 2200 lifetime burn | MED (confirmed) | **FIXED** — replaced with a tier-independent per-run credit cap (`WARMER_MAX_SERPER_CREDITS_PER_RUN`, 900); dropped the lifetime dependency + `_serper_exhausted` |
+| `urn:uuid:`/braced baseline-id forms pass `uuid.UUID()` but 22P02 → phantom "not found" | LOW (confirmed) | **FIXED** — validate the canonical hyphenated form |
+| `kpi_gate_verdict` + main() KPI refactor | — | **No findings** (correct; the only divergence vs the old inline check is empty→PAUSED, the intended fix) |
+| L2 title persistence (flag-gated) | — | **No findings** (flag-OFF byte-identical; flag-ON-but-column-absent swallowed on both save + read; list-title coerced at display) |
+| **`extract_weight_or_volume('5G')` → (5.0,'g')**: cellular "5G/4G/3G" mis-parsed as gram-weight → the same phone's base query and its "5G" PDP title hash to DIFFERENT cache keys (false-SPLIT → warmer cache MISS across electronics) | HIGH (confirmed) | **DEFERRED** — see below |
+
+### Deferred: the 5G/4G/5G weight-token false-split (HIGH, pre-existing)
+
+`extract_weight_or_volume` (ps:2928) matches bare `<digit>G` as grams, so `size_variant_token('Galaxy S24 FE 5G')` → `fe.5g` vs `fe` for the base model → different cache keys → a guaranteed warm-vs-live MISS for any electronics whose genuine PDP title carries "5G". **It is PRE-EXISTING in main `cdaf5c5` (not a Wave-1 regression)** and NOT trivially fixable, because the same extractor feeds the **correctness matcher's weight axis** (ps:1827/1839/1851 — PR #9 territory) AND the disambiguation is **category-dependent**: "5G" is cellular for a phone but "5 grams" for a supplement ("Creatine 5G"). A category-blind strip would FALSE-MERGE supplement weights ("Creatine 5G" ≡ "Creatine 10G" → wrong-SKU cache serve — strictly worse). The correct fix is **category-aware** (exclude cellular `[2-5]G` from weight ONLY for electronics/gadget context, preserving supplement gram parsing) and must be verified by the correctness COVERAGE sweep — so it belongs in a dedicated correctness session, not the warmer-gate wave. Impact until fixed: warmer coverage degradation (a miss → live pending/converted), NOT a wrong price. Tracked for the next correctness-sweep session.

--- a/docs/investigations/2026-06-30-warmer-recon.md
+++ b/docs/investigations/2026-06-30-warmer-recon.md
@@ -1,0 +1,79 @@
+# Wave 1 recon — price-cache warmer + cache-key parity + usable_exact_genuine KPI
+
+**Date:** 2026-07-01 · **Branch:** `feature/genuine-price-warmer` (off `origin/main` cdaf5c5)
+**Method:** 5-agent parallel recon workflow (`wf_4de01065-497`) + dispatcher first-hand reads of the crux functions.
+
+This note is the deliverable of Wave-1 Task 1. It reshapes the plan: several legs are **already built**, and the "cache-key parity silent killer" is **not** where the design doc assumed.
+
+---
+
+## 0. Executive reframing (read this first)
+
+| Design-doc assumption | Recon reality |
+|---|---|
+| "Warmed key ≠ live key" is a builder bug | **False at the builder.** Warmer calls `compare_from_text(query, nocache=True)` → the SAME `_get_price` → `build_size_aware_price_cache_key(...)` a live user hits. The builder already alias-normalizes EDT≡"eau de toilette", oz≡ml, TB≡GB. |
+| Parity is the silent killer for the gate | For the **gate**, warmer + KPI read the SAME truth-set query strings → parity is **trivially guaranteed**. The free-form divergence (verbose warmed title vs terse live query) is real but **on-device only**, and unmeasured by the gate. |
+| Titleless display/cache inconsistency is the folded item | The bigger bug is **the DB (L2 `product_prices`) never persists `title`** → a warmed price rehydrated from Postgres is titleless → fails the KPI + `should_cache_price`. |
+| KPI + per-category gate need building (Task 3) | **Already built.** `run_usable_exact_genuine_kpi` returns `per_category`, and `main()` enforces `≥0.85`/category (eval_runner.py:1433-1441). |
+| 30-50/category truth set exists to extend | Only **18 products / 3 categories** (electronics/fashion/fragrances × 6) exist today. |
+
+**Net:** Wave 1's real work = (a) baseline-uuid validation; (b) **persist+rehydrate the DB title** (durability); (c) a warmer Serper-budget guard; (d) truth-set expansion; (e) a cache-key parity TEST that pins what's already safe + documents the parser residual; (f) surface the per-category gate verdict. The prod-warm + flag-flip remain the gated terminal actions.
+
+---
+
+## 1. Warmer cron — `scripts/cron_warm_price_cache.py`
+
+- **Query source (3 files, no DB):** `WARMER_SUBSET` (default `smoke20`, `full`→whole set) → `load_gold_truth()` reads `data/validation_gold_truth.json` + `select_queries()` filters via `data/eval_smoke_subset.json`; then `_merge_catalog()` folds in `data/warmer_catalog.json` (`warm-*` ids, every run); then `_rotation_window()` slices `MAX_QUERIES_PER_RUN` (default 25) from a Redis cursor `warmer:cursor`. (cron:203-221)
+- **Write path:** `_warm_one` → `svc.compare_from_text(record["query"], region=…, nocache=True)` (cron:172-174). **`nocache=True` bypasses the READ, not the WRITE.** Inside `_get_price`, writes fire when `should_cache_price(...)` passes: `set_cached(cache_key, best, price_cache_ttl(best))` (Redis) + `self._save_price_to_db(...)` → `product_prices` insert. (scs:4764-4766, 5934-5937)
+- **Off-clock budget overrides (import-time, warmer-only):** `PRICE_RACE_TIMEOUT`=`WARMER_PRICE_RACE_TIMEOUT`(60); `STREAM_HARD_CAP_SECONDS`=`WARMER_STREAM_HARD_CAP`(150); `FAN_OUT_BUDGET_SECONDS`=`WARMER_FAN_OUT_BUDGET`(35); Firecrawl/Scrape.do timeouts raised. (cron:49-58) → the slow genuine curl/render actually finishes off-clock.
+- **GAPS:** (1) **No Serper-budget guard** — only the `MAX_QUERIES_PER_RUN` count cap; relies on the generic per-request `api_budget_service`. (2) **No fresh-purge / clean-cache assertion** — `main()` goes flag→load→merge→window→warm loop, overwriting whatever is there.
+- **Gate:** fail-closed `ENABLE_PRICE_CACHE_WARMER` only.
+
+## 2. Cache-key parity — `price_service.py` + `structured_comparison_service.py`
+
+- **Single derivation:** `_get_price` builds `cache_key = build_size_aware_price_cache_key(brand, name, variant, region, search_query)` (scs:4155), where `search_query = product_info.get("search_query", f"{brand} {name} {variant}")` (scs:3469) — the **parser's** output, identical function for warmer-write and live-read. Physical key = `md5("|".join(...))[:12]` → `price:<12hex>`.
+- **`_identity_cache_token(text)`** (ps:5009) composes 3 axes with `.`: concentration (`extract_concentration`→lowercased, EDP/EDT/…), electronics/variant qualifiers (`_quals_in`→sorted-joined, FE/Pro/Max), size/storage/count/weight (`size_variant_token`→`256gb`/`100ml`). `_strip_identity_axes` removes these from `name`/`variant` so the same axis in `name` vs `search_query` collapses to one base.
+- **Alias normalization — ALREADY SAFE:** `extract_concentration` maps `eau de toilette` and `edt` → the single label `EDT` (ps:2773-2789); `size_variant_token`/`extract_size_ml_any` snap `oz`→`ml` (3.4oz→100ml), `TB`→`GB`, `L`→`ml`.
+- **The real residual (UPSTREAM, parser):** a size/qualifier axis PRESENT in the verbose warmed title but ABSENT from a short live query → different token → different key:
+  - Warm `"Dior Sauvage Eau de Toilette 100ml"` → token `edt.100ml`; live `"Dior Sauvage EDT"` → token `edt` → **DIFFERENT key.** The alias collapses; the **size presence/absence does not.**
+  - `"Samsung Galaxy S24 256GB"` vs `"Galaxy S24 256GB"`: token `256gb` both; base collapses IFF the parser fills `brand="Samsung"` for both (it normally does).
+- **Consequence for the gate:** the warmer and the KPI both read the SAME truth-set strings → identical parser output → identical key → parity is **guaranteed for the gate measurement**. Fully fixing the free-form on-device case requires deriving the key from the RESOLVED-MATCH identity (matched PDP brand/name/concentration/size) fed back on both sides — a larger change that risks flag-OFF byte-identity. **Decision: pin the already-safe alias parity with a test; document the parser residual; do NOT re-architect keying in Wave 1.**
+
+## 3. usable_exact_genuine KPI — `scripts/eval_runner.py`
+
+- **`usable_exact_genuine_for_product`** (eval:484-583): (a) non-pending positive amount; (b) `source_method ∈ GENUINE_BH_SOURCE_METHODS` (eval:400-423, mirrors ps `_GENUINE_BH_SOURCE_METHODS`, parity-pinned); (c) `in_stock is True` (unknown≠usable); (d) present non-listing PDP url; (e) exact identity vs the truth entry via `_selection_match` + fail-closed structured axes (`storage_gb`/`size_ml`/`concentration`/`colorway`). **A titleless price → `title==""` → returns False** (eval:538-540).
+- **`run_usable_exact_genuine_kpi`** (eval:1213-1275): loads `data/usable_exact_genuine_truth.json`, GETs `/api/v1/text/price-kpi?q=&region=&nocache=` per truth entry (`nocache=false` for `--read-cache` WARMED, else COLD), maps body[0]+truth through the checker, aggregates **per-category** `{usable, requested, share}` + overall. PROD-HTTP (post-deploy). `_KPI_HTTP_TIMEOUT=90`.
+- **Per-category gate — ALREADY WIRED:** `main()` (eval:1424-1441) prints the KPI JSON, computes `failing = {c: share for share < 0.85}`, exits 1 + "warmer activation stays PAUSED" if any category is below. So Task 3's mechanism exists.
+- **Baseline uuid bug:** `--baseline-run-id` → `eval_gate._regression_gate` → `fetch_eval_run` → `.eq("id", run_id)` on a `uuid PK` (eval_persistence:91-110). A truncated `54b603e8` triggers Postgres `22P02 invalid input syntax for type uuid`, but the `try/except` **swallows it → returns None → "baseline not found"** (indistinguishable from a genuinely missing row). Full uuid `54b603e8-4eab-41c9-a34d-a5e391446559` casts cleanly. **Fix: validate the id is a full uuid before the query and raise a clear error.**
+- **Truth set:** `data/usable_exact_genuine_truth.json` — 18 products, 3 categories (electronics/fragrances/fashion × 6), deliberately disjoint from `warmer_catalog.json` (pinned by `tests/test_kpi_set_disjoint_from_warmer.py`).
+
+## 4. `/price-kpi` endpoint — `app/api/text_routes.py:636-692`
+
+- Params `q, region, nocache(default True)`. Runs the real `parse_product_query` → resolves `category = p0.category or _infer_category_from_query(q) or "other"` (text:667) → threads it into `_get_price(brand, name, variant, region, search_query, nocache, category)` (text:671) → `set_resolved_price_category(category)` ContextVar (scs:4144). Non-showable (`is_price_showable(enforce_correctness=True)` fails) → `make_pending_price` (text:678-682); returns `overview.products[0].price` via `public_price_view`.
+- **`public_price_view`** (ps:4990-5006) drops ONLY `guard_rejected` + `_`-prefixed keys; **keeps `title`, `source_method`**. A null title in the KPI response ⇒ either a PEND (`make_pending_price` has no title) or a genuinely titleless resolved listing.
+- **`nocache=true` against prod STILL WRITES** to the shared Upstash + `product_prices` whenever `should_cache_price` passes → local KPI runs pollute prod cache (the documented gotcha).
+
+## 5. Titleless + showable + cache discipline — `price_service.py`
+
+- **`is_price_showable(…, enforce_correctness=False)`** (ps:1204): base checks (dict, positive amount, `source_method ∈ _showable_source_methods()` = genuine ∪ converted_usd, implausibility guards). Correctness backstop is opt-in + flag-gated (`if enforce_correctness and exact_gate_enabled()`, ps:1266). **Titleless-with-url is SHOWN**: pends only when identity AND url both missing (ps:1290); the axis backstop at ps:1312-1317 is `if identity and (...)` → skipped when titleless. This title-OR-url leniency is DELIBERATE (documented over-rejection avoidance for descriptive converted/page-scrape/iHerb titles).
+- **`should_cache_price`** (ps:4940) hard-requires `title` (ps:4959-4961) + valid PDP url + `in_stock is not False` + `_selection_match`. → **titleless is SHOWN but NOT cached.**
+- **`_backstop_identity_ok`** (ps:4776): axis-only (`_axis_mismatch(strict_extras=False)`), brand-independent. Callers: display chokepoint (ps:1312) + cache-READ revalidation (`_cache_price_identity_ok`, scs:728/741). No-op when flag OFF or title-less.
+- **Flag guard** `exact_gate_enabled()` (ps:3028, default ON) present on every surface → flag-OFF byte-identical to b207bfa.
+
+**Reconciliation decision:** do NOT tighten display to pend titleless (that re-introduces the documented over-rejection). Instead **persist + rehydrate the DB `title`** so warmed prices are durably KPI-usable and cacheable — making the warmer's cache side (which already requires title) consistent with what it serves.
+
+---
+
+## 6. Revised Wave-1 task list (supersedes the plan's Tasks 2-7 detail)
+
+1. **Baseline-uuid validation** (eval_runner/eval_gate) — clear error on a non-full-uuid `--baseline-run-id`; correct the CLAUDE.md gate command to the full uuid. *[safe, TDD]*
+2. **DB title persistence + rehydration** (`product_data_service.save_price`/`get_cached_price`, migration for a `title` column) — the durability fix; gated so flag-OFF byte-identical + safe on a missing column. *[safe, TDD, needs a migration]*
+3. **Warmer Serper-budget guard** (`cron_warm_price_cache.py`) — a pre-run + per-query budget circuit using `api_budget_service`; estimate + cap the spend. *[safe, TDD]*
+4. **Cache-key parity test** (`tests/test_price_cache_key_parity.py`) — pin EDT≡"eau de toilette"/oz≡ml same-size → same key; distinct variants differ; DOCUMENT the parser axis-presence residual as xfail/comment. *[safe, TDD]*
+5. **Per-category gate verdict surfacing** — emit a structured `{gate_pass, failing}` in the KPI JSON (mechanism already in `main()`); optionally a `--kpi-gate` exit contract test. *[safe, TDD]*
+6. **Truth-set expansion** — grow existing categories for statistical power + seed new categories with verified BH-available SKUs (research-gated; only add products with a plausible genuine BH source). *[data, research-gated]*
+7. **Fresh-purge precondition helper** — a clean-cache assertion the warmer/measurement can call; for LOCAL runs, an isolated-cache path OR a documented purge-after. *[safe, TDD]*
+
+**GATED terminal actions (need explicit user GO + a healthy paid Serper key):**
+- **Task 6/warm real sample + measure KPI** — writes to the SHARED prod cache + burns paid Serper. Requires isolated-cache OR accept+purge-after.
+- **Task 7/flip `ENABLE_PRICE_CACHE_WARMER`** — prod activation, iff per-category KPI ≥85% ∧ parity proven ∧ clean cache ∧ sweep+comm green.

--- a/docs/runbooks/2026-06-30-warmer-activation.md
+++ b/docs/runbooks/2026-06-30-warmer-activation.md
@@ -1,0 +1,98 @@
+# Warmer activation runbook — the GATED terminal step of Wave 1
+
+**Owner:** Ahmed (interactive terminal — needs `railway login` + a healthy PAID Serper key).
+**Precondition:** the Wave-1 code (branch `feature/genuine-price-warmer`) is merged + deployed. That branch ships the gate machinery (per-category KPI verdict, Serper-budget guard, DB-title persistence, cache-key parity pins) but leaves `ENABLE_PRICE_CACHE_WARMER` **OFF**. This runbook is the "flip it iff the gate is green" step Claude cannot do (no Railway auth in a non-interactive session).
+
+> **Why this is a manual gate, not auto-code:** the warmer WRITES genuine BHD prices into the SHARED prod cache and BURNS paid Serper. It previously poisoned the cache when no correctness gate existed. The exact-SKU gate (PR #9) + fail-closed `should_cache_price` now guard the write; this runbook is the human confirmation that the WARMED per-category KPI clears ≥85% before we let the cron write continuously.
+
+---
+
+## Step 0 — Serper health (do NOT skip)
+
+The warmer burns paid Serper continuously. Confirm the key is healthy + has headroom:
+
+```bash
+# 1. Confirm the paid key is set on Railway (the 7de9c750… paid key per 2026-06-27).
+railway variables --service web | grep -i SERPER_API_KEY
+
+# 2. Liveness — a bare prices endpoint (NEVER a full compare; that rides the 30s cap).
+curl "https://web-production-58776.up.railway.app/api/v1/text/prices/CeraVe%20Moisturising%20Lotion"
+#   -> a real BHD amount (not estimated) == key alive. A 400 "Not enough credits" == DEPLETED -> rotate first.
+
+# 3. Headroom — the warmer's pre-run guard trims to what get_remaining('serper') affords
+#    (~30 credits/query). A smoke20 warm (~20 queries x2 products) ~= 400-600 credits.
+```
+
+**If depleted:** rotate per the CLAUDE.md playbook (new key → `railway variables --set` + `railway redeploy` + sync local `.env` + reset `budget:serper:<key8>:lifetime` + DEL `budget:serper:burn_alert_fired:*`) BEFORE proceeding.
+
+## Step 1 — (optional but recommended) make the warm DURABLE: migration 033 + title flag
+
+Without this, a warmed price is genuine+title in Redis L1 but rehydrates title-less from the DB after the L1 TTL (→ not usable_exact_genuine long-term). Applying it makes the warm durably SKU-verifiable.
+
+```
+# Apply 033 (Supabase MCP apply_migration, or the SQL editor):
+#   migrations/033_product_prices_title.sql   (ADD COLUMN IF NOT EXISTS title TEXT)
+# THEN (order matters — column first, flag second):
+railway variables --service web --set ENABLE_PRICE_TITLE_PERSIST=true
+railway redeploy --service web
+```
+Verify the column exists (`information_schema.columns` where table='product_prices' and column='title') before flipping the flag. Rollback: flip the flag OFF, then `migrations/rollback/033_product_prices_title.sql`.
+
+## Step 2 — fresh cache (measurement hygiene)
+
+The 18 wrong keys + 211 DB rows were purged during PR #9. Re-verify nothing wrong survives for the KPI truth queries. **GOTCHA:** any `_get_price`/warm with `nocache=True` STILL WRITES the shared Upstash + `product_prices` (nocache bypasses the READ, not the WRITE). So the warm + the `/price-kpi` measurement below BOTH write to prod cache — that is the warmer's intended effect, and the exact-SKU gate ensures only correct SKUs are cached. If you want a clean-room measurement instead, point `SUPABASE_*`/`UPSTASH_*` at an isolated project for the warm+KPI, then the prod cache is untouched.
+
+## Step 3 — warm a bounded per-category sample (off-clock budgets)
+
+The warmer runs the gold + `warmer_catalog` queries with the off-clock timeouts (`WARMER_PRICE_RACE_TIMEOUT=60`, `WARMER_STREAM_HARD_CAP=150`) so the slow genuine curl finishes. Bound the spend:
+
+```bash
+# LOCAL manual warm (writes to the SHARED prod cache — that's the point):
+ENABLE_PRICE_CACHE_WARMER=true WARMER_SUBSET=smoke20 MAX_QUERIES_PER_RUN=20 \
+  python -m scripts.cron_warm_price_cache
+#  -> logs: genuine=… converted=… none=… | genuine-share=…% ; the pre-run Serper
+#     guard trims the window if headroom is low; the per-query circuit stops on exhaustion.
+```
+
+To warm the KPI TRUTH set specifically (electronics/fashion/fragrances today — expand the truth set for more categories), warm those exact queries so the L1 key matches the KPI read (same parser output = same cache key; see the cache-key parity residual — phrase the warm queries the way the KPI queries are phrased).
+
+## Step 4 — measure the WARMED per-category KPI
+
+```bash
+# POST-warm, read-cache (nocache=false) so it serves the warmed prices:
+python -m scripts.eval_runner --kpi usable_exact_genuine --read-cache \
+  --base-url https://web-production-58776.up.railway.app --concurrency 1
+```
+Read the JSON `gate` block:
+```json
+"gate": { "threshold": 0.85, "pass": true|false, "failing": {…}, "measured_categories": […] }
+```
+- `pass: true` (every measured category ≥0.85, at least one measured) → the gate is GREEN.
+- `pass: false` → note the `failing` categories; the warmer stays OFF. Diagnose per category (was it a genuine-source gap, a cache-key miss, or a titleless L2 rehydrate?).
+
+Save the JSON to `docs/investigations/2026-06-30-warmer-kpi-result.md`.
+
+## Step 5 — AUTO-ACTIVATION decision
+
+Flip the warmer ON **iff ALL** hold:
+1. per-category KPI `gate.pass == true` (≥85%/category, Step 4),
+2. cache-key parity respected (warm queries phrased like live/KPI queries — Task-4 pins),
+3. the cache is clean (Step 2),
+4. the branch comm gate is green (branch-only-NEW failures == []).
+
+```bash
+# Register the cron (dispatcher decision) + flip the flag:
+railway variables --service web --set ENABLE_PRICE_CACHE_WARMER=true
+# Railway cron service:  schedule 0 */12 * * *   command  python -m scripts.cron_warm_price_cache
+#   (12h beats the 24h L1 TTL). Size MAX_QUERIES_PER_RUN / WARMER_SUBSET to the Serper plan.
+railway redeploy --service web
+```
+
+**Any red leg → leave `ENABLE_PRICE_CACHE_WARMER` OFF + write the per-leg diagnosis. Do not start Wave 2 until Wave 1's gate is green (or consciously deferred).**
+
+## Serper cost estimate (for budgeting)
+
+- One warm query ≈ 2 products × ~10–30 credits = ~20–60 credits.
+- A smoke20 warm (20 queries) ≈ 400–1,200 credits per run.
+- The cron at 12h cadence with `MAX_QUERIES_PER_RUN=25` ≈ ~500–1,500 credits / run × 2 runs/day.
+- Free Serper (~2,500 one-time) affords ~2–5 runs; **sustained warming needs the paid plan.** The pre-run budget guard trims each run to affordable, and the per-query circuit halts on exhaustion — so a low balance degrades coverage gracefully rather than blowing the budget.

--- a/docs/runbooks/2026-06-30-warmer-activation.md
+++ b/docs/runbooks/2026-06-30-warmer-activation.md
@@ -12,15 +12,20 @@
 The warmer burns paid Serper continuously. Confirm the key is healthy + has headroom:
 
 ```bash
-# 1. Confirm the paid key is set on Railway (the 7de9c750… paid key per 2026-06-27).
-railway variables --service web | grep -i SERPER_API_KEY
+# 1. Confirm the paid key is SET on Railway (presence only — do NOT echo the value).
+railway variables --service web | grep -qi '^SERPER_API_KEY=' && echo 'SERPER_API_KEY set' || echo 'MISSING'
 
 # 2. Liveness — a bare prices endpoint (NEVER a full compare; that rides the 30s cap).
-curl "https://web-production-58776.up.railway.app/api/v1/text/prices/CeraVe%20Moisturising%20Lotion"
-#   -> a real BHD amount (not estimated) == key alive. A 400 "Not enough credits" == DEPLETED -> rotate first.
+curl "https://web-production-58776.up.railway.app/api/v1/text/prices/iPhone%2015%20128GB"
+#   -> regional_prices.bahrain.amount a real BHD number == key alive. A 400 "Not enough
+#      credits" (or all-pending) == DEPLETED -> rotate first.
 
-# 3. Headroom — the warmer's pre-run guard trims to what get_remaining('serper') affords
-#    (~30 credits/query). A smoke20 warm (~20 queries x2 products) ~= 400-600 credits.
+# 3. Headroom — the warmer's pre-run guard is a TIER-INDEPENDENT per-run credit cap
+#    (WARMER_MAX_SERPER_CREDITS_PER_RUN default 900, at ~WARMER_SERPER_CREDITS_PER_QUERY
+#    default 30 credits/query -> 900/30=30 affordable, so the default MAX_QUERIES_PER_RUN=25
+#    window is NOT trimmed). It deliberately does NOT consult api_budget_service's lifetime
+#    counter, so it can never mis-fire on a healthy paid key. A smoke20 warm (~20 queries
+#    x2 products) ~= 400-600 credits.
 ```
 
 **If depleted:** rotate per the CLAUDE.md playbook (new key → `railway variables --set` + `railway redeploy` + sync local `.env` + reset `budget:serper:<key8>:lifetime` + DEL `budget:serper:burn_alert_fired:*`) BEFORE proceeding.
@@ -95,4 +100,5 @@ railway redeploy --service web
 - One warm query ≈ 2 products × ~10–30 credits = ~20–60 credits.
 - A smoke20 warm (20 queries) ≈ 400–1,200 credits per run.
 - The cron at 12h cadence with `MAX_QUERIES_PER_RUN=25` ≈ ~500–1,500 credits / run × 2 runs/day.
-- Free Serper (~2,500 one-time) affords ~2–5 runs; **sustained warming needs the paid plan.** The pre-run budget guard trims each run to affordable, and the per-query circuit halts on exhaustion — so a low balance degrades coverage gracefully rather than blowing the budget.
+- **Spend knobs:** `MAX_QUERIES_PER_RUN` (count cap, default 25) is the hard bound; `WARMER_MAX_SERPER_CREDITS_PER_RUN` (per-run credit ceiling, default 900; `<=0` disables) trims the window to `WARMER_MAX_SERPER_CREDITS_PER_RUN / WARMER_SERPER_CREDITS_PER_QUERY` (default 900/30 = 30) queries, layered UNDER the count cap. At defaults the credit cap (30) exceeds the count cap (25) so it never trims — lower `WARMER_MAX_SERPER_CREDITS_PER_RUN` to bound a run below 25 queries.
+- Free Serper (~2,500 one-time) affords ~2–5 runs; **sustained warming needs the paid plan.** The tier-independent per-run credit cap bounds each run and a truly-depleted account simply rejects calls (handled gracefully by `_warm_one`), so a low balance degrades coverage rather than blowing the budget.

--- a/migrations/033_product_prices_title.sql
+++ b/migrations/033_product_prices_title.sql
@@ -1,0 +1,39 @@
+-- Migration 033: product_prices.title — persist the resolved listing title
+--
+-- The L2 price cache (product_prices) never stored the resolved/matched listing
+-- TITLE, so a warmed price rehydrated from Postgres came back title-less. That
+-- title-less price then:
+--   * fails the usable_exact_genuine KPI (it needs a title to re-verify the SKU),
+--   * fails should_cache_price (title is a hard requirement), so it can never be
+--     re-cached, and
+--   * is shown by is_price_showable only via the url-OR-title leniency.
+-- The Redis L1 object keeps the title (exact gate ON), so a FRESH warm measures
+-- usable, but the benefit decays to a title-less DB row after the L1 TTL.
+--
+-- This adds a nullable `title TEXT` column so save_price can persist it and
+-- get_cached_price can rehydrate it, making a warmed price durably SKU-verifiable
+-- on the cache-served path.
+--
+-- ROLLOUT ORDER (important): apply THIS migration FIRST, then flip
+-- ENABLE_PRICE_TITLE_PERSIST=true. The application code only writes/reads the
+-- column when that flag is ON (default OFF = byte-identical to today), so a
+-- deploy with the code but without the column is a no-op, and flipping the flag
+-- before the column exists would only degrade the L2 read to a miss (never a
+-- crash — get_cached_price swallows the error).
+--
+-- Plan: docs/plans/2026-06-30-genuine-price-warmer-and-variant-metadata-plan.md
+-- Rollback: migrations/rollback/033_product_prices_title.sql
+-- Additive + nullable → safe, no backfill, no lock of note on a small table.
+
+BEGIN;
+
+ALTER TABLE public.product_prices
+  ADD COLUMN IF NOT EXISTS title TEXT;
+
+COMMENT ON COLUMN public.product_prices.title IS
+  'Resolved/matched listing title, persisted so a rehydrated L2 price stays '
+  'SKU-verifiable (usable_exact_genuine KPI + should_cache_price). Written/read '
+  'only when ENABLE_PRICE_TITLE_PERSIST is ON. Nullable: legacy rows + flag-OFF '
+  'writes have NULL, which the app treats exactly as the pre-033 title-less row.';
+
+COMMIT;

--- a/migrations/rollback/033_product_prices_title.sql
+++ b/migrations/rollback/033_product_prices_title.sql
@@ -1,0 +1,12 @@
+-- Rollback 033: drop product_prices.title
+--
+-- Safe: the column is only written/read when ENABLE_PRICE_TITLE_PERSIST is ON.
+-- Flip that flag OFF BEFORE running this rollback so no in-flight insert/select
+-- references the column, then drop it.
+
+BEGIN;
+
+ALTER TABLE public.product_prices
+  DROP COLUMN IF EXISTS title;
+
+COMMIT;

--- a/scripts/cron_warm_price_cache.py
+++ b/scripts/cron_warm_price_cache.py
@@ -107,50 +107,50 @@ def _int_env(name: str, default: int) -> int:
 
 def _serper_per_query_estimate() -> int:
     """Estimated Serper credits ONE warm query (2 products) drives. Cold BH
-    discovery burns ~10-30 credits/query post-B.0; 30 is a safe upper estimate
-    for the pre-run headroom check. Override via WARMER_SERPER_CREDITS_PER_QUERY.
-    <=0 disables the pre-run trim (keeps the count cap only)."""
+    discovery burns ~10-30 credits/query post-B.0; 30 is a safe upper estimate.
+    Override via WARMER_SERPER_CREDITS_PER_QUERY. <=0 disables the pre-run credit
+    trim (the MAX_QUERIES_PER_RUN count cap remains)."""
     return _int_env("WARMER_SERPER_CREDITS_PER_QUERY", 30)
 
 
-def _budget_bounded_window(window: List[Dict[str, Any]],
-                           *, per_query: Optional[int] = None) -> List[Dict[str, Any]]:
-    """Trim `window` to what the REMAINING Serper budget can afford, so a run
-    can never drive the paid key into overage. Never GROWS the window (the
-    MAX_QUERIES_PER_RUN cap already bounded it). FAIL-OPEN: on any budget/Redis
-    error, or when the estimate is disabled (<=0), return the window unchanged —
-    the count cap is the Redis-down backstop, consistent with the codebase's
-    fail-open budget posture."""
+def _serper_max_credits_per_run() -> int:
+    """Per-RUN Serper credit ceiling for the warmer, bounding a SINGLE run's spend.
+
+    Deliberately TIER-INDEPENDENT: it does NOT consult api_budget_service's
+    lifetime counter / has_budget('serper'). That counter is capped at the
+    hardcoded FREE-tier config ceiling (serper monthly_limit=2200); on a healthy
+    PAID key — the exact key the warmer is designed for — once lifetime burn
+    passes 2200, get_remaining('serper') returns 0 and has_budget returns False,
+    which would WRONGLY disable the warmer entirely (adversarial sweep MED). A
+    fixed per-run cap protects against a single run's blowout without ever
+    permanently disabling the warmer, and the real account simply rejects calls
+    with 'Not enough credits' (handled gracefully by _warm_one) if truly depleted.
+    Override via WARMER_MAX_SERPER_CREDITS_PER_RUN; <=0 disables the credit trim."""
+    return _int_env("WARMER_MAX_SERPER_CREDITS_PER_RUN", 900)
+
+
+def _budget_bounded_window(
+    window: List[Dict[str, Any]], *, per_query: Optional[int] = None,
+    max_credits: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Trim `window` so this RUN's ESTIMATED Serper spend stays within the per-run
+    credit cap, layered UNDER the MAX_QUERIES_PER_RUN count cap. Never GROWS the
+    window. Disabled (window returned unchanged) when either knob is <=0. Uses NO
+    external budget state, so it can never mis-fire on a paid key or a Redis
+    outage — the fixed cap + the count cap are the whole bound."""
     per_query = _serper_per_query_estimate() if per_query is None else per_query
-    if per_query <= 0 or not window:
+    max_credits = _serper_max_credits_per_run() if max_credits is None else max_credits
+    if per_query <= 0 or max_credits <= 0 or not window:
         return window
-    try:
-        from app.services.api_budget_service import get_remaining
-        remaining = int(get_remaining("serper"))
-    except Exception as exc:  # noqa: BLE001 — budget check must never block the warmer
-        logger.info("[cron_warm] Serper headroom check unavailable (%s) — no trim", exc)
-        return window
-    affordable = remaining // per_query
+    affordable = max_credits // per_query
     if affordable >= len(window):
         return window
     logger.warning(
-        "[cron_warm] Serper headroom ~%d credits affords ~%d of %d queries "
+        "[cron_warm] per-run Serper cap ~%d credits affords ~%d of %d queries "
         "(@~%d/query) — trimming this run",
-        remaining, affordable, len(window), per_query,
+        max_credits, affordable, len(window), per_query,
     )
     return window[:max(0, affordable)]
-
-
-def _serper_exhausted() -> bool:
-    """Per-query circuit: True iff the Serper budget is exhausted right now, so
-    the warm loop can STOP early instead of burning into overage. FAIL-OPEN
-    (False) on any budget/Redis error — the count cap remains the hard bound."""
-    try:
-        from app.services.api_budget_service import has_budget
-        return not has_budget("serper")
-    except Exception as exc:  # noqa: BLE001
-        logger.info("[cron_warm] Serper budget check unavailable (%s) — not stopping", exc)
-        return False
 
 
 def load_warmer_catalog(path: Path = _WARMER_CATALOG_PATH) -> List[Dict[str, Any]]:
@@ -267,30 +267,27 @@ async def main() -> Optional[Dict[str, int]]:
     queries = _merge_catalog(queries, load_warmer_catalog())
 
     window = _rotation_window(queries, max_q)
-    # PRE-RUN Serper-budget guard — trim the window to what the paid key can
-    # afford so a run never drives it into overage (fail-open; the count cap is
-    # the Redis-down backstop).
+    # PRE-RUN Serper-budget guard — trim the window to the per-run credit cap so a
+    # single run never blows the budget. Tier-independent (no lifetime-counter
+    # dependency), so it can never mis-fire on a healthy paid key.
     window = _budget_bounded_window(window)
     if not window:
         logger.warning(
-            "[cron_warm] Serper headroom too low to warm any query — skipping run"
+            "[cron_warm] per-run Serper credit cap too low to afford any query "
+            "(WARMER_MAX_SERPER_CREDITS_PER_RUN / WARMER_SERPER_CREDITS_PER_QUERY) "
+            "— skipping run"
         )
         return None
+    est_credits = len(window) * _serper_per_query_estimate()
     logger.info(
-        "[cron_warm] warming %d/%d queries (subset=%s, PRICE_RACE_TIMEOUT=%s) off-clock",
+        "[cron_warm] warming %d/%d queries (subset=%s, PRICE_RACE_TIMEOUT=%s, "
+        "est ~%d Serper credits) off-clock",
         len(window), len(queries), subset or "full", os.environ["PRICE_RACE_TIMEOUT"],
+        est_credits,
     )
 
     totals = {"genuine": 0, "converted": 0, "estimated": 0, "none": 0}
-    for i, record in enumerate(window):
-        # PER-QUERY circuit — stop the moment Serper is exhausted rather than
-        # burning the remaining window into overage.
-        if _serper_exhausted():
-            logger.warning(
-                "[cron_warm] Serper budget exhausted mid-run — stopping early "
-                "(%d/%d queries warmed)", i, len(window),
-            )
-            break
+    for record in window:
         tally = await _warm_one(record)
         for k in totals:
             totals[k] += tally[k]

--- a/scripts/cron_warm_price_cache.py
+++ b/scripts/cron_warm_price_cache.py
@@ -105,6 +105,54 @@ def _int_env(name: str, default: int) -> int:
         return default
 
 
+def _serper_per_query_estimate() -> int:
+    """Estimated Serper credits ONE warm query (2 products) drives. Cold BH
+    discovery burns ~10-30 credits/query post-B.0; 30 is a safe upper estimate
+    for the pre-run headroom check. Override via WARMER_SERPER_CREDITS_PER_QUERY.
+    <=0 disables the pre-run trim (keeps the count cap only)."""
+    return _int_env("WARMER_SERPER_CREDITS_PER_QUERY", 30)
+
+
+def _budget_bounded_window(window: List[Dict[str, Any]],
+                           *, per_query: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Trim `window` to what the REMAINING Serper budget can afford, so a run
+    can never drive the paid key into overage. Never GROWS the window (the
+    MAX_QUERIES_PER_RUN cap already bounded it). FAIL-OPEN: on any budget/Redis
+    error, or when the estimate is disabled (<=0), return the window unchanged —
+    the count cap is the Redis-down backstop, consistent with the codebase's
+    fail-open budget posture."""
+    per_query = _serper_per_query_estimate() if per_query is None else per_query
+    if per_query <= 0 or not window:
+        return window
+    try:
+        from app.services.api_budget_service import get_remaining
+        remaining = int(get_remaining("serper"))
+    except Exception as exc:  # noqa: BLE001 — budget check must never block the warmer
+        logger.info("[cron_warm] Serper headroom check unavailable (%s) — no trim", exc)
+        return window
+    affordable = remaining // per_query
+    if affordable >= len(window):
+        return window
+    logger.warning(
+        "[cron_warm] Serper headroom ~%d credits affords ~%d of %d queries "
+        "(@~%d/query) — trimming this run",
+        remaining, affordable, len(window), per_query,
+    )
+    return window[:max(0, affordable)]
+
+
+def _serper_exhausted() -> bool:
+    """Per-query circuit: True iff the Serper budget is exhausted right now, so
+    the warm loop can STOP early instead of burning into overage. FAIL-OPEN
+    (False) on any budget/Redis error — the count cap remains the hard bound."""
+    try:
+        from app.services.api_budget_service import has_budget
+        return not has_budget("serper")
+    except Exception as exc:  # noqa: BLE001
+        logger.info("[cron_warm] Serper budget check unavailable (%s) — not stopping", exc)
+        return False
+
+
 def load_warmer_catalog(path: Path = _WARMER_CATALOG_PATH) -> List[Dict[str, Any]]:
     """Load the structural warmer-only catalog (data/warmer_catalog.json) as a
     list of query records. Missing / malformed file -> [] (the warmer still runs
@@ -219,13 +267,30 @@ async def main() -> Optional[Dict[str, int]]:
     queries = _merge_catalog(queries, load_warmer_catalog())
 
     window = _rotation_window(queries, max_q)
+    # PRE-RUN Serper-budget guard — trim the window to what the paid key can
+    # afford so a run never drives it into overage (fail-open; the count cap is
+    # the Redis-down backstop).
+    window = _budget_bounded_window(window)
+    if not window:
+        logger.warning(
+            "[cron_warm] Serper headroom too low to warm any query — skipping run"
+        )
+        return None
     logger.info(
         "[cron_warm] warming %d/%d queries (subset=%s, PRICE_RACE_TIMEOUT=%s) off-clock",
         len(window), len(queries), subset or "full", os.environ["PRICE_RACE_TIMEOUT"],
     )
 
     totals = {"genuine": 0, "converted": 0, "estimated": 0, "none": 0}
-    for record in window:
+    for i, record in enumerate(window):
+        # PER-QUERY circuit — stop the moment Serper is exhausted rather than
+        # burning the remaining window into overage.
+        if _serper_exhausted():
+            logger.warning(
+                "[cron_warm] Serper budget exhausted mid-run — stopping early "
+                "(%d/%d queries warmed)", i, len(window),
+            )
+            break
         tally = await _warm_one(record)
         for k in totals:
             totals[k] += tally[k]

--- a/scripts/eval_gate.py
+++ b/scripts/eval_gate.py
@@ -19,6 +19,7 @@ The caller (eval_runner.main) maps pass->exit 0, fail->exit 1.
 """
 from __future__ import annotations
 
+import uuid
 from typing import Any, Optional, Tuple
 
 from scripts.eval_persistence import fetch_eval_run
@@ -26,6 +27,13 @@ from scripts.eval_persistence import fetch_eval_run
 # Per-axis regression tolerance: a drop strictly greater than this (absolute,
 # on the 0..1 axis-average scale) fails the regression gate. 2% per plan F4.4.
 REGRESSION_TOLERANCE = 0.02
+
+# The canonical full-uuid form the warmer/regression baseline anchor MUST use.
+# A TRUNCATED id (e.g. `54b603e8`) casts to `uuid` server-side with 22P02, which
+# fetch_eval_run swallows → a silent None → an ambiguous "not found". Validating
+# the format up front turns that into a clear malformed-id error that names the
+# correct full form.
+_FULL_BASELINE_EXAMPLE = "54b603e8-4eab-41c9-a34d-a5e391446559"
 
 _AXES = ("price", "specs", "winner", "factual")
 
@@ -66,6 +74,19 @@ def _axis_value(obj: "Any", axis: str) -> float:
 def _regression_gate(report: "Any", baseline_run_id: Optional[str]) -> Tuple[bool, str]:
     if not baseline_run_id:
         return False, "GATE FAIL [regression]: no --baseline-run-id provided"
+
+    # Validate the id is a FULL uuid BEFORE the DB round-trip. A truncated id
+    # (e.g. `54b603e8`) would 22P02 server-side and fetch_eval_run would swallow
+    # it into a silent None → the ambiguous "not found" below. Fail LOUD + CLEAR
+    # here so the operator knows the id is malformed, not the row missing.
+    try:
+        uuid.UUID(str(baseline_run_id))
+    except (ValueError, AttributeError, TypeError):
+        return False, (
+            f"GATE FAIL [regression]: baseline id {baseline_run_id!r} is not a "
+            f"valid UUID. A truncated/short id silently matches NOTHING (Postgres "
+            f"22P02) — pass the FULL uuid, e.g. {_FULL_BASELINE_EXAMPLE}"
+        )
 
     baseline = fetch_eval_run(baseline_run_id)
     if baseline is None:

--- a/scripts/eval_gate.py
+++ b/scripts/eval_gate.py
@@ -19,7 +19,7 @@ The caller (eval_runner.main) maps pass->exit 0, fail->exit 1.
 """
 from __future__ import annotations
 
-import uuid
+import re
 from typing import Any, Optional, Tuple
 
 from scripts.eval_persistence import fetch_eval_run
@@ -28,11 +28,16 @@ from scripts.eval_persistence import fetch_eval_run
 # on the 0..1 axis-average scale) fails the regression gate. 2% per plan F4.4.
 REGRESSION_TOLERANCE = 0.02
 
-# The canonical full-uuid form the warmer/regression baseline anchor MUST use.
-# A TRUNCATED id (e.g. `54b603e8`) casts to `uuid` server-side with 22P02, which
-# fetch_eval_run swallows → a silent None → an ambiguous "not found". Validating
-# the format up front turns that into a clear malformed-id error that names the
-# correct full form.
+# The canonical full-uuid form an eval_runs.id ALWAYS takes (Postgres uuid output).
+# We validate this exact shape rather than uuid.UUID(): uuid.UUID also accepts
+# `urn:uuid:...`, braced `{...}`, and 32-hex-no-hyphen forms, some of which
+# Postgres 22P02-rejects → fetch_eval_run swallows into a silent None → the
+# ambiguous "not found" the check is meant to prevent (adversarial sweep LOW).
+# The canonical regex accepts every real baseline id and rejects the truncated
+# footgun (`54b603e8`) + the odd forms up front.
+_CANONICAL_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
 _FULL_BASELINE_EXAMPLE = "54b603e8-4eab-41c9-a34d-a5e391446559"
 
 _AXES = ("price", "specs", "winner", "factual")
@@ -75,17 +80,17 @@ def _regression_gate(report: "Any", baseline_run_id: Optional[str]) -> Tuple[boo
     if not baseline_run_id:
         return False, "GATE FAIL [regression]: no --baseline-run-id provided"
 
-    # Validate the id is a FULL uuid BEFORE the DB round-trip. A truncated id
-    # (e.g. `54b603e8`) would 22P02 server-side and fetch_eval_run would swallow
-    # it into a silent None → the ambiguous "not found" below. Fail LOUD + CLEAR
-    # here so the operator knows the id is malformed, not the row missing.
-    try:
-        uuid.UUID(str(baseline_run_id))
-    except (ValueError, AttributeError, TypeError):
+    # Validate the id is a canonical FULL uuid BEFORE the DB round-trip. A
+    # truncated id (e.g. `54b603e8`) — or an odd urn:uuid/braced form — would
+    # 22P02 server-side and fetch_eval_run would swallow it into a silent None →
+    # the ambiguous "not found" below. Fail LOUD + CLEAR here instead.
+    if not (isinstance(baseline_run_id, str)
+            and _CANONICAL_UUID_RE.fullmatch(baseline_run_id.strip())):
         return False, (
             f"GATE FAIL [regression]: baseline id {baseline_run_id!r} is not a "
-            f"valid UUID. A truncated/short id silently matches NOTHING (Postgres "
-            f"22P02) — pass the FULL uuid, e.g. {_FULL_BASELINE_EXAMPLE}"
+            f"canonical UUID. A truncated/short or oddly-formatted id silently "
+            f"matches NOTHING (Postgres 22P02) — pass the FULL uuid, "
+            f"e.g. {_FULL_BASELINE_EXAMPLE}"
         )
 
     baseline = fetch_eval_run(baseline_run_id)

--- a/scripts/eval_runner.py
+++ b/scripts/eval_runner.py
@@ -1214,6 +1214,16 @@ _KPI_HTTP_TIMEOUT = 90.0
 USABLE_EXACT_GENUINE_GATE = 0.85
 
 
+def _safe_num(v: Any, default: float = 0.0) -> float:
+    """Coerce to float, defaulting on non-numeric — so a corrupted aggregation
+    dict yields a FAIL-CLOSED verdict (a malformed share/requested counts as 0)
+    rather than raising and crashing the warmer-activation decision."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
 def kpi_gate_verdict(
     per_category: Dict[str, Any], threshold: float = USABLE_EXACT_GENUINE_GATE,
 ) -> Dict[str, Any]:
@@ -1221,14 +1231,15 @@ def kpi_gate_verdict(
     dict. A category with 0 `requested` is NOT counted (nothing measured), and
     an EMPTY measured set does NOT pass (the warmer must never auto-activate on
     zero data). `pass` is True iff at least one category was measured and NONE
-    is below `threshold`."""
+    is below `threshold`. Fail-closed on malformed values (non-numeric
+    share/requested → 0), so a corrupt dict PAUSES rather than crashing."""
     measured = {
         c: v for c, v in per_category.items()
-        if isinstance(v, dict) and v.get("requested", 0) > 0
+        if isinstance(v, dict) and _safe_num(v.get("requested")) > 0
     }
     failing = {
-        c: round(float(v.get("share", 0.0)), 4)
-        for c, v in measured.items() if float(v.get("share", 0.0)) < threshold
+        c: round(_safe_num(v.get("share")), 4)
+        for c, v in measured.items() if _safe_num(v.get("share")) < threshold
     }
     return {
         "threshold": threshold,

--- a/scripts/eval_runner.py
+++ b/scripts/eval_runner.py
@@ -1209,6 +1209,34 @@ async def run_eval(
 # headroom over the ~25-30s compare wall.
 _KPI_HTTP_TIMEOUT = 90.0
 
+# The per-category warmer-activation gate: a category's usable_exact_genuine
+# share must be >= this (WARMED) to unlock ENABLE_PRICE_CACHE_WARMER for it.
+USABLE_EXACT_GENUINE_GATE = 0.85
+
+
+def kpi_gate_verdict(
+    per_category: Dict[str, Any], threshold: float = USABLE_EXACT_GENUINE_GATE,
+) -> Dict[str, Any]:
+    """Machine-readable warmer-activation verdict from the KPI's per-category
+    dict. A category with 0 `requested` is NOT counted (nothing measured), and
+    an EMPTY measured set does NOT pass (the warmer must never auto-activate on
+    zero data). `pass` is True iff at least one category was measured and NONE
+    is below `threshold`."""
+    measured = {
+        c: v for c, v in per_category.items()
+        if isinstance(v, dict) and v.get("requested", 0) > 0
+    }
+    failing = {
+        c: round(float(v.get("share", 0.0)), 4)
+        for c, v in measured.items() if float(v.get("share", 0.0)) < threshold
+    }
+    return {
+        "threshold": threshold,
+        "pass": bool(measured) and not failing,
+        "failing": failing,
+        "measured_categories": sorted(measured.keys()),
+    }
+
 
 async def run_usable_exact_genuine_kpi(
     *, base_url: str, read_cache: bool, concurrency: int = 1,
@@ -1272,6 +1300,7 @@ async def run_usable_exact_genuine_kpi(
         "overall": {"usable": total_u, "requested": total_r,
                     "share": (total_u / total_r if total_r else 0.0)},
         "per_category": per_category,
+        "gate": kpi_gate_verdict(per_category),
     }
 
 
@@ -1430,13 +1459,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 3
         print(json.dumps(kpi, indent=2))
-        gate = 0.85
-        failing = {c: v["share"] for c, v in kpi["per_category"].items()
-                   if v["share"] < gate}
+        gate = kpi["gate"]
         print(f"# usable_exact_genuine overall={kpi['overall']['share']:.3f} "
-              f"({kpi['cache_mode']}); per-category gate>={gate}")
-        if failing:
-            print(f"# BELOW GATE: {failing} — warmer activation stays PAUSED", file=sys.stderr)
+              f"({kpi['cache_mode']}); per-category gate>={gate['threshold']} "
+              f"pass={gate['pass']} measured={gate['measured_categories']}")
+        if not gate["pass"]:
+            reason = (f"BELOW GATE: {gate['failing']}" if gate["failing"]
+                      else "NO CATEGORY MEASURED (zero usable data)")
+            print(f"# {reason} — warmer activation stays PAUSED", file=sys.stderr)
             return 1
         return 0
 

--- a/scripts/warm_kpi_truth.py
+++ b/scripts/warm_kpi_truth.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Warm the usable_exact_genuine KPI truth set OFF-CLOCK into the shared cache.
+
+The KPI truth set is deliberately DISJOINT from the warmer's gold/catalog queries,
+so the production warmer cron never warms it. This one-off resolves each truth
+query off-clock (60s PRICE_RACE_TIMEOUT so the slow genuine curl/scrape finishes)
+via the SAME path /price-kpi reads — parse_product_query -> _get_price(nocache=True)
+-> the write fires inside via should_cache_price — so a subsequent warmed KPI
+(`eval_runner --kpi usable_exact_genuine --read-cache`) serves genuine from cache.
+
+Usage: python -m scripts.warm_kpi_truth <out.jsonl> [limit]
+
+GOTCHA: nocache=True bypasses the cache READ, not the WRITE -> this WRITES to the
+shared prod Upstash + product_prices. Only run with intent (the exact-SKU gate
+ensures only correct SKUs cache).
+"""
+from __future__ import annotations
+
+import os
+
+os.environ["PRICE_RACE_TIMEOUT"] = os.getenv("WARMER_PRICE_RACE_TIMEOUT", "60")
+os.environ["STREAM_HARD_CAP_SECONDS"] = os.getenv("WARMER_STREAM_HARD_CAP", "150")
+os.environ["FAN_OUT_BUDGET_SECONDS"] = os.getenv("WARMER_FAN_OUT_BUDGET", "35")
+os.environ.setdefault("FIRECRAWL_TIMEOUT", "45")
+os.environ.setdefault("SCRAPEDO_TIMEOUT", "35")
+
+from pathlib import Path
+try:
+    from dotenv import load_dotenv
+    load_dotenv(dotenv_path=str(Path(__file__).resolve().parent.parent / ".env"), override=False)
+except Exception:
+    pass
+
+import asyncio
+import io
+import json
+import sys
+
+
+async def _warm_one(svc, t):
+    from app.services.extraction_service import parse_product_query
+    from app.services.price_service import _infer_category_from_query
+    q = t["query"]
+    region = t.get("region", "bahrain")
+    try:
+        parsed, _ = await parse_product_query(q)
+    except Exception as exc:  # noqa: BLE001
+        parsed = {}
+    p0 = ((parsed or {}).get("products") or [{}])[0]
+    brand = (p0.get("brand") or "").strip()
+    name = (p0.get("name") or q).strip()
+    variant = p0.get("variant")
+    category = (p0.get("category") or _infer_category_from_query(q) or "other")
+    sq = (f"{brand} {name} {variant or ''}".strip()) or q
+    try:
+        price = await svc._get_price(brand, name, variant, region, sq, True, category)
+    except Exception as exc:  # noqa: BLE001
+        return {"query": q, "category": t.get("category"), "error": str(exc)[:120]}
+    p = price if isinstance(price, dict) else {}
+    return {
+        "query": q, "category": t.get("category"),
+        "source_method": p.get("source_method"), "amount": p.get("amount"),
+        "in_stock": p.get("in_stock"), "url": p.get("url"),
+        "title": p.get("title"),
+    }
+
+
+async def main():
+    from scripts.eval_runner import load_usable_exact_genuine_truth
+    from app.services.structured_comparison_service import get_comparison_service
+    out_path = sys.argv[1] if len(sys.argv) > 1 else ".warm_kpi_out.jsonl"
+    limit = int(sys.argv[2]) if len(sys.argv) > 2 else None
+    truth = load_usable_exact_genuine_truth()
+    if limit:
+        truth = truth[:limit]
+    rows = []
+    for t in truth:
+        svc = get_comparison_service()  # per-request instance (concurrency contract)
+        rows.append(await _warm_one(svc, t))
+    with io.open(out_path, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    genuine = sum(1 for r in rows if r.get("source_method") and "convert" not in (r.get("source_method") or "")
+                  and "estimat" not in (r.get("source_method") or "") and r.get("amount"))
+    print(f"warmed {len(rows)} rows -> {out_path}; genuine-ish={genuine}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_eval_gate.py
+++ b/tests/test_eval_gate.py
@@ -25,6 +25,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 GOLD_PATH = REPO_ROOT / "data" / "validation_gold_truth.json"
 SMOKE_PATH = REPO_ROOT / "data" / "eval_smoke_subset.json"
 
+# A real eval_runs baseline id is a full uuid; the regression gate now validates
+# that format before the DB round-trip (a truncated id would 22P02 + get swallowed
+# into a phantom "not found"). Use uuid-shaped ids in these tests accordingly.
+_BASE_UUID = "0e1d2c3b-4a59-4687-8765-0f1e2d3c4b5a"
+_MISSING_UUID = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+
 
 def _report(*, pass_rate=0.95, price=0.9, specs=0.9, winner=0.95, factual=1.0) -> EvalReport:
     return EvalReport(
@@ -69,7 +75,7 @@ def _baseline(price=0.90, specs=0.90, winner=0.95, factual=1.0, pass_rate=0.95):
 def test_regression_pass_when_axes_flat():
     current = _report(price=0.90, specs=0.90, winner=0.95, factual=1.0)
     with patch("scripts.eval_gate.fetch_eval_run", return_value=_baseline()):
-        ok, msg = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id="base-1")
+        ok, msg = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id=_BASE_UUID)
     assert ok is True
     assert "PASS" in msg
 
@@ -77,7 +83,7 @@ def test_regression_pass_when_axes_flat():
 def test_regression_pass_when_axes_improve():
     current = _report(price=0.95, specs=0.93, winner=0.98, factual=1.0)
     with patch("scripts.eval_gate.fetch_eval_run", return_value=_baseline()):
-        ok, _ = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id="base-1")
+        ok, _ = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id=_BASE_UUID)
     assert ok is True
 
 
@@ -85,7 +91,7 @@ def test_regression_pass_within_2pct_drop():
     # winner drops 0.95 -> 0.934 = 1.6% absolute drop → within the 2% tolerance.
     current = _report(price=0.90, specs=0.90, winner=0.934, factual=1.0)
     with patch("scripts.eval_gate.fetch_eval_run", return_value=_baseline()):
-        ok, _ = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id="base-1")
+        ok, _ = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id=_BASE_UUID)
     assert ok is True
 
 
@@ -93,7 +99,7 @@ def test_regression_fail_when_any_axis_drops_more_than_2pct():
     # price drops 0.90 -> 0.87 = 3% absolute drop → fails.
     current = _report(price=0.87, specs=0.90, winner=0.95, factual=1.0)
     with patch("scripts.eval_gate.fetch_eval_run", return_value=_baseline()):
-        ok, msg = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id="base-1")
+        ok, msg = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id=_BASE_UUID)
     assert ok is False
     assert "FAIL" in msg
     assert "price" in msg
@@ -102,7 +108,7 @@ def test_regression_fail_when_any_axis_drops_more_than_2pct():
 def test_regression_fail_lists_every_dropping_axis():
     current = _report(price=0.85, specs=0.80, winner=0.95, factual=1.0)
     with patch("scripts.eval_gate.fetch_eval_run", return_value=_baseline()):
-        ok, msg = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id="base-1")
+        ok, msg = eval_gate.evaluate_gate(current, mode="regression", baseline_run_id=_BASE_UUID)
     assert ok is False
     assert "price" in msg and "specs" in msg
 
@@ -115,7 +121,7 @@ def test_regression_requires_baseline_run_id():
 
 def test_regression_fail_when_baseline_row_missing():
     with patch("scripts.eval_gate.fetch_eval_run", return_value=None):
-        ok, msg = eval_gate.evaluate_gate(_report(), mode="regression", baseline_run_id="ghost")
+        ok, msg = eval_gate.evaluate_gate(_report(), mode="regression", baseline_run_id=_MISSING_UUID)
     assert ok is False
     assert "not found" in msg.lower() or "missing" in msg.lower()
 

--- a/tests/test_eval_kpi_baseline.py
+++ b/tests/test_eval_kpi_baseline.py
@@ -1,0 +1,76 @@
+"""Wave-1 Task A — the regression-gate baseline id must be a FULL uuid.
+
+A truncated id (e.g. the CLAUDE.md-cited `54b603e8`) triggers Postgres
+`22P02 invalid input syntax for type uuid`, which `fetch_eval_run` swallows in
+its try/except and turns into a silent `None` → the gate reports "baseline not
+found", indistinguishable from a genuinely-missing row. This pins a CLEAR,
+distinct error for a malformed/truncated id BEFORE the DB round-trip, so a
+next-session operator who fat-fingers the truncated anchor gets told exactly
+what is wrong (and the full-uuid form to use).
+"""
+from __future__ import annotations
+
+import types
+from unittest import mock
+
+from scripts import eval_gate
+
+
+_FULL_UUID = "54b603e8-4eab-41c9-a34d-a5e391446559"
+_TRUNCATED = "54b603e8"
+
+
+def _report(**axes):
+    """Minimal EvalReport stand-in: axis_avg_<axis> attrs + pass_rate."""
+    base = {"axis_avg_price": 0.5, "axis_avg_specs": 0.5,
+            "axis_avg_winner": 0.5, "axis_avg_factual": 0.5, "pass_rate": 0.9}
+    base.update(axes)
+    return types.SimpleNamespace(**base)
+
+
+def test_truncated_baseline_id_gives_clear_malformed_error_not_not_found():
+    # A truncated (non-full-uuid) id must be rejected with a CLEAR malformed-id
+    # message that names the full-uuid form — NOT the ambiguous "not found".
+    passed, msg = eval_gate.evaluate_gate(
+        _report(), mode="regression", baseline_run_id=_TRUNCATED,
+    )
+    assert passed is False
+    low = msg.lower()
+    assert "uuid" in low
+    # It must be distinguishable from the genuinely-missing-row message.
+    assert "not found" not in low
+    # And it should point at the correct full-uuid form.
+    assert _FULL_UUID in msg
+
+
+def test_truncated_baseline_id_never_hits_the_db():
+    # The format check short-circuits BEFORE fetch_eval_run, so a malformed id
+    # never even issues the 22P02-triggering query.
+    with mock.patch.object(eval_gate, "fetch_eval_run") as m:
+        eval_gate.evaluate_gate(
+            _report(), mode="regression", baseline_run_id=_TRUNCATED,
+        )
+        m.assert_not_called()
+
+
+def test_full_uuid_proceeds_to_fetch_then_reports_not_found():
+    # A well-formed full uuid PASSES the format check and reaches fetch_eval_run;
+    # a None there is the genuine "not found" path (distinct from malformed).
+    with mock.patch.object(eval_gate, "fetch_eval_run", return_value=None) as m:
+        passed, msg = eval_gate.evaluate_gate(
+            _report(), mode="regression", baseline_run_id=_FULL_UUID,
+        )
+        m.assert_called_once_with(_FULL_UUID)
+    assert passed is False
+    assert "not found" in msg.lower()
+
+
+def test_full_uuid_with_found_baseline_passes_when_no_axis_drop():
+    baseline = {"axis_avg_price": 0.5, "axis_avg_specs": 0.5,
+                "axis_avg_winner": 0.5, "axis_avg_factual": 0.5}
+    with mock.patch.object(eval_gate, "fetch_eval_run", return_value=baseline):
+        passed, msg = eval_gate.evaluate_gate(
+            _report(), mode="regression", baseline_run_id=_FULL_UUID,
+        )
+    assert passed is True
+    assert "PASS" in msg

--- a/tests/test_eval_kpi_baseline.py
+++ b/tests/test_eval_kpi_baseline.py
@@ -43,6 +43,19 @@ def test_truncated_baseline_id_gives_clear_malformed_error_not_not_found():
     assert _FULL_UUID in msg
 
 
+def test_noncanonical_uuid_forms_rejected_clearly_not_as_not_found():
+    # urn:uuid / braced forms pass uuid.UUID() but 22P02 at Postgres -> would be
+    # swallowed into a phantom "not found"; the canonical-form check rejects them
+    # up front with the clear malformed-id message (adversarial sweep LOW).
+    for bad in (f"urn:uuid:{_FULL_UUID}", "{" + _FULL_UUID + "}"):
+        passed, msg = eval_gate.evaluate_gate(
+            _report(), mode="regression", baseline_run_id=bad,
+        )
+        assert passed is False, bad
+        assert "not found" not in msg.lower(), bad
+        assert "uuid" in msg.lower(), bad
+
+
 def test_truncated_baseline_id_never_hits_the_db():
     # The format check short-circuits BEFORE fetch_eval_run, so a malformed id
     # never even issues the 22P02-triggering query.

--- a/tests/test_eval_kpi_gate_verdict.py
+++ b/tests/test_eval_kpi_gate_verdict.py
@@ -53,3 +53,21 @@ def test_threshold_is_inclusive():
 
 def test_default_threshold_is_085():
     assert USABLE_EXACT_GENUINE_GATE == 0.85
+
+
+def test_malformed_values_fail_closed_never_raise():
+    # A corrupted aggregation dict must PAUSE (pass=False), never raise.
+    for pc in (
+        {"e": {"requested": 5, "share": "oops"}},
+        {"e": {"requested": 5, "share": None}},
+        {"e": {"requested": "x", "share": 1.0}},
+    ):
+        v = kpi_gate_verdict(pc)
+        assert v["pass"] is False, pc
+
+
+def test_malformed_share_counts_as_failing_when_requested_valid():
+    v = kpi_gate_verdict({"e": {"requested": 5, "share": "bad"}})
+    # requested is valid (measured) but share coerces to 0 -> below gate -> failing.
+    assert v["measured_categories"] == ["e"]
+    assert "e" in v["failing"]

--- a/tests/test_eval_kpi_gate_verdict.py
+++ b/tests/test_eval_kpi_gate_verdict.py
@@ -1,0 +1,55 @@
+"""Wave-1 — the machine-readable warmer-activation gate verdict.
+
+`kpi_gate_verdict` turns the KPI's per-category dict into a structured
+`{threshold, pass, failing, measured_categories}` so a runbook / CI can decide
+warmer activation without re-deriving the >=0.85 rule. Critically it FAILS on
+zero data (the old inline `failing` dict was empty for an empty per_category
+and thus PASSED on nothing measured).
+"""
+from __future__ import annotations
+
+from scripts.eval_runner import kpi_gate_verdict, USABLE_EXACT_GENUINE_GATE
+
+
+def _cat(share, requested=6):
+    return {"usable": round(share * requested), "requested": requested, "share": share}
+
+
+def test_all_categories_above_gate_pass():
+    pc = {"electronics": _cat(0.9), "fragrances": _cat(0.86), "fashion": _cat(1.0)}
+    v = kpi_gate_verdict(pc)
+    assert v["pass"] is True
+    assert v["failing"] == {}
+    assert v["measured_categories"] == ["electronics", "fashion", "fragrances"]
+
+
+def test_one_category_below_gate_fails_and_names_it():
+    pc = {"electronics": _cat(0.9), "fragrances": _cat(0.5)}
+    v = kpi_gate_verdict(pc)
+    assert v["pass"] is False
+    assert "fragrances" in v["failing"]
+    assert "electronics" not in v["failing"]
+
+
+def test_empty_per_category_does_not_pass():
+    # Zero measured data must NEVER auto-unlock the warmer.
+    v = kpi_gate_verdict({})
+    assert v["pass"] is False
+    assert v["measured_categories"] == []
+
+
+def test_zero_requested_category_is_not_measured():
+    pc = {"electronics": _cat(0.9), "grocery": {"usable": 0, "requested": 0, "share": 0.0}}
+    v = kpi_gate_verdict(pc)
+    assert v["measured_categories"] == ["electronics"]
+    assert v["pass"] is True  # grocery had nothing measured -> ignored, not a fail
+
+
+def test_threshold_is_inclusive():
+    pc = {"electronics": _cat(USABLE_EXACT_GENUINE_GATE)}
+    v = kpi_gate_verdict(pc)
+    assert v["pass"] is True
+
+
+def test_default_threshold_is_085():
+    assert USABLE_EXACT_GENUINE_GATE == 0.85

--- a/tests/test_price_cache_key_parity.py
+++ b/tests/test_price_cache_key_parity.py
@@ -1,0 +1,95 @@
+"""Wave-1 — cache-key parity between the warmer WRITE and the live READ.
+
+Recon (docs/investigations/2026-06-30-warmer-recon.md) established that the
+warmer and a live compare use the SAME `_get_price` ->
+`build_size_aware_price_cache_key(brand, name, variant, region, search_query)`
+derivation, and that `_identity_cache_token` ALREADY alias-normalizes the
+identity axes. These pin exactly what collapses to one key vs what stays
+distinct — so a future change to the keying is a CONSCIOUS decision, and the
+"warmed key != live key" fear is bounded to the ONE residual it actually is
+(a size/qualifier axis PRESENT in the verbose warmed title but ABSENT from a
+terse live query).
+
+Prod default is `ENABLE_EXACT_PRICE_GATE` ON (the composite-token path).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.services.price_service import build_size_aware_price_cache_key as K
+
+
+@pytest.fixture(autouse=True)
+def _gate_on(monkeypatch):
+    # Pin the prod-default composite-identity-token path for every test here.
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "true")
+    yield
+
+
+# --- ALIAS PARITY: different wording of the SAME sku -> ONE key --------------
+
+def test_edt_spelled_and_abbreviated_same_size_collapse():
+    verbose = K("Dior", "Sauvage Eau de Toilette", None, "bahrain",
+                "Dior Sauvage Eau de Toilette 100ml")
+    abbrev = K("Dior", "Sauvage EDT", None, "bahrain", "Dior Sauvage EDT 100ml")
+    assert verbose == abbrev, "EDT == 'eau de toilette' (same size) must be one key"
+
+
+def test_oz_and_ml_same_bottle_collapse():
+    ml = K("Dior", "Sauvage EDT", None, "bahrain", "Dior Sauvage EDT 100ml")
+    oz = K("Dior", "Sauvage EDT", None, "bahrain", "Dior Sauvage EDT 3.4 oz")
+    assert ml == oz, "3.4 oz snaps to 100ml -> one key"
+
+
+def test_storage_brand_omitted_in_identity_still_one_key_when_brand_arg_set():
+    # The parser normally fills brand='Samsung' for both the verbose and terse
+    # query, so a brandless search_query still keys the same.
+    with_brand_word = K("Samsung", "Galaxy S24 256GB", None, "bahrain",
+                        "Samsung Galaxy S24 256GB")
+    brandless_query = K("Samsung", "Galaxy S24 256GB", None, "bahrain",
+                        "Galaxy S24 256GB")
+    assert with_brand_word == brandless_query
+
+
+# --- DISCRIMINATION: distinct VARIANTS must NOT collide ----------------------
+
+def test_distinct_concentration_differs():
+    edt = K("Dior", "Sauvage EDT", None, "bahrain", "Dior Sauvage EDT 100ml")
+    edp = K("Dior", "Sauvage EDP", None, "bahrain", "Dior Sauvage EDP 100ml")
+    assert edt != edp
+
+
+def test_distinct_storage_differs():
+    s256 = K("Samsung", "Galaxy S24 256GB", None, "bahrain", "Samsung Galaxy S24 256GB")
+    s128 = K("Samsung", "Galaxy S24 128GB", None, "bahrain", "Samsung Galaxy S24 128GB")
+    assert s256 != s128
+
+
+# --- DOCUMENTED RESIDUAL: size present vs absent diverges --------------------
+
+def test_size_presence_vs_absence_diverges_documented_on_device_residual():
+    """The warmed verbose title carries a size the terse live query omits ->
+    token `edt.100ml` vs `edt` -> DIFFERENT keys. This is the on-device parity
+    residual (recon note s.2): the warmer catalog must phrase queries the way
+    live users do, OR the key must derive from the RESOLVED-match identity (a
+    larger change deferred out of Wave 1). Pinned so a future change is
+    deliberate, not accidental."""
+    with_size = K("Dior", "Sauvage EDT", None, "bahrain", "Dior Sauvage EDT 100ml")
+    without_size = K("Dior", "Sauvage EDT", None, "bahrain", "Dior Sauvage EDT")
+    assert with_size != without_size
+
+
+# --- FLAG-OFF ROLLBACK: axis-less product keys identically both ways ---------
+
+def test_flag_off_axisless_product_keys_identically_to_flag_on(monkeypatch):
+    # A plain product with NO size/concentration/qualifier axis falls back to the
+    # legacy get_price_cache_key on BOTH the flag-ON and flag-OFF paths, so the
+    # cache namespace for sizeless products is byte-identical (no warm-cache
+    # invalidation on a rollback). This is the load-bearing rollback invariant.
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "true")
+    on = K("Dior", "Sauvage", None, "bahrain", "Dior Sauvage")
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "false")
+    off = K("Dior", "Sauvage", None, "bahrain", "Dior Sauvage")
+    assert on == off

--- a/tests/test_price_title_persistence.py
+++ b/tests/test_price_title_persistence.py
@@ -110,3 +110,37 @@ def test_get_cached_price_rehydrates_title_when_flag_on(monkeypatch):
     assert out is not None
     assert out["title"] == "Dior Sauvage EDT 100ml"
     assert "title" in sink["select_cols"]
+
+
+def test_get_cached_price_flag_on_none_title_omits_title_key(monkeypatch):
+    # A legacy/flag-OFF row rehydrated under the flag has title=None — the falsy
+    # guard `_title_persist_enabled() and row.get("title")` must NOT inject a None
+    # title (locks the truthiness check against a `'title' in row` refactor).
+    monkeypatch.setenv("ENABLE_PRICE_TITLE_PERSIST", "true")
+    row = dict(_ROW); row["title"] = None
+    _install_client(monkeypatch, {}, row=row)
+    out = _run(pds.get_cached_price("k", "bahrain"))
+    assert out is not None
+    assert "title" not in out
+
+
+def test_get_cached_price_flag_on_missing_title_key_omits(monkeypatch):
+    monkeypatch.setenv("ENABLE_PRICE_TITLE_PERSIST", "true")
+    row = {k: v for k, v in _ROW.items() if k != "title"}
+    _install_client(monkeypatch, {}, row=row)
+    out = _run(pds.get_cached_price("k", "bahrain"))
+    assert out is not None
+    assert "title" not in out
+
+
+def test_save_price_flag_on_preserves_all_columns(monkeypatch):
+    # A column-drop regression (keeping title but losing brand/amount) must fail.
+    monkeypatch.setenv("ENABLE_PRICE_TITLE_PERSIST", "true")
+    sink = {}
+    _install_client(monkeypatch, sink)
+    _run(pds.save_price("k", "Dior", "Sauvage", None, "bahrain",
+                        {"amount": 45.0, "currency": "BHD", "source_method": "woo_store_api",
+                         "title": "Dior Sauvage EDT 100ml"}))
+    ins = sink["insert"]
+    for col in ("product_key", "brand", "name", "region", "amount", "source_method", "title"):
+        assert col in ins, col

--- a/tests/test_price_title_persistence.py
+++ b/tests/test_price_title_persistence.py
@@ -1,0 +1,112 @@
+"""Wave-1 — persist + rehydrate the resolved listing title on the L2 cache.
+
+The DB (product_prices) never stored `title`, so a rehydrated L2 price was
+title-less → not usable_exact_genuine, not re-cacheable. This pins the
+flag-gated fix: when ENABLE_PRICE_TITLE_PERSIST is ON, save_price writes `title`
+and get_cached_price selects + returns it. Flag OFF = byte-identical (no `title`
+in the insert, no `title` in the returned dict) so it is safe before migration
+033 lands.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services import product_data_service as pds
+
+
+class _FakeQuery:
+    def __init__(self, sink, row=None):
+        self._sink = sink
+        self._row = row
+
+    def insert(self, payload):
+        self._sink["insert"] = payload
+        return self
+
+    def select(self, cols):
+        self._sink["select_cols"] = cols
+        return self
+
+    def eq(self, *a, **k):
+        return self
+
+    def order(self, *a, **k):
+        return self
+
+    def limit(self, *a, **k):
+        return self
+
+    def execute(self):
+        class _R:
+            data = [self._row] if self._row is not None else []
+        return _R()
+
+
+class _FakeClient:
+    def __init__(self, sink, row=None):
+        self._sink = sink
+        self._row = row
+
+    def table(self, name):
+        self._sink["table"] = name
+        return _FakeQuery(self._sink, self._row)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _install_client(monkeypatch, sink, row=None):
+    monkeypatch.setattr(pds, "get_admin_supabase_client",
+                        lambda: _FakeClient(sink, row))
+
+
+# --- SAVE side --------------------------------------------------------------
+
+def test_save_price_omits_title_when_flag_off(monkeypatch):
+    monkeypatch.delenv("ENABLE_PRICE_TITLE_PERSIST", raising=False)
+    sink = {}
+    _install_client(monkeypatch, sink)
+    _run(pds.save_price("k", "Dior", "Sauvage", None, "bahrain",
+                        {"amount": 45.0, "currency": "BHD", "title": "Dior Sauvage EDT 100ml"}))
+    assert "title" not in sink["insert"]
+
+
+def test_save_price_writes_title_when_flag_on(monkeypatch):
+    monkeypatch.setenv("ENABLE_PRICE_TITLE_PERSIST", "true")
+    sink = {}
+    _install_client(monkeypatch, sink)
+    _run(pds.save_price("k", "Dior", "Sauvage", None, "bahrain",
+                        {"amount": 45.0, "currency": "BHD", "title": "Dior Sauvage EDT 100ml"}))
+    assert sink["insert"]["title"] == "Dior Sauvage EDT 100ml"
+
+
+# --- READ side --------------------------------------------------------------
+
+_ROW = {
+    "amount": 45.0, "currency": "BHD", "retailer": "theperfumesclub",
+    "url": "https://x/p", "source_method": "woo_store_api", "estimated": False,
+    "fetched_at": "2999-01-01T00:00:00+00:00", "title": "Dior Sauvage EDT 100ml",
+}
+
+
+def test_get_cached_price_excludes_title_when_flag_off(monkeypatch):
+    monkeypatch.delenv("ENABLE_PRICE_TITLE_PERSIST", raising=False)
+    sink = {}
+    _install_client(monkeypatch, sink, row=dict(_ROW))
+    out = _run(pds.get_cached_price("k", "bahrain"))
+    assert out is not None
+    assert "title" not in out
+    assert "title" not in sink["select_cols"]
+
+
+def test_get_cached_price_rehydrates_title_when_flag_on(monkeypatch):
+    monkeypatch.setenv("ENABLE_PRICE_TITLE_PERSIST", "true")
+    sink = {}
+    _install_client(monkeypatch, sink, row=dict(_ROW))
+    out = _run(pds.get_cached_price("k", "bahrain"))
+    assert out is not None
+    assert out["title"] == "Dior Sauvage EDT 100ml"
+    assert "title" in sink["select_cols"]

--- a/tests/test_warmer_preconditions.py
+++ b/tests/test_warmer_preconditions.py
@@ -1,0 +1,66 @@
+"""Wave-1 — price-cache warmer preconditions: a Serper-budget guard.
+
+The warmer burns PAID Serper continuously (each query warms 2 products at
+~10-30 credits). Today the only spend control is the MAX_QUERIES_PER_RUN count
+cap; there is no headroom check, so a run can drive the key straight into
+overage. These pin a two-layer guard:
+  - a PRE-RUN window trim: shrink the run to what the remaining Serper budget
+    can afford (never grows it);
+  - a PER-QUERY circuit: stop the loop the moment Serper is exhausted.
+Both fail-OPEN (a Redis/budget outage must not block the warmer) — the hard
+MAX_QUERIES_PER_RUN cap remains the Redis-down backstop.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+from scripts import cron_warm_price_cache as warmer
+
+
+def _win(n):
+    return [{"query": f"q{i}", "region": "bahrain"} for i in range(n)]
+
+
+def test_budget_bounded_window_trims_to_affordable():
+    # remaining=60 credits, ~30/query -> affords ~2 of 5.
+    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
+         mock.patch("app.services.api_budget_service.get_remaining", return_value=60):
+        out = warmer._budget_bounded_window(_win(5))
+    assert len(out) == 2
+
+
+def test_budget_bounded_window_keeps_full_when_ample():
+    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
+         mock.patch("app.services.api_budget_service.get_remaining", return_value=10_000):
+        out = warmer._budget_bounded_window(_win(5))
+    assert len(out) == 5
+
+
+def test_budget_bounded_window_fail_open_on_error():
+    # get_remaining raising (Redis down) must NOT trim (fail-open) — the count
+    # cap MAX_QUERIES_PER_RUN is the backstop.
+    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
+         mock.patch("app.services.api_budget_service.get_remaining",
+                    side_effect=RuntimeError("redis down")):
+        out = warmer._budget_bounded_window(_win(5))
+    assert len(out) == 5
+
+
+def test_budget_bounded_window_zero_when_no_headroom():
+    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
+         mock.patch("app.services.api_budget_service.get_remaining", return_value=10):
+        out = warmer._budget_bounded_window(_win(5))
+    assert out == []
+
+
+def test_serper_exhausted_reflects_has_budget():
+    with mock.patch("app.services.api_budget_service.has_budget", return_value=False):
+        assert warmer._serper_exhausted() is True
+    with mock.patch("app.services.api_budget_service.has_budget", return_value=True):
+        assert warmer._serper_exhausted() is False
+
+
+def test_serper_exhausted_fail_open_false_on_error():
+    with mock.patch("app.services.api_budget_service.has_budget",
+                    side_effect=RuntimeError("redis down")):
+        assert warmer._serper_exhausted() is False

--- a/tests/test_warmer_preconditions.py
+++ b/tests/test_warmer_preconditions.py
@@ -1,14 +1,13 @@
-"""Wave-1 — price-cache warmer preconditions: a Serper-budget guard.
+"""Wave-1 — price-cache warmer preconditions: a per-run Serper-credit cap.
 
 The warmer burns PAID Serper continuously (each query warms 2 products at
-~10-30 credits). Today the only spend control is the MAX_QUERIES_PER_RUN count
-cap; there is no headroom check, so a run can drive the key straight into
-overage. These pin a two-layer guard:
-  - a PRE-RUN window trim: shrink the run to what the remaining Serper budget
-    can afford (never grows it);
-  - a PER-QUERY circuit: stop the loop the moment Serper is exhausted.
-Both fail-OPEN (a Redis/budget outage must not block the warmer) — the hard
-MAX_QUERIES_PER_RUN cap remains the Redis-down backstop.
+~10-30 credits). It is bounded by the MAX_QUERIES_PER_RUN count cap plus a
+per-RUN credit ceiling (_budget_bounded_window) that is TIER-INDEPENDENT: it
+does NOT consult api_budget_service's lifetime counter, which is capped at the
+free-tier config ceiling (serper monthly_limit=2200) and would WRONGLY disable
+the warmer on a healthy paid key once lifetime burn passes 2200 (adversarial
+sweep MED). The fixed cap + count cap are the whole bound; a truly-depleted real
+account just rejects calls (handled gracefully by _warm_one).
 """
 from __future__ import annotations
 
@@ -21,46 +20,45 @@ def _win(n):
     return [{"query": f"q{i}", "region": "bahrain"} for i in range(n)]
 
 
-def test_budget_bounded_window_trims_to_affordable():
-    # remaining=60 credits, ~30/query -> affords ~2 of 5.
-    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
-         mock.patch("app.services.api_budget_service.get_remaining", return_value=60):
-        out = warmer._budget_bounded_window(_win(5))
+def test_budget_bounded_window_trims_to_per_run_credit_cap():
+    # cap=60 credits, ~30/query -> affords 2 of 5.
+    out = warmer._budget_bounded_window(_win(5), per_query=30, max_credits=60)
     assert len(out) == 2
 
 
-def test_budget_bounded_window_keeps_full_when_ample():
-    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
-         mock.patch("app.services.api_budget_service.get_remaining", return_value=10_000):
-        out = warmer._budget_bounded_window(_win(5))
+def test_budget_bounded_window_keeps_full_when_cap_ample():
+    out = warmer._budget_bounded_window(_win(5), per_query=30, max_credits=10_000)
     assert len(out) == 5
 
 
-def test_budget_bounded_window_fail_open_on_error():
-    # get_remaining raising (Redis down) must NOT trim (fail-open) — the count
-    # cap MAX_QUERIES_PER_RUN is the backstop.
-    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
-         mock.patch("app.services.api_budget_service.get_remaining",
-                    side_effect=RuntimeError("redis down")):
-        out = warmer._budget_bounded_window(_win(5))
+def test_budget_bounded_window_disabled_when_cap_zero():
+    # max_credits<=0 disables the credit trim (count cap MAX_QUERIES_PER_RUN remains).
+    out = warmer._budget_bounded_window(_win(5), per_query=30, max_credits=0)
     assert len(out) == 5
 
 
-def test_budget_bounded_window_zero_when_no_headroom():
-    with mock.patch.object(warmer, "_serper_per_query_estimate", return_value=30), \
-         mock.patch("app.services.api_budget_service.get_remaining", return_value=10):
-        out = warmer._budget_bounded_window(_win(5))
+def test_budget_bounded_window_disabled_when_per_query_zero():
+    out = warmer._budget_bounded_window(_win(5), per_query=0, max_credits=900)
+    assert len(out) == 5
+
+
+def test_budget_bounded_window_zero_when_cap_below_one_query():
+    out = warmer._budget_bounded_window(_win(5), per_query=30, max_credits=10)
     assert out == []
 
 
-def test_serper_exhausted_reflects_has_budget():
-    with mock.patch("app.services.api_budget_service.has_budget", return_value=False):
-        assert warmer._serper_exhausted() is True
-    with mock.patch("app.services.api_budget_service.has_budget", return_value=True):
-        assert warmer._serper_exhausted() is False
+def test_budget_bounded_window_is_tier_independent_no_budget_calls():
+    # It must NOT consult get_remaining/has_budget — those reflect the free-tier
+    # ceiling and would falsely disable the warmer on a healthy paid key.
+    with mock.patch("app.services.api_budget_service.get_remaining") as gr, \
+         mock.patch("app.services.api_budget_service.has_budget") as hb:
+        warmer._budget_bounded_window(_win(5), per_query=30, max_credits=900)
+        gr.assert_not_called()
+        hb.assert_not_called()
 
 
-def test_serper_exhausted_fail_open_false_on_error():
-    with mock.patch("app.services.api_budget_service.has_budget",
-                    side_effect=RuntimeError("redis down")):
-        assert warmer._serper_exhausted() is False
+def test_defaults_are_sane():
+    assert warmer._serper_per_query_estimate() == 30
+    assert warmer._serper_max_credits_per_run() == 900
+    # Default cap affords the default MAX_QUERIES_PER_RUN(25) window (900/30=30 >= 25).
+    assert warmer._serper_max_credits_per_run() // warmer._serper_per_query_estimate() >= 25

--- a/tests/test_warmer_preconditions.py
+++ b/tests/test_warmer_preconditions.py
@@ -57,8 +57,32 @@ def test_budget_bounded_window_is_tier_independent_no_budget_calls():
         hb.assert_not_called()
 
 
-def test_defaults_are_sane():
+def test_defaults_are_sane(monkeypatch):
+    # Isolate from any ambient WARMER_* env so the defaults are what we assert.
+    monkeypatch.delenv("WARMER_SERPER_CREDITS_PER_QUERY", raising=False)
+    monkeypatch.delenv("WARMER_MAX_SERPER_CREDITS_PER_RUN", raising=False)
     assert warmer._serper_per_query_estimate() == 30
     assert warmer._serper_max_credits_per_run() == 900
     # Default cap affords the default MAX_QUERIES_PER_RUN(25) window (900/30=30 >= 25).
     assert warmer._serper_max_credits_per_run() // warmer._serper_per_query_estimate() >= 25
+
+
+def test_main_skips_run_when_budget_trims_window_to_empty(monkeypatch):
+    # The budget-guard early-return in main(): a trimmed-to-empty window skips the
+    # run (returns None) WITHOUT warming a single query.
+    import asyncio
+    monkeypatch.setattr(warmer, "_flag_on", lambda: True)
+    monkeypatch.setattr(warmer, "load_gold_truth", lambda *a, **k: {"queries": []})
+    monkeypatch.setattr(warmer, "select_queries", lambda *a, **k: _win(5))
+    monkeypatch.setattr(warmer, "load_warmer_catalog", lambda *a, **k: [])
+    monkeypatch.setattr(warmer, "_budget_bounded_window", lambda w, **k: [])
+    warmed = {"n": 0}
+
+    async def _no_warm(record):
+        warmed["n"] += 1
+        return {"genuine": 0, "converted": 0, "estimated": 0, "none": 0}
+
+    monkeypatch.setattr(warmer, "_warm_one", _no_warm)
+    result = asyncio.get_event_loop().run_until_complete(warmer.main())
+    assert result is None
+    assert warmed["n"] == 0  # never warmed anything


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until the warmed per-category KPI ≥85% is measured (runbook §4)

Wave 1 of `docs/plans/2026-06-30-genuine-price-warmer-and-variant-metadata-plan.md`. **This PR does NOT activate the warmer** — it builds a trustworthy gate + safety fixes so `ENABLE_PRICE_CACHE_WARMER` can be flipped ON *iff* the gate is green. The flag stays OFF; activation is the human-gated runbook step (needs Railway login + paid Serper).

**Safety property:** with default flags, *none* of these changes alter the deployed prod runtime — the entire PR is inert until an operator flips flags.

## Recon reframed the plan (`docs/investigations/2026-06-30-warmer-recon.md`)
- **Cache-key parity is NOT a builder bug.** The warmer calls the *same* `compare_from_text → _get_price → build_size_aware_price_cache_key` a live user hits, and the builder already alias-normalizes EDT≡"eau de toilette"≡3.4oz. Warmer + KPI read the same truth-set strings → parity is guaranteed *for the gate*. The only residual is upstream/parser (a size axis present in a verbose warmed title but absent from a terse live query) — pinned + documented, not re-architected (that would risk flag-OFF parity).
- **The real durability bug: the DB (L2 `product_prices`) never persisted `title`** → a rehydrated warmed price is title-less → fails the KPI + `should_cache_price`. Fixed (flag-gated).
- The per-category ≥0.85 KPI gate + `run_usable_exact_genuine_kpi` already existed — extended, not rebuilt.

## Changes (all flag-OFF / default-OFF byte-identical to main cdaf5c5)
1. **`eval_gate`** — reject a truncated/odd `--baseline-run-id` (canonical-uuid form check) instead of the swallowed 22P02 → phantom "not found".
2. **Warmer Serper-budget guard** — a **tier-independent** per-run credit cap (`WARMER_MAX_SERPER_CREDITS_PER_RUN`, default 900) layered under `MAX_QUERIES_PER_RUN`. Deliberately does NOT consult the free-tier-calibrated lifetime counter (which would falsely disable the warmer on a healthy paid key past 2200 burn).
3. **KPI gate verdict** — `kpi_gate_verdict()` emits `{threshold, pass, failing, measured_categories}`; **fails on zero data** (the old inline check passed on an empty per_category).
4. **Cache-key parity pins** — EDT/eau-de-toilette/oz collapse; EDP/128GB stay distinct; the size-present-vs-absent residual + flag-OFF axis-less namespace pinned.
5. **L2 title persistence** — nullable `title` column (migration 033, **NOT applied**) + `save_price` writes / `get_cached_price` rehydrates it, gated by `ENABLE_PRICE_TITLE_PERSIST` (default OFF; rollout = migration-then-flag).
6. **Activation runbook** (`docs/runbooks/2026-06-30-warmer-activation.md`) — the gated flip-iff-green terminal step + Serper cost estimate.

## Verification
- New/changed tests green (55 across touched files); all sources compile.
- **Adversarial coverage sweep** of all 5 change areas (reproduced through the runtime), dispatcher-gated → 3 real findings: **MED budget-guard** (fixed — the free-tier-ceiling false-disable above), **LOW uuid urn:/braced** (fixed — canonical form), **HIGH 5G weight-split** (pre-existing, deferred: category-aware fix needs the correctness coverage sweep — see recon §7). `gate-verdict` + `title-persistence` clean.
- **Comm gate green:** branch-only-NEW failures == `[]` vs `.qa-correctness/main-baseline-failed.txt` (46 == 46; 8353 passed).
- CI `backend-tests` is RED-by-design on every commit incl shipped main (`test_value_math` TDD stubs + `test_youtube` env) — **gate on the comm-diff, not CI green.**

## NOT in this PR (gated / deferred)
- Warmer activation (prod warm + KPI + `ENABLE_PRICE_CACHE_WARMER` flip) — runbook, user-gated.
- Migration 033 apply + `ENABLE_PRICE_TITLE_PERSIST` flip — gated prod-DB change.
- The 5G/4G weight-token cache-key false-split — pre-existing; category-aware fix + coverage sweep in a follow-up.
- **Wave 2 (VariantDescriptor)** — blocked until Wave 1's KPI gate passes (needs the prod measurement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
