### PR TITLE
fix(price): category-aware cellular-generation exclusion in weight parsing (warmer cache-key parity)

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -2915,14 +2915,25 @@ def _strip_cellular_generation(text: str, category: Optional[str]) -> str:
     electronics) and its gram weight is preserved. Non-electronics / unresolved text is
     returned unchanged — the SAFE direction (never a false gram-weight merge).
 
+    CRITICAL: the INFERENCE fallback runs on the CELLULAR-STRIPPED text, never the raw
+    text. `is_electronics_query`'s brand+digit rule would otherwise be satisfied by the
+    "3" of a bare "3G" on a food that merely shares an electronics BRAND whole-token
+    ("Apple Sauce 3G", "Nothing Bundt Cake 2G") — self-promoting it to electronics and
+    false-merging its genuine gram sizes (coverage review R2). Inferring on the stripped
+    text removes that digit, so only text with a REAL device/model signal resolves to
+    electronics ("Galaxy S24 FE" stays electronics via "Galaxy"/"S24").
+
     Gated on `exact_gate_enabled()` so with the gate OFF the strip is a no-op and the
     legacy cache namespace stays BYTE-IDENTICAL to b207bfa (a rollback must not orphan
     the warmed cache)."""
     if not text or not exact_gate_enabled():
         return text
-    cat = _resolve_extractor_category(category, text)
+    stripped = _CELLULAR_GEN_RE.sub(" ", text)
+    if stripped == text:
+        return text  # no cellular token present — skip category resolution entirely
+    cat = _resolve_extractor_category(category, stripped)
     if (cat or "").lower() == "electronics":
-        return _CELLULAR_GEN_RE.sub(" ", text)
+        return stripped
     return text
 
 
@@ -5130,6 +5141,14 @@ def build_size_aware_price_cache_key(
     # to ONE key. Defaults to the per-task ContextVar when the caller omits it.
     token = _identity_cache_token(full_text, category)
     if not token:
+        # NOTE (known, pre-existing, non-regressive narrow gap): this legacy fallback
+        # hashes the RAW name, so a sizeless+qualifierless electronics model that carries
+        # "5G" ONLY in its name (e.g. "iPhone 15 5G" with no storage/qualifier anywhere)
+        # does NOT collapse onto its base. It is NOT the reported/warmer scenario (there the
+        # 5G rides search_query, or storage/qualifier makes the token non-empty → handled
+        # above). A blanket _strip_identity_axes(name) here would DOSE-MERGE supplements
+        # (1000 IU ≡ 5000 IU) since this branch has no token to carry the dose — so it is
+        # deliberately left as-is rather than "fixed" unsafely.
         return get_price_cache_key(brand, name, variant, region)
     # Strip ANY size/storage/concentration/qualifier token out of name+variant so
     # the base key is identity-axis-agnostic; the normalized composite token is the

--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -2891,6 +2891,40 @@ _COUNT_RE = re.compile(
 # is "g" or "ml", or None when no weight/volume token is present.
 _WEIGHT_VOLUME_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(kg|g|ml|l|lbs?|pounds?)\b", re.I)
 
+# A bare cellular-GENERATION token — "5G"/"4G"/"3G"/"2G" — is a NETWORK generation on
+# a phone/tablet/router, NOT a "5 gram" net weight. In ELECTRONICS context it must be
+# excluded from weight parsing so a phone's base query ("Galaxy S24 FE") and its genuine
+# "…5G" PDP title hash to ONE size token / price cache key (the warmer's warm-vs-live
+# parity). This is consistent with the codebase's documented stance that 5G is noise, not
+# a discriminator (see _ELECTRONICS_QUALIFIERS, which deliberately omits "5g").
+# Bounded to 2-5 (the real cellular generations); "5GB" is UNAFFECTED (the trailing B
+# blocks the \bG\b boundary). CATEGORY-SCOPED by the caller — a supplement/grocery "5G"/
+# "10G" is a genuine gram weight, so a category-blind strip would FALSE-MERGE
+# "Creatine 5G" == "Creatine 10G" (a strictly-worse wrong-SKU cache serve).
+_CELLULAR_GEN_RE = re.compile(r"\b[2-5]G\b", re.I)
+
+
+def _strip_cellular_generation(text: str, category: Optional[str]) -> str:
+    """Remove bare cellular-generation tokens (see `_CELLULAR_GEN_RE`) from `text` when
+    the resolved category is ELECTRONICS and the exact-price gate is ON.
+
+    Category resolution reuses `_resolve_extractor_category` (explicit arg > the
+    orchestrator per-task ContextVar > best-effort inference; "other" is re-inferred),
+    so an LLM-mislabelled "other" phone still collapses while a supplement/grocery text
+    resolves to its own category (the cosmetic/supplement/grocery detectors run BEFORE
+    electronics) and its gram weight is preserved. Non-electronics / unresolved text is
+    returned unchanged — the SAFE direction (never a false gram-weight merge).
+
+    Gated on `exact_gate_enabled()` so with the gate OFF the strip is a no-op and the
+    legacy cache namespace stays BYTE-IDENTICAL to b207bfa (a rollback must not orphan
+    the warmed cache)."""
+    if not text or not exact_gate_enabled():
+        return text
+    cat = _resolve_extractor_category(category, text)
+    if (cat or "").lower() == "electronics":
+        return _CELLULAR_GEN_RE.sub(" ", text)
+    return text
+
 
 def extract_storage_gb(text: str) -> Optional[float]:
     """Smallest storage size in `text`, in GB (TB→GB ×1024). None when no
@@ -2925,14 +2959,22 @@ def extract_count(text: str) -> Optional[float]:
     return max(vals) if vals else None
 
 
-def extract_weight_or_volume(text: str) -> Optional[Tuple[float, str]]:
+def extract_weight_or_volume(
+    text: str, category: Optional[str] = None
+) -> Optional[Tuple[float, str]]:
     """(value, base) net weight/volume in `text` — grams (g/kg→g) OR millilitres
     (ml/L→ml), whichever token appears. None when neither is present. Smallest
     matching token of the FIRST base seen wins (a single listing carries one
     pack size). Grams and ml are distinct bases — the caller must only compare
-    same-base values, so a weight vs a volume never trips a false match."""
+    same-base values, so a weight vs a volume never trips a false match.
+
+    `category` (optional): in ELECTRONICS context a bare cellular-generation token
+    ("5G"/"4G"/…) is a network generation, NOT a gram weight, so it is excluded
+    (see `_strip_cellular_generation`). Defaults to the orchestrator per-task
+    ContextVar when omitted; supplement/grocery gram parsing is untouched."""
     if not text:
         return None
+    text = _strip_cellular_generation(text, category)
     grams: List[float] = []
     mls: List[float] = []
     for num, unit in _WEIGHT_VOLUME_RE.findall(text):
@@ -2971,7 +3013,7 @@ _SIZE_STRIP_RE = re.compile(
 )
 
 
-def size_variant_token(text: Optional[str]) -> str:
+def size_variant_token(text: Optional[str], category: Optional[str] = None) -> str:
     """A stable normalized size/variant token for a product identity string, or
     "" when no size is present (Faithful-Results Task 1.4).
 
@@ -3003,7 +3045,9 @@ def size_variant_token(text: Optional[str]) -> str:
     count = extract_count(text)
     if count:
         return f"{_fmt(count)}ct"
-    wv = extract_weight_or_volume(text)
+    # `category` is threaded ONLY into the weight branch — it is the only axis where a
+    # cellular-generation token ("5G") could be mis-read as grams (electronics context).
+    wv = extract_weight_or_volume(text, category)
     if wv:
         value, base = wv
         return f"{_fmt(value)}{base}"
@@ -5006,7 +5050,7 @@ def public_price_view(price: Any) -> Any:
     }
 
 
-def _identity_cache_token(text: str) -> str:
+def _identity_cache_token(text: str, category: Optional[str] = None) -> str:
     """A stable composite cache token of ALL identity-discriminating axes —
     concentration (EDP/EDT/…) + variant qualifier (FE/Pro/Max/…) + size/storage/
     count/weight — so distinct VARIANTS of the same product never collide on one
@@ -5024,7 +5068,7 @@ def _identity_cache_token(text: str) -> str:
     quals = _quals_in(text, _ELECTRONICS_QUALIFIERS)
     if quals:
         parts.append("".join(sorted(quals)))
-    size = size_variant_token(text)
+    size = size_variant_token(text, category)
     if size:
         parts.append(size)
     return ".".join(parts)
@@ -5050,7 +5094,7 @@ def _strip_identity_axes(text: str) -> str:
 
 def build_size_aware_price_cache_key(
     brand: str, name: str, variant: Optional[str], region: str,
-    identity_text: str = "",
+    identity_text: str = "", category: Optional[str] = None,
 ) -> str:
     """Price cache key that folds in a normalized size/variant token so distinct
     sizes never collide (Task 1.4).
@@ -5081,7 +5125,10 @@ def build_size_aware_price_cache_key(
         )
         return generate_cache_key("price", brand, base_name, base_variant, region, token)
     full_text = f"{name} {variant or ''} {identity_text or ''}"
-    token = _identity_cache_token(full_text)
+    # `category` (the orchestrator-resolved pair category) lets the size token drop a bare
+    # cellular-generation "5G" for electronics so a base query and its "…5G" PDP collapse
+    # to ONE key. Defaults to the per-task ContextVar when the caller omits it.
+    token = _identity_cache_token(full_text, category)
     if not token:
         return get_price_cache_key(brand, name, variant, region)
     # Strip ANY size/storage/concentration/qualifier token out of name+variant so

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -4153,7 +4153,7 @@ class StructuredComparisonService:
         # the parser left it out of name/variant (electronics fixture: storage in
         # specs, variant=None).
         cache_key = build_size_aware_price_cache_key(
-            brand, name, variant, region, search_query
+            brand, name, variant, region, search_query, category=category
         )
         # I5.1 — price-only cache-bust probe forces the price reads to miss so
         # the routing escalation re-runs deterministically (specs/reviews stay

--- a/tests/test_cellular_generation_cache_key.py
+++ b/tests/test_cellular_generation_cache_key.py
@@ -201,6 +201,48 @@ def test_other_labelled_supplement_reinfers_and_keeps_grams():
     assert k5 != k10
 
 
+# --- Brand-collision foods must NOT false-merge (coverage review R2, CRITICAL) ----
+# A non-electronics product whose title carries an electronics-BRAND whole-token
+# (apple/nothing/beats/…) PLUS a bare [2-5]G gram token must NOT be promoted to
+# electronics by the cellular digit ITSELF (the brand+digit inference rule would
+# otherwise fire on the "3" of "3G") — else the genuine gram weight is stripped and
+# two different sizes collapse to ONE cache key. Category resolution must infer on the
+# CELLULAR-STRIPPED text so the [2-5]G can never be the promoting digit.
+
+_BRAND_COLLISION_FOODS = [
+    ("Apple Sauce", "Apple Sauce 3G Jar", "Apple Sauce 5G Jar", "other"),
+    ("Caramel Apple", "Caramel Apple 2G", "Caramel Apple 4G", "other"),
+    ("Bundt Cake", "Nothing Bundt Cake 2G", "Nothing Bundt Cake 5G", "other"),
+    ("Apple Sauce", "Apple Sauce 3G Jar", "Apple Sauce 5G Jar", None),
+]
+
+
+@pytest.mark.parametrize("brand_name,ta,tb,cat", _BRAND_COLLISION_FOODS)
+def test_brand_collision_food_not_false_merged(brand_name, ta, tb, cat):
+    assert _key("X", brand_name, ta, cat) != _key("X", brand_name, tb, cat), (ta, tb, cat)
+
+
+def test_brand_collision_food_gram_preserved_extract():
+    # The gram weight must survive for a brand-collision food even at category="other"/None
+    # (the [2-5]G must NOT self-promote the text to electronics).
+    assert ps.extract_weight_or_volume("Apple Sauce 3G Jar", category="other") == (3.0, "g")
+    assert ps.extract_weight_or_volume("Nothing Bundt Cake 2G", category=None) == (2.0, "g")
+
+
+def test_brand_collision_food_fairness_gram_preserved():
+    # coverage review R2 finding #2 — the fairness extractors (no category arg) must keep
+    # the like-for-like gram basis for a brand-collision food.
+    assert ps._extract_grocery({"name": "Apple Sauce 3G"}) == 3.0
+    assert ps._extract_grocery({"name": "Apple Sauce 5G"}) == 5.0
+
+
+def test_phone_still_collapses_after_stripped_inference():
+    # The fix (infer on the cellular-stripped text) must PRESERVE the "other"-labelled
+    # phone collapse — "Galaxy S24 FE" (stripped) still infers electronics.
+    assert (_key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE 5G Smartphone", "other")
+            == _key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE", "other"))
+
+
 # ---------------------------------------------------------------------------
 # ROLLBACK — flag OFF is byte-identical to b207bfa (the cellular strip is a no-op)
 # ---------------------------------------------------------------------------

--- a/tests/test_cellular_generation_cache_key.py
+++ b/tests/test_cellular_generation_cache_key.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+"""Cellular-generation tokens ("5G"/"4G"/"3G"/"2G") must NOT be mis-parsed as a
+gram weight in ELECTRONICS context.
+
+PRE-EXISTING BUG (main): `_WEIGHT_VOLUME_RE` matched "5G" -> (5.0, "g"), so a
+phone's base query ("Galaxy S24 FE") and its genuine "...5G Smartphone" PDP title
+injected a phantom "5g" size token and hashed to DIFFERENT price cache keys — a
+guaranteed warm-vs-live cache MISS across the electronics class that undermines the
+price-cache warmer's parity.
+
+CORRECT FIX (category-aware): exclude the bare cellular [2-5]G token from weight
+parsing ONLY for electronics/gadget context, PRESERVING supplement/grocery gram
+parsing — a category-blind strip would FALSE-MERGE "Creatine 5G" == "Creatine 10G"
+(a strictly-worse wrong-SKU cache serve). The exclusion is gated by the exact-price
+gate, so with ENABLE_EXACT_PRICE_GATE=false the legacy cache namespace is byte-
+identical to b207bfa (a rollback must not orphan the warmed cache).
+
+COVERAGE-DRIVEN (CLAUDE.md discipline): enumerate REAL electronics AND supplement/
+grocery products in BOTH directions — collapse for electronics, stay-distinct for
+gram categories — plus adversarial model tokens that embed a "G" (Moto G54, Nokia
+G22) which must NOT be eaten by the cellular strip.
+"""
+import pytest
+
+import app.services.price_service as ps
+
+
+def _key(brand, name, identity, category, variant=None, region="bahrain"):
+    return ps.build_size_aware_price_cache_key(
+        brand, name, variant, region, identity, category=category
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLEAN-RED CORE (existing signatures only) — the reported parity bug, driven
+# via the per-task ContextVar so it fails cleanly against un-patched main.
+# ---------------------------------------------------------------------------
+
+def test_core_parity_electronics_base_vs_5g_pdp_via_contextvar():
+    ps.set_resolved_price_category("electronics")
+    try:
+        base = ps.build_size_aware_price_cache_key(
+            "Samsung", "Galaxy S24 FE", None, "bahrain", "Galaxy S24 FE")
+        pdp = ps.build_size_aware_price_cache_key(
+            "Samsung", "Galaxy S24 FE", None, "bahrain",
+            "Galaxy S24 FE 5G Smartphone")
+        assert base == pdp
+    finally:
+        ps.set_resolved_price_category(None)
+
+
+# ---------------------------------------------------------------------------
+# extract_weight_or_volume — category-aware cellular exclusion
+# ---------------------------------------------------------------------------
+
+def test_extract_weight_electronics_excludes_bare_5g():
+    assert ps.extract_weight_or_volume("5G", category="electronics") is None
+    assert ps.extract_weight_or_volume(
+        "Galaxy S24 FE 5G Smartphone", category="electronics") is None
+
+
+@pytest.mark.parametrize("gen", ["2G", "3G", "4G", "5G"])
+def test_extract_weight_electronics_excludes_all_cellular_generations(gen):
+    assert ps.extract_weight_or_volume(f"Galaxy A55 {gen}", category="electronics") is None
+
+
+def test_extract_weight_supplements_keeps_gram_weight():
+    # A supplement/grocery "NG" IS N grams — the false-merge the task forbids.
+    assert ps.extract_weight_or_volume("Creatine 5G", category="supplements") == (5.0, "g")
+    assert ps.extract_weight_or_volume("Coffee Sachet 2G", category="grocery") == (2.0, "g")
+
+
+def test_extract_weight_none_category_keeps_gram_weight():
+    # Unresolved category is the SAFE (conservative) direction: DON'T strip, so a
+    # gram weight is preserved (no risk of a false supplement/grocery merge).
+    ps.set_resolved_price_category(None)
+    assert ps.extract_weight_or_volume("Something 5G") == (5.0, "g")
+
+
+def test_extract_weight_electronics_real_multidigit_gram_survives():
+    # ONLY the bare cellular [2-5]G token is excluded — a genuine multi-digit weight
+    # token ("250 g") is still parsed (proves the strip is surgical, not a blanket kill).
+    assert ps.extract_weight_or_volume("Gadget 250 g", category="electronics") == (250.0, "g")
+
+
+def test_extract_weight_electronics_storage_gb_never_grams():
+    # "5GB" is storage — the trailing B blocks the \bG\b boundary, so it was never
+    # a gram token and stays None regardless of the fix.
+    assert ps.extract_weight_or_volume("Memory Card 5GB", category="electronics") is None
+
+
+# ---------------------------------------------------------------------------
+# size_variant_token — the phantom weight token is gone for electronics
+# ---------------------------------------------------------------------------
+
+def test_size_token_electronics_5g_is_empty():
+    assert ps.size_variant_token("Galaxy S24 FE 5G", category="electronics") == ""
+    assert ps.size_variant_token("Galaxy S24 FE", category="electronics") == ""
+
+
+def test_size_token_supplement_grams_distinct():
+    # THE required (b) invariant — "Creatine 5G" and "Creatine 10G" stay DISTINCT.
+    assert ps.size_variant_token("Creatine 5G", category="supplements") == "5g"
+    assert ps.size_variant_token("Creatine 10G", category="supplements") == "10g"
+    assert (ps.size_variant_token("Creatine 5G", category="supplements")
+            != ps.size_variant_token("Creatine 10G", category="supplements"))
+
+
+def test_size_token_electronics_via_contextvar_when_no_explicit_category():
+    ps.set_resolved_price_category("electronics")
+    try:
+        assert ps.size_variant_token("Galaxy S24 FE 5G") == ""
+    finally:
+        ps.set_resolved_price_category(None)
+
+
+# ---------------------------------------------------------------------------
+# CORE cache-key parity — explicit category (the production threading path)
+# ---------------------------------------------------------------------------
+
+def test_key_electronics_base_and_5g_pdp_collapse():
+    # THE reported (a) invariant.
+    base = _key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE", "electronics")
+    pdp = _key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE 5G Smartphone", "electronics")
+    assert base == pdp
+
+
+def test_key_electronics_5g_in_name_collapses_onto_base():
+    base = _key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE", "electronics")
+    named = _key("Samsung", "Galaxy S24 FE 5G", "Galaxy S24 FE 5G", "electronics")
+    assert base == named
+
+
+def test_key_electronics_fe_qualifier_still_discriminates():
+    # 5G is noise, but the FE model qualifier is a REAL discriminator — a base "Galaxy
+    # S24" must NOT collapse onto "Galaxy S24 FE" (only the cellular token is stripped).
+    s24 = _key("Samsung", "Galaxy S24", "Galaxy S24 5G", "electronics")
+    s24fe = _key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE 5G", "electronics")
+    assert s24 != s24fe
+
+
+def test_key_electronics_5g_does_not_disturb_storage_variant():
+    a = _key("Apple", "iPhone 15", "iPhone 15 128GB", "electronics")
+    b = _key("Apple", "iPhone 15", "iPhone 15 128GB 5G", "electronics")
+    assert a == b  # 5G stripped as noise; both keep the 128gb token
+    c = _key("Apple", "iPhone 15", "iPhone 15 256GB 5G", "electronics")
+    assert a != c  # storage still discriminates
+
+
+# --- COVERAGE SWEEP: real electronics, base vs cellular-suffixed forms ------
+
+_ELECTRONICS_COLLAPSE = [
+    ("Samsung", "Galaxy S24 FE", "Galaxy S24 FE 5G Smartphone"),
+    ("Samsung", "Galaxy A55", "Galaxy A55 5G Dual SIM"),
+    ("Samsung", "Galaxy A37", "Galaxy A37 5G"),
+    ("Samsung", "Galaxy Tab S10 Lite", "Galaxy Tab S10 Lite 5G"),
+    ("Google", "Pixel 8", "Pixel 8 5G"),
+    ("OnePlus", "Nord 4", "OnePlus Nord 4 5G"),
+    ("Xiaomi", "Redmi Note 13", "Redmi Note 13 4G"),
+    ("Motorola", "Moto G54", "Moto G54 5G"),   # model token embeds "G54" — must NOT be eaten
+    ("Nokia", "G22", "Nokia G22 4G"),          # model IS "G22" — must NOT be eaten
+]
+
+
+@pytest.mark.parametrize("brand,name,cellular_title", _ELECTRONICS_COLLAPSE)
+def test_sweep_electronics_cellular_suffix_collapses_onto_base(brand, name, cellular_title):
+    base = _key(brand, name, name, "electronics")
+    suffixed = _key(brand, name, cellular_title, "electronics")
+    assert base == suffixed, (name, cellular_title)
+
+
+# --- COVERAGE SWEEP: gram categories keep DISTINCT weights ------------------
+# The SAME [2-5]G surface that COLLAPSES for electronics must stay a DISTINCT gram
+# weight for supplement/grocery — the strictly-worse false-merge the task forbids.
+
+_GRAM_DISTINCT = [
+    ("Optimum", "Creatine", "Creatine 5G", "Creatine 10G", "supplements"),
+    ("Nescafe", "Coffee Sachet", "Coffee Sachet 2G", "Coffee Sachet 4G", "grocery"),
+    ("Generic", "Sugar Stick", "Sugar Stick 3G", "Sugar Stick 5G", "grocery"),
+]
+
+
+@pytest.mark.parametrize("brand,name,ta,tb,category", _GRAM_DISTINCT)
+def test_sweep_gram_categories_stay_distinct(brand, name, ta, tb, category):
+    assert _key(brand, name, ta, category) != _key(brand, name, tb, category), (ta, tb)
+
+
+# --- "other" (LLM-mislabel) is re-inferred from the title ------------------
+
+def test_other_labelled_phone_reinfers_electronics_and_collapses():
+    base = _key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE 5G Smartphone", "other")
+    pdp = _key("Samsung", "Galaxy S24 FE", "Galaxy S24 FE", "other")
+    assert base == pdp
+
+
+def test_other_labelled_supplement_reinfers_and_keeps_grams():
+    # CRITICAL safety: an "other"-labelled supplement must re-infer to supplements
+    # (NOT electronics) so its gram weights stay distinct — no false merge.
+    k5 = _key("Optimum", "Creatine", "Creatine Monohydrate 5G", "other")
+    k10 = _key("Optimum", "Creatine", "Creatine Monohydrate 10G", "other")
+    assert k5 != k10
+
+
+# ---------------------------------------------------------------------------
+# ROLLBACK — flag OFF is byte-identical to b207bfa (the cellular strip is a no-op)
+# ---------------------------------------------------------------------------
+
+def test_flag_off_cellular_strip_is_noop(monkeypatch):
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "false")
+    # b207bfa parity: "5G" is STILL parsed as grams flag-OFF, so the legacy cache
+    # namespace is unchanged and a rollback does not orphan the warmed cache.
+    assert ps.extract_weight_or_volume("5G", category="electronics") == (5.0, "g")
+    assert ps.size_variant_token("Galaxy S24 FE 5G", category="electronics") == "5g"


### PR DESCRIPTION
## Problem

`extract_weight_or_volume` in `app/services/price_service.py` mis-parsed bare cellular-generation tokens — `extract_weight_or_volume("5G")` returned `(5.0, "g")`. That phantom `5g` size token flowed into `size_variant_token` / `_identity_cache_token`, so a phone's base query (`"Galaxy S24 FE"`) and its genuine `"…5G"` PDP title hashed to **different** price cache keys — a guaranteed warm-vs-live cache **miss** across the electronics class that undermines the price-cache warmer's parity. Pre-existing on `main`.

## Fix (category-aware, gate-guarded)

- New `_CELLULAR_GEN_RE = re.compile(r"\b[2-5]G\b", re.I)` + `_strip_cellular_generation(text, category)`: strips the bare cellular token **only** for electronics context and **only** when the exact-price gate is ON.
- Category resolution reuses `_resolve_extractor_category` (explicit arg → per-task ContextVar → inference), and the inference runs on the **cellular-stripped** text so a bare `[2-5]G` can never be the digit that promotes a look-alike product to electronics. The cosmetic/supplement/grocery detectors run before electronics, so a supplement/grocery `"5G"`/`"10G"` stays a genuine gram weight — no false `"Creatine 5G" == "Creatine 10G"` merge.
- Threaded an optional `category` through `extract_weight_or_volume` → `size_variant_token` → `_identity_cache_token` → `build_size_aware_price_cache_key`, passed from `scs._get_price` (the orchestrator-resolved pair category).

## Safety

- **Flag-OFF byte-identity:** with `ENABLE_EXACT_PRICE_GATE=false` the strip is a no-op, so the cache namespace stays byte-identical to `b207bfa` (a rollback does not orphan the warmed cache). `tests/test_exact_gate_flag_off_parity.py` green.
- **Matcher weight axis untouched:** `_weights_volumes` / `_axis_mismatch` (the correctness/display gate) are a separate `_WEIGHT_VOLUME_RE` consumer, left unchanged — only the cache-key namespace moves. Even where two cellular variants now share a key, the read-path revalidation (`_cache_price_identity_ok`) and `_selection_match` still reject a cross-gen serve → at worst a cache miss + re-resolve, never a wrong price.
- Consistent with the codebase's documented stance that 5G is noise, not a discriminator (`_ELECTRONICS_QUALIFIERS` deliberately omits `"5g"`).

## Commits

- `979b808` — category-aware cellular exclusion in weight parsing (the core fix).
- `b7c58db` — infer category on the cellular-stripped text, fixing a **brand-collision false-merge** regression that a max-effort adversarial review caught (`"Apple Sauce 3G"` was self-promoted to electronics by the `[2-5]G` digit via the brand+digit rule, stripping its genuine gram weight). Fixed TDD-first.

## Verification

- **Tests:** `tests/test_cellular_generation_cache_key.py` — coverage-driven, both directions, incl. adversarial G-embedded models (`Moto G54`, `Nokia G22`), brand-collision foods, and `"other"` re-inference. Pins both required invariants: (a) base query and `"…FE 5G Smartphone"` share one key; (b) `"Creatine 5G" != "Creatine 10G"`.
- **Adversarial coverage review** (3 independent framings — wrong-SKU leak / false-merge safety / completeness+regex, every claim reproduced through the runtime): found and fixed the one real regression above; no blockers remain.
- **Zero-regression comm gate** vs `origin/main`: `branch-only-NEW == []`. The lone flagged failure (`test_prices_endpoint_rate_limited`) is the documented shared-state rate-limiter flake — verified PASS in isolation.

## Documented, deliberately NOT fixed (non-blocking)

- Title-less **Tier-3 GPT estimate** (never a genuine price; indicative-flagged; short-TTL; same model-tier ballpark) can share the collapsed key. Hardening it would disable estimate caching for negligible benefit.
- A **sizeless + qualifierless** electronics model with `"5G"` only in its *name* does not collapse onto its base (pre-existing empty-token fallback hashes the raw name; **not** the warmer scenario). The obvious `_strip_identity_axes(name)` fix is unsafe — it dose-merges supplements (`1000 IU ≡ 5000 IU`) — so it is left with an explanatory code comment.

## Deploy note

This is a **warmer prerequisite** (`ENABLE_PRICE_CACHE_WARMER` is paused, so no urgency). On deploy it changes electronics cache-key behavior under the default-ON `ENABLE_EXACT_PRICE_GATE` — a one-time, self-healing cache-key migration for electronics-`5G` entries. Post-merge: `python -m scripts.eval_runner --subset smoke20 --mode regression --baseline-run-id 54b603e8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
