### PR TITLE
Fragrance pair-reconcile: stop pending genuine prices from unlisted houses (flag-gated)

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -1472,7 +1472,10 @@ def _product_size_text_fields(product: Dict[str, Any]) -> List[str]:
     return fields
 
 
-def effective_pair_size_ml(product: Dict[str, Any]) -> Optional[float]:
+def effective_pair_size_ml(
+    product: Dict[str, Any],
+    treat_unsized_as_flagship: bool = False,
+) -> Optional[float]:
     """ITEM 2 — the SIZE (ml) a product is effectively being compared at, derived
     from ALL available signals — product NAME first (the listing the user named
     is ground truth), then price listing title, then price.size, then the spec
@@ -1486,6 +1489,15 @@ def effective_pair_size_ml(product: Dict[str, Any]) -> Optional[float]:
         two unsized designer fragrances converge on the same 100ml basis), ELSE
       - None for any non-fragrance / non-designer product with no size signal (so
         two unsized phones stay None==None and never trip a false mismatch).
+
+    `treat_unsized_as_flagship` (frag-reconcile fix, flag-gated by the caller):
+    when True, a SIZE-UNSPECIFIED product defaults to the flagship 100ml basis
+    even when the NAME is not _is_designer_fragrance_name-recognized. The caller
+    passes True ONLY on the canon=="fragrances" reconcile path, where the
+    orchestrator already confirmed the pair is a fragrance — so the too-narrow
+    brand-keyword heuristic must not be the gate for the flagship default. It
+    NEVER overrides an explicit size token (any `\\d+ml` above still wins), so a
+    genuine 30ml/50ml still resolves to its real size.
     """
     if not isinstance(product, dict):
         return None
@@ -1501,6 +1513,11 @@ def effective_pair_size_ml(product: Dict[str, Any]) -> Optional[float]:
     # bias), so two unsized designer fragrances are treated as the SAME basis.
     name = product.get("full_name") or product.get("name") or ""
     if _is_designer_fragrance_name(name):
+        return _FRAGRANCE_FLAGSHIP_SIZE_ML
+    # frag-reconcile fix — the caller has already established (via the resolved
+    # category) that this is a fragrance; default an unsized fragrance to the
+    # flagship basis even when the name is not brand-keyword-recognized.
+    if treat_unsized_as_flagship:
         return _FRAGRANCE_FLAGSHIP_SIZE_ML
     return None
 
@@ -1525,6 +1542,7 @@ def target_pair_size_ml(
     user_query: Optional[str],
     p0: Dict[str, Any],
     p1: Dict[str, Any],
+    treat_unsized_as_flagship: bool = False,
 ) -> Optional[float]:
     """The size (ml) the PAIR should be compared at — the FAIRNESS target.
 
@@ -1547,6 +1565,13 @@ def target_pair_size_ml(
     n0 = (p0.get("full_name") or p0.get("name") or "") if isinstance(p0, dict) else ""
     n1 = (p1.get("full_name") or p1.get("name") or "") if isinstance(p1, dict) else ""
     if _is_designer_fragrance_name(n0) and _is_designer_fragrance_name(n1):
+        return _FRAGRANCE_FLAGSHIP_SIZE_ML
+    # frag-reconcile fix — on the canon=="fragrances" path the pair is already
+    # known to be fragrances; a size-SILENT designer/retail pair shares the same
+    # flagship 100ml basis even when neither name is brand-keyword-recognized.
+    # An explicit user size above still wins; a per-product explicit size is
+    # honored later in reconcile (effective size != target -> re-select / pend).
+    if treat_unsized_as_flagship:
         return _FRAGRANCE_FLAGSHIP_SIZE_ML
     return None
 
@@ -1662,6 +1687,7 @@ def reconcile_pair_sizes(
     product_data: List[Dict[str, Any]],
     user_query: Optional[str] = None,
     candidates_by_name: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    treat_unsized_as_flagship: bool = False,
 ) -> bool:
     """Task C2 + ITEM 2 + same-size GENUINE re-selection — pair-level size-basis
     reconciliation (FAIRNESS).
@@ -1724,19 +1750,19 @@ def reconcile_pair_sizes(
     # flagship-target derivation so a SHARED explicit size the user didn't type is
     # never overridden up to 100ml. (When the user DID type a size, the target is
     # authoritative — the re-selection path below resolves to it.)
-    eff0 = effective_pair_size_ml(p0)
-    eff1 = effective_pair_size_ml(p1)
+    eff0 = effective_pair_size_ml(p0, treat_unsized_as_flagship)
+    eff1 = effective_pair_size_ml(p1, treat_unsized_as_flagship)
     if user_size is None and eff0 is not None and eff0 == eff1:
         return False
 
-    target = target_pair_size_ml(user_query, p0, p1)
+    target = target_pair_size_ml(user_query, p0, p1, treat_unsized_as_flagship)
 
     # No shared target (non-fragrance / mixed pair, no user size) → legacy
     # effective-size comparison. Equal/both-unknown → no-op; genuine divergence →
     # both pending. Electronics stays exactly as before.
     if target is None:
-        size0 = effective_pair_size_ml(p0)
-        size1 = effective_pair_size_ml(p1)
+        size0 = effective_pair_size_ml(p0, treat_unsized_as_flagship)
+        size1 = effective_pair_size_ml(p1, treat_unsized_as_flagship)
         if size0 == size1:
             return False
         _mark_size_pending(p0, p1)
@@ -1750,7 +1776,7 @@ def reconcile_pair_sizes(
         retained candidates when the current price is off-target; on a successful
         swap mutates p['price'] (+ best_price/retailer) in place."""
         nonlocal changed
-        if effective_pair_size_ml(p) == target:
+        if effective_pair_size_ml(p, treat_unsized_as_flagship) == target:
             return True
         name = p.get("full_name") or p.get("name") or ""
         cands = candidates_by_name.get(name) or candidates_by_name.get(p.get("name") or "")
@@ -2610,11 +2636,16 @@ def reconcile_pair_fairness(
         return False
 
     canon = _canonical_fairness_key(category)
-    # FRAGRANCES — delegate to the shipped reconcile verbatim (behavior frozen).
+    # FRAGRANCES — delegate to the shipped reconcile. The orchestrator has already
+    # resolved the pair category to fragrances, so an UNSIZED product here IS a
+    # fragrance — pass the frag-reconcile fix flag so a size-silent genuine pair
+    # defaults to the flagship 100ml basis even when its house is not in the
+    # brand-keyword list (flag OFF -> byte-identical to the frozen behavior).
     if canon == "fragrances":
         return reconcile_pair_sizes(
             product_data, user_query=user_query,
             candidates_by_name=candidates_by_name,
+            treat_unsized_as_flagship=frag_reconcile_fix_enabled(),
         )
 
     spec = fairness_for_category(category)
@@ -3305,6 +3336,27 @@ def exact_gate_enabled() -> bool:
     """True iff the exact-identity correctness gate is active (default ON)."""
     return os.getenv("ENABLE_EXACT_PRICE_GATE", "true").strip().lower() not in (
         "false", "0", "no", "off", "",
+    )
+
+
+def frag_reconcile_fix_enabled() -> bool:
+    """True iff the fragrance-pair size-reconcile broadening is active (default
+    OFF -> byte-identical to today).
+
+    Read FRESH per call (env, not module-level) so a flag flip takes effect
+    without a restart. When ON, a SIZE-UNSPECIFIED fragrance on the
+    canon=="fragrances" reconcile path defaults to the flagship 100ml basis even
+    when its NAME is not caught by the (too-narrow) _is_designer_fragrance_name
+    brand-keyword heuristic — because the ORCHESTRATOR already resolved the pair
+    category to fragrances, so an unsized product on that path IS a fragrance. It
+    ONLY broadens the unsized case: any explicit `\\d+ml` token on either side is
+    still used verbatim (a genuine 30ml/50ml still resolves + still pends vs a
+    100ml partner). Fixes genuine adapter prices (woo/magento/noon carry no
+    price.size + no ml token in the title) being wrongly NULLED when only one side
+    was brand-keyword-recognized.
+    """
+    return os.getenv("ENABLE_FRAGRANCE_SIZE_RECONCILE_FIX", "false").strip().lower() in (
+        "true", "1", "yes", "on",
     )
 
 

--- a/tests/test_fragrance_size_reconcile_fix.py
+++ b/tests/test_fragrance_size_reconcile_fix.py
@@ -1,0 +1,248 @@
+"""frag-size-reconcile fix — a genuine fragrance PAIR where neither/one side is
+brand-keyword-recognized was wrongly NULLED by reconcile_pair_sizes.
+
+ROOT CAUSE: genuine adapter prices (woo/magento/noon) carry NO price["size"] and
+their title has no `\\d+ml` token. effective_pair_size_ml only defaulted a
+size-UNSPECIFIED product to the flagship 100ml basis when
+_is_designer_fragrance_name(name) was True (name contains a FRAGRANCE_BRAND_KEYWORD
+or is luxury). A genuine fragrance from an unlisted house ("Armaf Club de Nuit",
+"Nishane Hacivat") returned None -> target_pair_size_ml's both-designer gate failed
+-> the legacy branch saw 100 (recognized side) != None (unrecognized side) ->
+BOTH pended, nulling a correct genuine price.
+
+FIX (approach c, flag-gated): reconcile_pair_fairness passes
+treat_unsized_as_flagship=frag_reconcile_fix_enabled() into reconcile_pair_sizes
+on the canon=="fragrances" path. The orchestrator has already established the pair
+is a fragrance, so an UNSIZED product defaults to the flagship 100ml basis even
+without a brand-keyword name match. It ONLY broadens the unsized case — any
+explicit `\\d+ml` token on either side is used verbatim, so a genuine 30ml/50ml
+still resolves + still PENDS vs a 100ml partner.
+
+FLAG: ENABLE_FRAGRANCE_SIZE_RECONCILE_FIX, default OFF -> byte-identical to today.
+
+Run: pytest tests/test_fragrance_size_reconcile_fix.py -v
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+
+from app.services.price_service import (
+    reconcile_pair_sizes,
+    reconcile_pair_fairness,
+    effective_pair_size_ml,
+    target_pair_size_ml,
+)
+
+
+def _prod(name, amount, *, price_size=None, specs=None,
+          source_method="woo_store_api", title=None):
+    """A GENUINE adapter-shaped product: price.size is None + no ml token in the
+    title (matches woo/magento/noon)."""
+    price = {
+        "amount": amount, "currency": "BHD",
+        "source_method": source_method, "size": price_size,
+        "in_stock": True,
+    }
+    if title is not None:
+        price["title"] = title
+    return {
+        "name": name, "full_name": name,
+        "price": price,
+        "best_price": amount,
+        "retailer": "someshop.bh",
+        "specs": specs or {},
+    }
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv("ENABLE_FRAGRANCE_SIZE_RECONCILE_FIX", "true")
+
+
+@pytest.fixture
+def flag_off(monkeypatch):
+    monkeypatch.setenv("ENABLE_FRAGRANCE_SIZE_RECONCILE_FIX", "false")
+
+
+# ============================================================
+# FLAG ON — the fix recovers wrongly-pended genuine pairs
+# ============================================================
+class TestFlagOnRecoversGenuinePairs:
+    def test_recognized_plus_unrecognized_unsized_shows_both(self, flag_on):
+        # THE bug: Creed (recognized -> 100) + Armaf (unrecognized -> None today).
+        # With the fix both default to the flagship basis -> fair -> show both.
+        pd = [
+            _prod("Creed Aventus", 90.0),
+            _prod("Armaf Club de Nuit Intense", 35.0),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "fragrances")
+        assert changed is False
+        assert pd[0]["price"]["amount"] == 90.0
+        assert pd[1]["price"]["amount"] == 35.0
+        assert pd[0]["price"].get("unavailable") is not True
+        assert pd[1]["price"].get("unavailable") is not True
+
+    def test_both_unrecognized_unsized_shows_both(self, flag_on):
+        # Two genuine niche fragrances, neither in the keyword list, both unsized.
+        pd = [
+            _prod("Nishane Hacivat", 60.0),
+            _prod("Armaf Club de Nuit Intense", 35.0),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "fragrances")
+        assert changed is False
+        assert pd[0]["price"]["amount"] == 60.0
+        assert pd[1]["price"]["amount"] == 35.0
+
+    def test_via_reconcile_pair_sizes_directly(self, flag_on):
+        # Direct reconcile_pair_sizes with the flag param wired True.
+        pd = [
+            _prod("Creed Aventus", 90.0),
+            _prod("Armaf Club de Nuit Intense", 35.0),
+        ]
+        changed = reconcile_pair_sizes(pd, treat_unsized_as_flagship=True)
+        assert changed is False
+        assert pd[0]["price"]["amount"] == 90.0
+        assert pd[1]["price"]["amount"] == 35.0
+
+
+# ============================================================
+# FLAG ON — the correctness guards STAY intact
+# ============================================================
+class TestFlagOnGuardsIntact:
+    def test_explicit_different_sizes_still_pend(self, flag_on):
+        # A confirmed 30ml travel vs a 100ml full bottle GENUINELY differ ->
+        # still pend the off-target 30ml. NEVER show two different sizes as
+        # comparable just because the fix defaults unsized -> flagship.
+        pd = [
+            _prod("Nishane Hacivat 100ml", 100.0),
+            _prod("Armaf Club de Nuit 30ml", 20.0),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "fragrances")
+        assert changed is True
+        assert pd[0]["price"]["amount"] == 100.0            # 100ml = target, kept
+        assert pd[1]["price"]["amount"] is None             # 30ml off-target -> pended
+        assert pd[1]["price"]["reason"] == "size_mismatch"
+
+    def test_unsized_flagship_vs_explicit_30ml_pends_the_30(self, flag_on):
+        # One side unsized (-> 100 via the fix), the other explicitly 30ml.
+        # 30 != 100 -> pend ONLY the 30ml side; the unsized-flagship side shows.
+        pd = [
+            _prod("Armaf Club de Nuit Intense", 35.0),
+            _prod("Nishane Hacivat 30ml", 22.0),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "fragrances")
+        assert changed is True
+        assert pd[0]["price"]["amount"] == 35.0
+        assert pd[1]["price"]["amount"] is None
+        assert pd[1]["price"]["reason"] == "size_mismatch"
+
+    def test_both_explicit_off_flagship_different_both_pend(self, flag_on):
+        # 50ml vs 30ml, no candidates to reach a common basis -> both pend
+        # (the fix must not force these to 100).
+        pd = [
+            _prod("Armaf Club de Nuit 50ml", 40.0),
+            _prod("Nishane Hacivat 30ml", 22.0),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "fragrances")
+        assert changed is True
+        assert pd[0]["price"]["amount"] is None
+        assert pd[1]["price"]["amount"] is None
+
+    def test_user_query_size_still_authoritative(self, flag_on):
+        # User typed "50ml" -> target 50; both unsized products can't reach 50
+        # -> both pend (the fix does not override an explicit user size to 100).
+        pd = [
+            _prod("Armaf Club de Nuit Intense", 35.0),
+            _prod("Nishane Hacivat", 60.0),
+        ]
+        changed = reconcile_pair_fairness(
+            pd, "Armaf Club de Nuit vs Nishane Hacivat 50ml", "fragrances"
+        )
+        assert changed is True
+        assert pd[0]["price"]["amount"] is None
+        assert pd[1]["price"]["amount"] is None
+
+    def test_non_fragrance_category_untouched(self, flag_on):
+        # Electronics still never gets the flagship default (the flag only wires
+        # through on canon=="fragrances").
+        pd = [
+            _prod("iPhone 15 Pro", 400.0, source_method="local_bhd"),
+            _prod("Galaxy S24 Ultra", 450.0, source_method="local_bhd"),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "electronics")
+        assert pd[0]["price"]["amount"] == 400.0
+        assert pd[1]["price"]["amount"] == 450.0
+
+
+# ============================================================
+# FLAG OFF — byte-identical to today (the bug reproduces)
+# ============================================================
+class TestFlagOffByteIdentical:
+    def test_recognized_plus_unrecognized_unsized_still_pends_both(self, flag_off):
+        # The pre-fix behavior: BOTH nulled (the very bug we fix). Flag OFF must
+        # reproduce it exactly.
+        pd = [
+            _prod("Creed Aventus", 90.0),
+            _prod("Armaf Club de Nuit Intense", 35.0),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "fragrances")
+        assert changed is True
+        assert pd[0]["price"]["amount"] is None
+        assert pd[1]["price"]["amount"] is None
+        assert pd[1]["price"]["reason"] == "size_mismatch"
+
+    def test_effective_size_default_off(self, flag_off):
+        # treat_unsized_as_flagship default False -> unrecognized unsized -> None.
+        p = _prod("Armaf Club de Nuit Intense", 35.0)
+        assert effective_pair_size_ml(p) is None
+
+    def test_target_default_off(self, flag_off):
+        p0 = _prod("Armaf Club de Nuit Intense", 35.0)
+        p1 = _prod("Nishane Hacivat", 60.0)
+        assert target_pair_size_ml(None, p0, p1) is None
+
+
+# ============================================================
+# Recognized-pair regression — the surviving pair still shows on BOTH states
+# ============================================================
+class TestRecognizedPairStillShows:
+    @pytest.mark.parametrize("flag_val", ["true", "false"])
+    def test_recognized_designer_pair_shows(self, monkeypatch, flag_val):
+        # Baccarat Rouge (mfk-recognized via brand token) + Layton (parfums de
+        # marly). Both -> 100 via _is_designer_fragrance_name on both flag states.
+        monkeypatch.setenv("ENABLE_FRAGRANCE_SIZE_RECONCILE_FIX", flag_val)
+        pd = [
+            _prod("Maison Francis Kurkdjian Baccarat Rouge 540", 120.0),
+            _prod("Parfums de Marly Layton", 95.0),
+        ]
+        changed = reconcile_pair_fairness(pd, None, "fragrances")
+        assert changed is False
+        assert pd[0]["price"]["amount"] == 120.0
+        assert pd[1]["price"]["amount"] == 95.0
+
+
+# ============================================================
+# effective_pair_size_ml / target_pair_size_ml — explicit-size precedence with
+# the flag param True (the broadening must NEVER override a real size token)
+# ============================================================
+class TestExplicitSizeWinsOverFlag:
+    def test_effective_explicit_size_wins(self):
+        p = _prod("Armaf Club de Nuit 30ml", 20.0)
+        assert effective_pair_size_ml(p, True) == 30.0    # real size, not 100
+
+    def test_effective_unsized_defaults_flagship_when_flagged(self):
+        p = _prod("Armaf Club de Nuit Intense", 35.0)
+        assert effective_pair_size_ml(p, True) == 100.0
+
+    def test_effective_non_frag_still_none_without_flag(self):
+        # A phone unsized stays None even conceptually — the flag param is only
+        # ever True on the fragrance path, but assert the default is preserved.
+        p = _prod("iPhone 15 Pro", 400.0, source_method="local_bhd")
+        assert effective_pair_size_ml(p) is None
+
+    def test_target_user_size_beats_flag(self):
+        p0 = _prod("Armaf Club de Nuit Intense", 35.0)
+        p1 = _prod("Nishane Hacivat", 60.0)
+        assert target_pair_size_ml("something 50ml", p0, p1, True) == 50.0


### PR DESCRIPTION
## Problem (recon wf_09d336f0, warmer-effectiveness lane)

The one-shot warmer pass showed genuine fragrance prices being **nulled after `_get_price` during pair assembly**. Root cause: `reconcile_pair_fairness` → `reconcile_pair_sizes` defaults an unsized product to the flagship 100ml basis **only when `_is_designer_fragrance_name` recognizes the brand** (a curated keyword list). A genuine fragrance from an *unlisted* house (Armaf, Nishane, Zimaya, Maison Alhambra…) returns `None`, so a pair like **Creed Aventus (recognized → 100) vs Armaf Club de Nuit (unlisted → None)** hits the target-mismatch branch and `_mark_size_pending` **nulls BOTH correct genuine prices** — even though both are standard flagship bottles.

## Fix (flag-gated, category-scoped)

Behind new flag `ENABLE_FRAGRANCE_SIZE_RECONCILE_FIX` (default **OFF → byte-identical**): `reconcile_pair_fairness` passes `treat_unsized_as_flagship` into `reconcile_pair_sizes` **only when the orchestrator-resolved pair category is `fragrances`**. On that path an unsized product IS a fragrance, so it defaults to the same flagship 100ml basis the code already applies to recognized designer pairs — the brand-keyword list no longer gates it.

**Correctness guards (all pinned):**
- Any explicit `Nml` token (name/title/`price.size`/spec) still resolves verbatim → **30ml vs 100ml still PENDS**; no wrong size minted.
- 100ml is the *same* flagship default already used for recognized pairs — not a synthesized value; only the unsized case is broadened.
- User-query size stays authoritative; PR#9 exact-gate + `reselect_to_target_size` implausible-low/high + concentration/OOS guards untouched.
- Electronics / non-fragrance never gets the flagship default (flag wired only on `canon=='fragrances'`).
- Flag-OFF reproduces the bug (and all prior behavior) exactly.

## Verification
- **Both-directions fragrance sweep (39 cases): clean** — one-side-recognized + both-size-silent pairs now SHOW (Creed×Armaf, Tom Ford×Nishane, Amouage×Maison Alhambra…); every explicit-size divergence still PENDS; flag-OFF byte-identical across all cases.
- **Regression: clean** — branch-only-NEW == [] after excluding 2 `test_algolia_tier2_wiring.py` failures that **reproduce on clean `origin/main`** (pre-existing live-Algolia-adapter-preempts-mock class, network-dependent; unrelated to this diff). Golden corpus green.
- Diff: `app/services/price_service.py` + `tests/test_fragrance_size_reconcile_fix.py` only.

## Activation
Flag defaults OFF. To activate (live + warmer benefit for fragrance pair-compares): set `ENABLE_FRAGRANCE_SIZE_RECONCILE_FIX=true` on Railway (web + price-warmer) after a spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)