### PR TITLE
Serper multi-key failover (SERPER_API_KEYS, rotate on depletion) — single-key inert/BC

### DIFF
--- a/app/services/api_budget_service.py
+++ b/app/services/api_budget_service.py
@@ -91,18 +91,62 @@ _MONTHLY_TTL = 35 * 24 * 3600
 _SERPER_NO_KEY_PREFIX = "nokey"
 
 
+# genuine-price serper-multikey — Redis prefix for the per-key exhaustion flag.
+# Kept in sync with serper_service._SERPER_EXHAUSTED_PREFIX so the counter-scoping
+# here and the failover there agree on which key is "active". Read directly via
+# cache_service (no serper_service import → no circular dependency).
+_SERPER_EXHAUSTED_PREFIX = "serper:exhausted:"
+
+
+def _serper_env_keys() -> list:
+    """Ordered Serper key list from env, read FRESH each call (Railway env update
+    / rotation takes effect without a restart). Priority: SERPER_API_KEYS
+    (comma-separated) then the single SERPER_API_KEY. Trimmed, blanks skipped,
+    order-preserving de-dupe. Self-contained (no serper_service import) to avoid
+    a serper_service ↔ api_budget_service cycle."""
+    raw_multi = (os.environ.get("SERPER_API_KEYS") or "").strip()
+    keys: list = []
+    if raw_multi:
+        for part in raw_multi.split(","):
+            k = part.strip()
+            if k and k not in keys:
+                keys.append(k)
+        if keys:
+            return keys
+    single = (os.environ.get("SERPER_API_KEY") or "").strip()
+    return [single] if single else []
+
+
 def _serper_key_prefix() -> str:
-    """First 8 chars of the live SERPER_API_KEY (read fresh each call so a
-    Railway env update / key rotation takes effect without a restart, mirroring
+    """First 8 chars of the ACTIVE Serper key (read fresh each call so a Railway
+    env update / key rotation takes effect without a restart, mirroring
     _serper_image_daily_budget).
 
     This scopes the Serper lifetime counter to the key that burned the credits:
     a rotation starts a fresh honest counter instead of inheriting the previous
     account's burn (the 5136-across-4-accounts false-trip, S2 G6). Falls back to
-    a stable 'nokey' sentinel when the env var is unset/empty so the key stays
-    deterministic."""
-    raw = (os.environ.get("SERPER_API_KEY") or "").strip()
-    return raw[:8] if raw else _SERPER_NO_KEY_PREFIX
+    a stable 'nokey' sentinel when no key is configured so the key stays
+    deterministic.
+
+    genuine-price serper-multikey: with SERPER_API_KEYS (comma-separated) set,
+    the counter tracks whichever key is CURRENTLY active (first NON-exhausted)
+    so each rotated-to key gets its own honest lifetime counter. With only the
+    single SERPER_API_KEY set (no SERPER_API_KEYS), this is byte-identical to
+    the pre-multikey scoping (first 8 chars of that key, or 'nokey')."""
+    keys = _serper_env_keys()
+    if not keys:
+        return _SERPER_NO_KEY_PREFIX
+    # Prefer the first key NOT flagged exhausted; if all are flagged (or Redis is
+    # down / no flags), fall back to the first key so the counter stays a stable,
+    # deterministic target.
+    for key in keys:
+        prefix = key[:8]
+        try:
+            if not _redis_get(_SERPER_EXHAUSTED_PREFIX + prefix):
+                return prefix
+        except Exception:  # noqa: BLE001
+            return prefix
+    return keys[0][:8]
 
 
 def _budget_key(provider: str) -> str:

--- a/app/services/api_budget_service.py
+++ b/app/services/api_budget_service.py
@@ -136,9 +136,15 @@ def _serper_key_prefix() -> str:
     keys = _serper_env_keys()
     if not keys:
         return _SERPER_NO_KEY_PREFIX
-    # Prefer the first key NOT flagged exhausted; if all are flagged (or Redis is
-    # down / no flags), fall back to the first key so the counter stays a stable,
-    # deterministic target.
+    # SINGLE-KEY INERT: with 0 or 1 resolved keys (the common prod case: only
+    # SERPER_API_KEY set, no SERPER_API_KEYS) there is NO exhaustion machinery —
+    # the prefix is that key's first 8 chars with NO Redis exhaustion read.
+    # Byte-identical to the pre-multikey scoping.
+    if len(keys) == 1:
+        return keys[0][:8]
+    # MULTI-KEY (>=2): prefer the first key NOT flagged exhausted; if all are
+    # flagged (or Redis is down / no flags), fall back to the first key so the
+    # counter stays a stable, deterministic target.
     for key in keys:
         prefix = key[:8]
         try:

--- a/app/services/serper_service.py
+++ b/app/services/serper_service.py
@@ -21,6 +21,186 @@ SERPER_BASE_URL = "https://google.serper.dev"
 
 
 # ============================================
+# MULTI-KEY SERPER FAILOVER (genuine-price serper-multikey)
+# ============================================
+# A single free Serper key holds a finite lifetime credit pool; when it
+# depletes mid-run the warmer cron (and live compares) silently degrade to
+# `estimated`. This layer reads an ORDERED key list from SERPER_API_KEYS
+# (comma-separated, priority order) and rotates to the next non-exhausted key
+# when a response signals credit depletion.
+#
+# Backward compatibility (critical): when only SERPER_API_KEY is set (no
+# SERPER_API_KEYS) and that key is NOT exhausted, behaviour is byte-identical
+# to before — the active key IS SERPER_API_KEY, exactly ONE POST fires on the
+# happy path (no rotation), only a single cheap Redis exhaustion-check read is
+# added. The module attr SERPER_API_KEY is preserved (tests patch it) and is
+# consulted as the single-key fallback so `monkeypatch.setattr(serper_service,
+# "SERPER_API_KEY", ...)` continues to work.
+#
+# Exhaustion is DISTINCT from the api_budget_service circuit breaker: a
+# credit-depletion failover marks the KEY exhausted (Redis flag serper:
+# exhausted:<key8>) and rotates — it does NOT trip the 3-failure CB cooldown.
+# A transient 500/timeout is neither: it neither marks the key exhausted nor
+# rotates (the caller's existing except/raise handling deals with it).
+
+# Redis prefix for the per-key exhaustion flag. Keyed by the same 8-char
+# prefix api_budget_service uses to scope the lifetime counter.
+_SERPER_EXHAUSTED_PREFIX = "serper:exhausted:"
+
+# TTL for the exhaustion flag. MODERATE (6h): long enough that a truly-depleted
+# free key is skipped for the rest of a warmer run / session, short enough that
+# a transiently-misclassified key (or a key whose free quota resets) is retried
+# later instead of being permanently blacklisted.
+_SERPER_EXHAUSTED_TTL = 6 * 3600
+
+# In-process de-dupe so the "key exhausted" WARNING logs once per key per
+# process (Redis carries the cross-process authoritative state).
+_serper_exhausted_logged: set = set()
+
+
+def _serper_key_prefix8(key: Optional[str]) -> str:
+    """First 8 chars of a key (for the Redis exhaustion flag + logs). Mirrors
+    api_budget_service._serper_key_prefix scoping."""
+    raw = (key or "").strip()
+    return raw[:8] if raw else "nokey"
+
+
+def _resolve_serper_keys() -> List[str]:
+    """Resolve the ORDERED Serper key list, fresh per call (so a Railway env
+    update takes effect without a restart).
+
+    Priority: SERPER_API_KEYS (comma-separated, order = priority; trimmed,
+    blanks skipped, de-duplicated preserving order). Falls back to the single
+    module-level SERPER_API_KEY when SERPER_API_KEYS is unset/empty — this is
+    what preserves backward compatibility AND test monkeypatching of the
+    SERPER_API_KEY module attr.
+    """
+    raw_multi = (os.environ.get("SERPER_API_KEYS") or "").strip()
+    keys: List[str] = []
+    if raw_multi:
+        for part in raw_multi.split(","):
+            k = part.strip()
+            if k and k not in keys:
+                keys.append(k)
+    if keys:
+        return keys
+    # Single-key fallback — read the MODULE attr (not os.getenv) so tests that
+    # monkeypatch serper_service.SERPER_API_KEY keep working and a runtime
+    # override is honoured.
+    single = (SERPER_API_KEY or "")
+    single = single.strip() if isinstance(single, str) else ""
+    return [single] if single else []
+
+
+def _is_serper_key_exhausted(key: str) -> bool:
+    """True if the per-key exhaustion flag is set in Redis. Fail-open: on Redis
+    error / unavailability the key is treated as NOT exhausted (do not block a
+    healthy key just because Redis is down)."""
+    try:
+        from app.services.cache_service import _redis_get
+        return bool(_redis_get(_SERPER_EXHAUSTED_PREFIX + _serper_key_prefix8(key)))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _mark_serper_key_exhausted(key: str) -> None:
+    """Set the per-key exhaustion flag in Redis with a MODERATE TTL and log a
+    WARNING once per key per process. Best-effort — a Redis failure just means
+    the flag is not persisted (the failover for THIS call still rotated)."""
+    prefix = _serper_key_prefix8(key)
+    try:
+        from app.services.cache_service import _redis_set
+        _redis_set(_SERPER_EXHAUSTED_PREFIX + prefix, "1", ex=_SERPER_EXHAUSTED_TTL)
+    except Exception:  # noqa: BLE001
+        pass
+    if prefix not in _serper_exhausted_logged:
+        _serper_exhausted_logged.add(prefix)
+        logger.warning(
+            "SERPER_KEY_EXHAUSTED key=%s… marked exhausted (ttl=%ss); "
+            "rotating to next key",
+            prefix,
+            _SERPER_EXHAUSTED_TTL,
+        )
+
+
+def _active_serper_key() -> Optional[str]:
+    """The first key in priority order that is NOT currently marked exhausted.
+    Returns None when there are no keys OR every key is exhausted (caller then
+    degrades exactly as the legacy 'SERPER_API_KEY not set' path)."""
+    for key in _resolve_serper_keys():
+        if not _is_serper_key_exhausted(key):
+            return key
+    return None
+
+
+def _response_signals_exhaustion(status_code: Optional[int], body_text: str) -> bool:
+    """Detect credit depletion from a Serper response. Two independent signals:
+      1. HTTP status in {402, 403} (payment/forbidden — credit-related), OR
+      2. body/message contains 'credit' (case-insensitive) — a depleted free
+         key returns {"message":"Not enough credits"} (observed with HTTP 400).
+    A transient 500 / non-credit 4xx does NOT match (no 'credit' substring,
+    status not in the set) so it never marks a key exhausted."""
+    if status_code in (402, 403):
+        return True
+    if isinstance(body_text, str) and body_text and "credit" in body_text.lower():
+        return True
+    return False
+
+
+async def _serper_post(client, path: str, payload: Dict[str, Any]):
+    """Shared Serper POST with credit-exhaustion failover.
+
+    Picks the active (first non-exhausted) key, POSTs to
+    `{SERPER_BASE_URL}{path}` with the standard headers, and — if the response
+    signals credit depletion — marks that key exhausted and retries with the
+    NEXT non-exhausted key (bounded to len(keys) attempts). Returns the httpx
+    Response of the FIRST non-exhaustion result (which the caller inspects /
+    raise_for_status()es exactly as before), so response handling is unchanged.
+
+    On the happy path (single healthy key) this fires exactly ONE POST and adds
+    only one cheap Redis exhaustion-check read — byte-identical behaviour.
+
+    The caller is responsible for the `if not <key>` guard BEFORE calling this
+    (preserving the legacy short-circuit + no-record_usage semantics). Callers
+    pass the active key implicitly via this helper; a None active key means all
+    keys are exhausted and this helper is not reached.
+    """
+    keys = _resolve_serper_keys()
+    attempts = 0
+    max_attempts = max(1, len(keys))
+    last_response = None
+    while attempts < max_attempts:
+        key = _active_serper_key()
+        if not key:
+            # All keys exhausted mid-loop — return the last response (if any) so
+            # the caller's existing handling degrades gracefully.
+            break
+        attempts += 1
+        response = await client.post(
+            f"{SERPER_BASE_URL}{path}",
+            headers={
+                "X-API-KEY": key,
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+        last_response = response
+        # Inspect for credit exhaustion. Reading .text on a MagicMock is cheap;
+        # on a real httpx.Response it is the already-buffered body.
+        try:
+            status = getattr(response, "status_code", None)
+            body_text = getattr(response, "text", "") or ""
+        except Exception:  # noqa: BLE001
+            status = None
+            body_text = ""
+        if _response_signals_exhaustion(status, body_text):
+            _mark_serper_key_exhausted(key)
+            continue  # rotate to the next non-exhausted key
+        return response
+    return last_response
+
+
+# ============================================
 # ORIGINAL FUNCTIONS (backward compatibility)
 # ============================================
 
@@ -72,19 +252,16 @@ async def search_web(
     Returns:
         Search results with organic, featured snippets, etc.
     """
-    if not SERPER_API_KEY:
+    if not _active_serper_key():
         logger.warning("SERPER_API_KEY not set")
         return {"organic": [], "error": "Search not configured"}
-    
+
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(
-                f"{SERPER_BASE_URL}/search",
-                headers={
-                    "X-API-KEY": SERPER_API_KEY,
-                    "Content-Type": "application/json"
-                },
-                json={
+            response = await _serper_post(
+                client,
+                "/search",
+                {
                     "q": query,
                     "num": num_results,
                     "gl": country,
@@ -153,13 +330,10 @@ async def _do_serper_shopping(product: str, gl: str) -> Dict[str, Any]:
     lives in the caller (search_product_prices)."""
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            shopping_response = await client.post(
-                f"{SERPER_BASE_URL}/shopping",
-                headers={
-                    "X-API-KEY": SERPER_API_KEY,
-                    "Content-Type": "application/json"
-                },
-                json={
+            shopping_response = await _serper_post(
+                client,
+                "/shopping",
+                {
                     "q": product,
                     "gl": gl,
                     "hl": "en",
@@ -226,7 +400,7 @@ async def search_product_prices(
     called if both shopping calls return empty (Saudi-only items like
     Almarai laban — pipeline naturally falls through to Tier 1.5).
     """
-    if not SERPER_API_KEY:
+    if not _active_serper_key():
         return {"shopping": [], "organic": [], "error": "Search not configured"}
 
     # HOTFIX-2 round 2 — drop GPT-emitted " price"/"buy"/etc. tails.
@@ -309,7 +483,7 @@ async def search_price_organic(
     Organic search for price context — only called when Tier 1 shopping fails.
     Returns organic results for GPT Tier 2 price extraction.
     """
-    if not SERPER_API_KEY:
+    if not _active_serper_key():
         return {"organic": [], "error": "Search not configured"}
 
     country_terms = {
@@ -325,13 +499,10 @@ async def search_price_organic(
 
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(
-                f"{SERPER_BASE_URL}/search",
-                headers={
-                    "X-API-KEY": SERPER_API_KEY,
-                    "Content-Type": "application/json"
-                },
-                json={
+            response = await _serper_post(
+                client,
+                "/search",
+                {
                     "q": search_query,
                     "gl": country,
                     "hl": "en",
@@ -408,18 +579,15 @@ async def search_videos(
     num_results: int = 5
 ) -> Dict[str, Any]:
     """Search for videos (reviews, tutorials, etc.)."""
-    if not SERPER_API_KEY:
+    if not _active_serper_key():
         return {"videos": [], "error": "Search not configured"}
-    
+
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(
-                f"{SERPER_BASE_URL}/videos",
-                headers={
-                    "X-API-KEY": SERPER_API_KEY,
-                    "Content-Type": "application/json"
-                },
-                json={
+            response = await _serper_post(
+                client,
+                "/videos",
+                {
                     "q": query,
                     "num": num_results
                 }
@@ -438,18 +606,15 @@ async def search_images(
     num_results: int = 5
 ) -> Dict[str, Any]:
     """Search for product images."""
-    if not SERPER_API_KEY:
+    if not _active_serper_key():
         return {"images": [], "error": "Search not configured"}
-    
+
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(
-                f"{SERPER_BASE_URL}/images",
-                headers={
-                    "X-API-KEY": SERPER_API_KEY,
-                    "Content-Type": "application/json"
-                },
-                json={
+            response = await _serper_post(
+                client,
+                "/images",
+                {
                     "q": query,
                     "num": num_results
                 }
@@ -477,18 +642,15 @@ async def search_news(
     num_results: int = 5
 ) -> Dict[str, Any]:
     """Search for recent news about a product."""
-    if not SERPER_API_KEY:
+    if not _active_serper_key():
         return {"news": [], "error": "Search not configured"}
-    
+
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(
-                f"{SERPER_BASE_URL}/news",
-                headers={
-                    "X-API-KEY": SERPER_API_KEY,
-                    "Content-Type": "application/json"
-                },
-                json={
+            response = await _serper_post(
+                client,
+                "/news",
+                {
                     "q": query,
                     "num": num_results
                 }
@@ -496,7 +658,7 @@ async def search_news(
             response.raise_for_status()
             record_usage("serper")
             return response.json()
-    
+
     except Exception as e:
         logger.error(f"News search error: {e}")
         return {"news": [], "error": str(e)}

--- a/app/services/serper_service.py
+++ b/app/services/serper_service.py
@@ -124,10 +124,22 @@ def _mark_serper_key_exhausted(key: str) -> None:
 
 
 def _active_serper_key() -> Optional[str]:
-    """The first key in priority order that is NOT currently marked exhausted.
-    Returns None when there are no keys OR every key is exhausted (caller then
-    degrades exactly as the legacy 'SERPER_API_KEY not set' path)."""
-    for key in _resolve_serper_keys():
+    """The active Serper key.
+
+    SINGLE-KEY INERT (the common prod case: only SERPER_API_KEY set, no
+    SERPER_API_KEYS): with 0 or 1 resolved keys there is NO exhaustion machinery
+    — return the single key (or None) directly with NO Redis exhaustion read.
+    This is byte-identical to the pre-multikey behaviour AND prevents a
+    single-key prod from ever self-skipping its own (only) key on a stale flag.
+
+    MULTI-KEY (>=2 resolved keys): return the first key in priority order that
+    is NOT currently marked exhausted (Redis-checked). Returns None when every
+    key is exhausted (caller then degrades exactly as the legacy 'SERPER_API_KEY
+    not set' path)."""
+    keys = _resolve_serper_keys()
+    if len(keys) <= 1:
+        return keys[0] if keys else None
+    for key in keys:
         if not _is_serper_key_exhausted(key):
             return key
     return None
@@ -136,13 +148,23 @@ def _active_serper_key() -> Optional[str]:
 def _response_signals_exhaustion(status_code: Optional[int], body_text: str) -> bool:
     """Detect credit depletion from a Serper response. Two independent signals:
       1. HTTP status in {402, 403} (payment/forbidden — credit-related), OR
-      2. body/message contains 'credit' (case-insensitive) — a depleted free
-         key returns {"message":"Not enough credits"} (observed with HTTP 400).
-    A transient 500 / non-credit 4xx does NOT match (no 'credit' substring,
-    status not in the set) so it never marks a key exhausted."""
+      2. an ERROR response (status >= 400) whose body contains 'credit'
+         (case-insensitive) — a depleted free key returns
+         {"message":"Not enough credits"} (observed with HTTP 400).
+
+    The 'credit' substring is STATUS-GATED to status >= 400: a legit HTTP 200
+    result body containing 'credit'/'accredited'/'credited' (e.g. a product
+    named "credit card") must NOT false-positive as depletion. A transient 500
+    / non-credit 4xx still does NOT match (no 'credit' substring)."""
     if status_code in (402, 403):
         return True
-    if isinstance(body_text, str) and body_text and "credit" in body_text.lower():
+    if (
+        status_code is not None
+        and status_code >= 400
+        and isinstance(body_text, str)
+        and body_text
+        and "credit" in body_text.lower()
+    ):
         return True
     return False
 
@@ -166,6 +188,23 @@ async def _serper_post(client, path: str, payload: Dict[str, Any]):
     keys are exhausted and this helper is not reached.
     """
     keys = _resolve_serper_keys()
+
+    # SINGLE-KEY INERT: 0 or 1 resolved keys (the common prod case) engage NO
+    # exhaustion machinery — one direct POST with the single key, NO
+    # _is_serper_key_exhausted read and NO _mark_serper_key_exhausted write and
+    # NO rotation. Byte-identical to the pre-multikey single-POST path. The
+    # exhaustion/rotation loop below runs ONLY when there are >=2 keys.
+    if len(keys) <= 1:
+        key = keys[0] if keys else None
+        return await client.post(
+            f"{SERPER_BASE_URL}{path}",
+            headers={
+                "X-API-KEY": key,
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+
     attempts = 0
     max_attempts = max(1, len(keys))
     last_response = None

--- a/tests/test_serper_multikey_failover.py
+++ b/tests/test_serper_multikey_failover.py
@@ -1,0 +1,307 @@
+"""genuine-price serper-multikey — multi-key Serper credit-exhaustion failover.
+
+A single free Serper key holds a finite lifetime credit pool; when it depletes
+mid-run the warmer cron (and live compares) silently degrade to `estimated`.
+This suite pins the failover layer added to `serper_service`:
+
+  (a) single SERPER_API_KEY, healthy   -> used, byte-identical, no rotation
+  (b) SERPER_API_KEYS="k1,k2,k3", k1 depleted -> k1 marked exhausted, k2 used,
+      call succeeds
+  (c) all keys exhausted -> graceful degradation (same as legacy depleted path)
+  (d) exhaustion flag persists (2nd call skips the exhausted key, no re-hit)
+  (e) the active key drives api_budget_service._serper_key_prefix()
+  (f) a transient 500 (not a credit error) does NOT mark the key exhausted
+
+Redis / cache_service is mocked with an in-memory dict so the exhaustion flag
+is observable without a live Redis. httpx is mocked at the module level exactly
+as the existing serper tests do (`app.services.serper_service.httpx.AsyncClient`).
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.services import serper_service
+from app.services import api_budget_service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int = 200, json_data: dict | None = None,
+                   text: str = "") -> MagicMock:
+    """A response whose .text is a real str (so the exhaustion predicate can
+    read the credit-depletion message the way a real httpx.Response exposes it)."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data if json_data is not None else {"organic": []}
+    resp.text = text
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    return resp
+
+
+def _patch_httpx_capture(responses):
+    """Patch httpx.AsyncClient. `.post(url, headers=..., json=...)` returns
+    responses[i] in order and records the X-API-KEY header of each call so
+    tests can assert WHICH key was used per attempt."""
+    state = {"n": 0, "keys": []}
+
+    class _AsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            headers = kwargs.get("headers", {})
+            state["keys"].append(headers.get("X-API-KEY"))
+            r = responses[state["n"]]
+            state["n"] += 1
+            return r
+
+    return patch("app.services.serper_service.httpx.AsyncClient", _AsyncClient), state
+
+
+class _FakeRedis:
+    """Minimal in-memory Redis replacement exercised via the cache_service
+    helpers serper_service imports (_redis_get / _redis_set)."""
+
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+
+    def set(self, key, value):
+        self.store[key] = value
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Route serper_service's lazy cache_service._redis_get/_set imports at an
+    in-memory dict so exhaustion flags are observable + persistent within a test."""
+    import app.services.cache_service as cache_service
+    r = _FakeRedis()
+    monkeypatch.setattr(cache_service, "redis_client", r)
+    # Reset the per-process WARNING de-dupe set between tests.
+    serper_service._serper_exhausted_logged.clear()
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _clear_multikey_env(monkeypatch):
+    """Ensure SERPER_API_KEYS is unset unless a test sets it (isolation)."""
+    monkeypatch.delenv("SERPER_API_KEYS", raising=False)
+    serper_service._serper_exhausted_logged.clear()
+
+
+_NOT_ENOUGH_CREDITS = '{"message":"Not enough credits"}'
+
+
+# ---------------------------------------------------------------------------
+# (a) single key, healthy -> byte-identical, no rotation, one POST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_key_healthy_no_rotation(monkeypatch, fake_redis):
+    monkeypatch.setattr(serper_service, "SERPER_API_KEY", "solo-key")
+    resp = _mock_response(200, {"organic": [{"title": "x"}]})
+    ctx, state = _patch_httpx_capture([resp])
+    with ctx:
+        with patch.object(serper_service, "record_usage") as mock_record:
+            result = await serper_service.search_web("test query")
+    assert state["n"] == 1, "healthy single key must fire exactly ONE POST"
+    assert state["keys"] == ["solo-key"]
+    assert result == {"organic": [{"title": "x"}]}
+    mock_record.assert_called_with("serper")
+    # No exhaustion flag set for a healthy key.
+    assert not serper_service._is_serper_key_exhausted("solo-key")
+
+
+# ---------------------------------------------------------------------------
+# (b) k1 depleted -> k1 marked exhausted, k2 used, call succeeds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k1_depleted_rotates_to_k2(monkeypatch, fake_redis):
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2,k3")
+    # k1 returns a 402/credit body; k2 returns a healthy 200.
+    depleted = _mock_response(402, {}, text=_NOT_ENOUGH_CREDITS)
+    healthy = _mock_response(200, {"organic": [{"title": "ok"}]})
+    ctx, state = _patch_httpx_capture([depleted, healthy])
+    with ctx:
+        with patch.object(serper_service, "record_usage") as mock_record:
+            result = await serper_service.search_web("q")
+    assert state["keys"] == ["k1", "k2"], "k1 tried, then rotated to k2"
+    assert result == {"organic": [{"title": "ok"}]}
+    mock_record.assert_called_with("serper")
+    assert serper_service._is_serper_key_exhausted("k1"), "k1 must be flagged"
+    assert not serper_service._is_serper_key_exhausted("k2")
+
+
+@pytest.mark.asyncio
+async def test_credit_body_on_400_also_rotates(monkeypatch, fake_redis):
+    """A depleted free key today returns HTTP 400 + 'Not enough credits' body;
+    the substring signal (not just status 402/403) must catch it."""
+    monkeypatch.setenv("SERPER_API_KEYS", "kA,kB")
+    depleted = _mock_response(400, {}, text=_NOT_ENOUGH_CREDITS)
+    healthy = _mock_response(200, {"organic": []})
+    ctx, state = _patch_httpx_capture([depleted, healthy])
+    with ctx:
+        await serper_service.search_web("q")
+    assert state["keys"] == ["kA", "kB"]
+    assert serper_service._is_serper_key_exhausted("kA")
+
+
+# ---------------------------------------------------------------------------
+# (c) all keys exhausted -> graceful degradation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_keys_exhausted_degrades_gracefully(monkeypatch, fake_redis):
+    monkeypatch.setenv("SERPER_API_KEYS", "x1,x2")
+    # Pre-mark both keys exhausted.
+    serper_service._mark_serper_key_exhausted("x1")
+    serper_service._mark_serper_key_exhausted("x2")
+    # No httpx call should occur — the guard short-circuits.
+    ctx, state = _patch_httpx_capture([])
+    with ctx:
+        with patch.object(serper_service, "record_usage") as mock_record:
+            result = await serper_service.search_web("q")
+    assert state["n"] == 0, "all-exhausted must NOT hit the network"
+    assert result == {"organic": [], "error": "Search not configured"}
+    mock_record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_keys_configured_degrades_like_legacy(monkeypatch, fake_redis):
+    """SERPER_API_KEY=None and no SERPER_API_KEYS -> legacy 'not configured'."""
+    monkeypatch.setattr(serper_service, "SERPER_API_KEY", None)
+    ctx, state = _patch_httpx_capture([])
+    with ctx:
+        with patch.object(serper_service, "record_usage") as mock_record:
+            result = await serper_service.search_web("q")
+    assert state["n"] == 0
+    assert result == {"organic": [], "error": "Search not configured"}
+    mock_record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (d) exhaustion flag persists — a second call skips the exhausted key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_persists_second_call_skips_key(monkeypatch, fake_redis):
+    monkeypatch.setenv("SERPER_API_KEYS", "p1,p2")
+    # Call 1: p1 depleted -> rotate to p2 (healthy).
+    depleted = _mock_response(403, {}, text="forbidden: not enough credit")
+    healthy1 = _mock_response(200, {"organic": [{"n": 1}]})
+    ctx1, state1 = _patch_httpx_capture([depleted, healthy1])
+    with ctx1:
+        await serper_service.search_web("q1")
+    assert state1["keys"] == ["p1", "p2"]
+    assert serper_service._is_serper_key_exhausted("p1")
+
+    # Call 2: p1 is already flagged in Redis -> active key is p2 from the start,
+    # so the FIRST (and only) POST uses p2, no re-hit of p1.
+    healthy2 = _mock_response(200, {"organic": [{"n": 2}]})
+    ctx2, state2 = _patch_httpx_capture([healthy2])
+    with ctx2:
+        result = await serper_service.search_web("q2")
+    assert state2["keys"] == ["p2"], "2nd call must skip the exhausted p1 entirely"
+    assert state2["n"] == 1
+    assert result == {"organic": [{"n": 2}]}
+
+
+# ---------------------------------------------------------------------------
+# (e) the active key drives api_budget_service._serper_key_prefix()
+# ---------------------------------------------------------------------------
+
+
+def test_active_key_drives_budget_prefix(monkeypatch, fake_redis):
+    monkeypatch.setenv("SERPER_API_KEYS", "aaaaaaaa11,bbbbbbbb22,cccccccc33")
+    # No exhaustion -> first key active -> prefix = first 8 of aaaaaaaa11.
+    assert api_budget_service._serper_key_prefix() == "aaaaaaaa"
+    # Exhaust the first key -> prefix tracks the next active key.
+    serper_service._mark_serper_key_exhausted("aaaaaaaa11")
+    assert api_budget_service._serper_key_prefix() == "bbbbbbbb"
+    # Exhaust the second -> tracks the third.
+    serper_service._mark_serper_key_exhausted("bbbbbbbb22")
+    assert api_budget_service._serper_key_prefix() == "cccccccc"
+
+
+def test_budget_prefix_single_key_backward_compatible(monkeypatch, fake_redis):
+    """With only SERPER_API_KEY set (no SERPER_API_KEYS), the counter prefix is
+    the single key's 8-char prefix — byte-identical to the pre-multikey scoping."""
+    monkeypatch.delenv("SERPER_API_KEYS", raising=False)
+    monkeypatch.setenv("SERPER_API_KEY", "singlekey1234")
+    # api_budget_service reads via serper_service._resolve_serper_keys which
+    # falls back to the SERPER_API_KEY module attr; align both.
+    monkeypatch.setattr(serper_service, "SERPER_API_KEY", "singlekey1234")
+    assert api_budget_service._serper_key_prefix() == "singleke"
+
+
+def test_budget_prefix_nokey_sentinel(monkeypatch, fake_redis):
+    monkeypatch.delenv("SERPER_API_KEYS", raising=False)
+    monkeypatch.delenv("SERPER_API_KEY", raising=False)
+    monkeypatch.setattr(serper_service, "SERPER_API_KEY", None)
+    assert api_budget_service._serper_key_prefix() == "nokey"
+
+
+# ---------------------------------------------------------------------------
+# (f) a transient 500 (not a credit error) does NOT mark the key exhausted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transient_500_does_not_mark_exhausted(monkeypatch, fake_redis):
+    monkeypatch.setenv("SERPER_API_KEYS", "t1,t2")
+    # A 500 with a non-credit body: _serper_post returns it as-is (no rotation),
+    # and search_web's raise_for_status() turns it into the {error} degrade.
+    transient = _mock_response(500, {}, text="Internal Server Error")
+    ctx, state = _patch_httpx_capture([transient])
+    with ctx:
+        result = await serper_service.search_web("q")
+    assert state["keys"] == ["t1"], "a 500 must NOT rotate keys"
+    assert state["n"] == 1, "no failover POST for a transient error"
+    assert not serper_service._is_serper_key_exhausted("t1"), \
+        "a transient 500 must NOT mark the key exhausted"
+    assert result.get("error"), "raise_for_status still degrades to an error dict"
+
+
+def test_response_signals_exhaustion_predicate():
+    """Unit-pin the detection predicate itself."""
+    f = serper_service._response_signals_exhaustion
+    assert f(402, "") is True
+    assert f(403, "") is True
+    assert f(400, '{"message":"Not enough credits"}') is True
+    assert f(200, "plenty of CREDIT left") is True  # case-insensitive substring
+    assert f(500, "Internal Server Error") is False
+    assert f(429, "rate limited") is False
+    assert f(200, "") is False
+    # A non-str body (e.g. a MagicMock's auto .text) must not blow up / match.
+    assert f(200, MagicMock()) is False
+
+
+def test_resolve_keys_multikey_trims_and_dedupes(monkeypatch):
+    monkeypatch.setenv("SERPER_API_KEYS", " k1 , , k2 ,k1, k3 ")
+    assert serper_service._resolve_serper_keys() == ["k1", "k2", "k3"]
+
+
+def test_resolve_keys_falls_back_to_single(monkeypatch):
+    monkeypatch.delenv("SERPER_API_KEYS", raising=False)
+    monkeypatch.setattr(serper_service, "SERPER_API_KEY", "onlyone")
+    assert serper_service._resolve_serper_keys() == ["onlyone"]

--- a/tests/test_serper_multikey_failover.py
+++ b/tests/test_serper_multikey_failover.py
@@ -288,7 +288,12 @@ def test_response_signals_exhaustion_predicate():
     assert f(402, "") is True
     assert f(403, "") is True
     assert f(400, '{"message":"Not enough credits"}') is True
-    assert f(200, "plenty of CREDIT left") is True  # case-insensitive substring
+    # STATUS-GATED: a legit HTTP 200 body containing 'credit'/'accredited'/
+    # 'credited' (e.g. a product named "credit card") must NOT false-positive.
+    assert f(200, "plenty of CREDIT left") is False
+    assert f(200, "the best credit card in Bahrain") is False
+    # A real depletion is a >=400 error whose body carries the credit message.
+    assert f(400, "Not enough credits") is True
     assert f(500, "Internal Server Error") is False
     assert f(429, "rate limited") is False
     assert f(200, "") is False


### PR DESCRIPTION
## Why
A single free Serper key (~2,500 credits) depletes in ~1-2 days under the 12h warmer cron, stalling discovery mid-run. This adds automatic multi-key failover so a pool of keys (~4 free ≈ 10,000 credits ≈ a week/cycle) keeps the cron and live traffic running.

## What
- New `SERPER_API_KEYS` (comma-separated, priority order). When the active key returns depletion (HTTP 402/403, or ≥400 with a "credit" body — a depleted free key returns 400 `Not enough credits`), it's marked exhausted in Redis (6h TTL) and the system rotates to the next key. Applies to both the warmer cron and live traffic. Budget counter stays per-key.
- **Single-key is fully INERT**: with only `SERPER_API_KEY` set (0/1 resolved keys), `_serper_post` does one direct POST with **zero** exhaustion Redis reads/writes and no rotation — byte-identical to pre-change. The failover machinery engages only at ≥2 keys. This preserves BC exactly and makes it impossible for single-key prod to self-skip its only key.

## Verification (built as impl → independent verify; both fixes gated)
An initial build had 3 bugs the independent verify caught and a fix round resolved:
- CRIT: predicate matched "credit" on HTTP 200 → fixed by status-gating (≥400 only); a legit 200 body with "credit card"/"accredited" no longer false-positives.
- HIGH: exhaustion gate read shared Upstash even single-key → 17 serper-mock tests failed → fixed by single-key-inert (zero Redis I/O).
- MED: stray `serper:exhausted:*` flags written to prod Redis (incl. the active key) → cleared from Upstash + prevented by single-key-inert + multi-key tests using an in-memory fake Redis.

Final: failover re-review **clean** (single-key inert, predicate fixed, multi-key rotation correct, no live-Upstash writes); regression **clean** — branch-only-NEW == [] (the only 2 residual failures are the pre-existing `test_algolia_tier2_wiring` live-mock-preempt flakes, confirmed on clean main); golden corpus green; `test_serper_multikey_failover` 13/13, `test_serper_gcc_fallback`/`test_serper_record_usage` pass unedited.

## Activation
After deploy, set `SERPER_API_KEYS=key1,key2,key3,key4` on `web` + `price-warmer`. Rotation is automatic; per-key burn visible via `budget:serper:<key8>:lifetime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)