### PR TITLE
fix(mobile): converted-USD honesty caption + image-compare lighting copy + cohort-priority selectability

### DIFF
--- a/SmartCompareApp/__tests__/EditPreferencesFlow.test.tsx
+++ b/SmartCompareApp/__tests__/EditPreferencesFlow.test.tsx
@@ -101,12 +101,13 @@ describe('EditPreferencesFlow', () => {
     mockSavePreferences.mockResolvedValue({ success: true });
   });
 
-  it('pre-fills priorities page with values from getPreferences()', async () => {
+  it('pre-fills priorities, mapping cohort-seeded values to canonical display keys', async () => {
     const { findByTestId } = renderScreen();
     const page = await findByTestId('page-priorities');
-    expect(JSON.parse(page.props.value)).toEqual(
-      FIXTURE_PREFS.priorities,
-    );
+    // FIXTURE has cohort-derived priorities (quality_reliability, best_price)
+    // which EditPreferencesFlow canonicalizes on load so the picker can show
+    // and edit them instead of leaving them invisible (device bug 2026-07-04).
+    expect(JSON.parse(page.props.value)).toEqual(['quality', 'price']);
   });
 
   it('Continue advances through all 4 pages and last page shows Save', async () => {
@@ -160,8 +161,9 @@ describe('EditPreferencesFlow', () => {
     await act(async () => { fireEvent.press(saveBtn); });
 
     await waitFor(() => expect(mockSavePreferences).toHaveBeenCalledTimes(1));
+    // priorities are saved as their canonicalized form (see load-time mapping).
     expect(mockSavePreferences).toHaveBeenCalledWith(
-      expect.objectContaining(FIXTURE_PREFS),
+      expect.objectContaining({ ...FIXTURE_PREFS, priorities: ['quality', 'price'] }),
     );
     expect(mockNavigation.goBack).toHaveBeenCalled();
   });

--- a/SmartCompareApp/__tests__/ResultsContent.imageUrl.test.tsx
+++ b/SmartCompareApp/__tests__/ResultsContent.imageUrl.test.tsx
@@ -70,7 +70,7 @@ jest.mock('../src/components/hero/RevealBurst', () => ({ RevealBurst: () => null
 jest.mock('../src/components/CohortBadge', () => ({ CohortBadge: () => null }));
 jest.mock('../src/components/FeedbackCard', () => ({ __esModule: true, default: () => null }));
 jest.mock('../src/components/results/ResultsAccordion', () => ({ ResultsAccordion: () => null }));
-jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false) }));
+jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false), isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd') }));
 
 import { ResultsContent } from '../src/components/results/ResultsContent';
 

--- a/SmartCompareApp/__tests__/ResultsContent.partialNote.test.tsx
+++ b/SmartCompareApp/__tests__/ResultsContent.partialNote.test.tsx
@@ -78,7 +78,7 @@ jest.mock('../src/components/FeedbackCard', () => ({ __esModule: true, default: 
 jest.mock('../src/components/results/ResultsAccordion', () => ({
   ResultsAccordion: () => null,
 }));
-jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false) }));
+jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false), isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd') }));
 
 import { ResultsContent } from '../src/components/results/ResultsContent';
 

--- a/SmartCompareApp/__tests__/ResultsContent.perCategory.test.tsx
+++ b/SmartCompareApp/__tests__/ResultsContent.perCategory.test.tsx
@@ -54,7 +54,7 @@ jest.mock('../src/components/results/ResultsAccordion', () => ({ ResultsAccordio
 
 // anyEstimated factory — overridden per fixture so fragrances suppresses
 // the Price pill while other categories keep all 3.
-jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false) }));
+jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false), isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd') }));
 
 import { ResultsContent } from '../src/components/results/ResultsContent';
 import { anyEstimated } from '../src/services/sourceMethod';

--- a/SmartCompareApp/__tests__/ResultsContent.scoreGuard.test.tsx
+++ b/SmartCompareApp/__tests__/ResultsContent.scoreGuard.test.tsx
@@ -74,7 +74,7 @@ jest.mock('../src/components/FeedbackCard', () => ({ __esModule: true, default: 
 jest.mock('../src/components/results/ResultsAccordion', () => ({
   ResultsAccordion: () => null,
 }));
-jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false) }));
+jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false), isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd') }));
 
 import { ResultsContent } from '../src/components/results/ResultsContent';
 

--- a/SmartCompareApp/__tests__/ResultsContent.specsComparisonShape.test.tsx
+++ b/SmartCompareApp/__tests__/ResultsContent.specsComparisonShape.test.tsx
@@ -54,7 +54,7 @@ jest.mock('../src/components/results/PersonalizationChip', () => ({ Personalizat
 jest.mock('../src/components/hero/RevealBurst', () => ({ RevealBurst: () => null }));
 jest.mock('../src/components/CohortBadge', () => ({ CohortBadge: () => null }));
 jest.mock('../src/components/FeedbackCard', () => ({ __esModule: true, default: () => null }));
-jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false) }));
+jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false), isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd') }));
 
 import { ResultsContent } from '../src/components/results/ResultsContent';
 import { colors } from '../src/theme';

--- a/SmartCompareApp/__tests__/ResultsContent.v2Wiring.test.tsx
+++ b/SmartCompareApp/__tests__/ResultsContent.v2Wiring.test.tsx
@@ -55,7 +55,7 @@ jest.mock('../src/components/hero/RevealBurst', () => ({ RevealBurst: () => null
 jest.mock('../src/components/CohortBadge', () => ({ CohortBadge: () => null }));
 jest.mock('../src/components/FeedbackCard', () => ({ __esModule: true, default: () => null }));
 jest.mock('../src/components/results/ResultsAccordion', () => ({ ResultsAccordion: () => null }));
-jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false) }));
+jest.mock('../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false), isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd') }));
 
 // Real renders for the units under test (DimensionBars, ConfidencePills,
 // ConfidenceDetailsSheet, FactualVerdict, ProductImage) — those carry the

--- a/SmartCompareApp/__tests__/components/PrioritiesPicker.test.tsx
+++ b/SmartCompareApp/__tests__/components/PrioritiesPicker.test.tsx
@@ -63,4 +63,36 @@ describe('PrioritiesPicker (S2.X3 OptionRow rewrite)', () => {
     fireEvent.press(getByTestId('priority-latest_features'));
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('renders cohort-seeded priorities as selected canonical rows (device bug 2026-07-04)', () => {
+    // A demographics-seeded user's priorities are stored as cohort-derived
+    // enums (best_price / quality_reliability). Before the fix these were
+    // INVISIBLE in the picker yet still consumed the 3-cap, so no priority
+    // could be chosen. They must now render as selected canonical rows.
+    const { getByTestId } = render(
+      <PrioritiesPicker
+        value={['best_price', 'quality_reliability']}
+        onChange={jest.fn()}
+      />
+    );
+    expect(
+      getByTestId('priority-price').props.accessibilityState?.selected
+    ).toBe(true);
+    expect(
+      getByTestId('priority-quality').props.accessibilityState?.selected
+    ).toBe(true);
+  });
+
+  it('still allows adding a visible priority when cohort-seeded (cap not silently full)', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <PrioritiesPicker
+        value={['best_price', 'quality_reliability']}
+        onChange={onChange}
+      />
+    );
+    // 2 cohort priorities map to [price, quality]; a 3rd visible pick works.
+    fireEvent.press(getByTestId('priority-durability'));
+    expect(onChange).toHaveBeenCalledWith(['price', 'quality', 'durability']);
+  });
 });

--- a/SmartCompareApp/__tests__/components/ResultsContent.render.test.tsx
+++ b/SmartCompareApp/__tests__/components/ResultsContent.render.test.tsx
@@ -134,6 +134,7 @@ jest.mock('../../src/components/results/ResultsAccordion', () => ({
 }));
 jest.mock('../../src/services/sourceMethod', () => ({
   anyEstimated: jest.fn(() => false),
+  isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd'),
 }));
 
 import { ResultsContent } from '../../src/components/results/ResultsContent';
@@ -497,5 +498,26 @@ describe('ResultsContent — render coverage', () => {
       <ResultsContent {...baseProps} result={result} />
     );
     expect(queryByTestId('results-content-runner-up-wins')).toBeNull();
+  });
+});
+
+describe('ResultsContent — converted-USD honesty caption', () => {
+  it('renders the caption below a converted_usd price', () => {
+    const products = [
+      { ...mockProducts[0], price: { ...mockProducts[0].price, source_method: 'converted_usd' } },
+      mockProducts[1],
+    ];
+    const { getByTestId } = render(<ResultsContent {...baseProps} products={products} />);
+    expect(getByTestId('results-product-converted-0')).toBeTruthy();
+  });
+
+  it('does NOT render the caption for genuine local prices', () => {
+    const products = [
+      { ...mockProducts[0], price: { ...mockProducts[0].price, source_method: 'local_bhd' } },
+      { ...mockProducts[1], price: { ...mockProducts[1].price, source_method: 'page_scrape' } },
+    ];
+    const { queryByTestId } = render(<ResultsContent {...baseProps} products={products} />);
+    expect(queryByTestId('results-product-converted-0')).toBeNull();
+    expect(queryByTestId('results-product-converted-1')).toBeNull();
   });
 });

--- a/SmartCompareApp/__tests__/components/ResultsContent.rewriteOrder.test.tsx
+++ b/SmartCompareApp/__tests__/components/ResultsContent.rewriteOrder.test.tsx
@@ -147,6 +147,7 @@ jest.mock('../../src/components/results/ResultsAccordion', () => {
 });
 jest.mock('../../src/services/sourceMethod', () => ({
   anyEstimated: jest.fn(() => false),
+  isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd'),
 }));
 
 import { ResultsContent } from '../../src/components/results/ResultsContent';

--- a/SmartCompareApp/__tests__/components/ResultsContent.runnerUp.test.tsx
+++ b/SmartCompareApp/__tests__/components/ResultsContent.runnerUp.test.tsx
@@ -81,7 +81,7 @@ jest.mock('../../src/components/FeedbackCard', () => ({ __esModule: true, defaul
 jest.mock('../../src/components/results/ResultsAccordion', () => ({
   ResultsAccordion: () => null,
 }));
-jest.mock('../../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false) }));
+jest.mock('../../src/services/sourceMethod', () => ({ anyEstimated: jest.fn(() => false), isConvertedUsd: jest.fn((p: any) => p?.source_method === 'converted_usd') }));
 
 import { ResultsContent } from '../../src/components/results/ResultsContent';
 

--- a/SmartCompareApp/__tests__/components/StreamingProductCard.test.tsx
+++ b/SmartCompareApp/__tests__/components/StreamingProductCard.test.tsx
@@ -111,4 +111,46 @@ describe('StreamingProductCard', () => {
     expect(getByTestId('card-price')).toBeTruthy();
     expect(getByTestId('card-rating')).toBeTruthy();
   });
+
+  it('shows the converted-from-USD caption for a converted_usd price', () => {
+    const { getByTestId } = render(
+      <StreamingProductCard
+        testID="card"
+        stage="prices"
+        product={{
+          name: 'Sauvage',
+          price: { amount: 45, currency: 'BHD', source_method: 'converted_usd' },
+        }}
+      />
+    );
+    expect(getByTestId('card-converted')).toBeTruthy();
+  });
+
+  it('hides the converted caption for a genuine local price', () => {
+    const { queryByTestId } = render(
+      <StreamingProductCard
+        testID="card"
+        stage="prices"
+        product={{
+          name: 'Sauvage',
+          price: { amount: 45, currency: 'BHD', source_method: 'local_bhd' },
+        }}
+      />
+    );
+    expect(queryByTestId('card-converted')).toBeNull();
+  });
+
+  it('hides the converted caption before the price stage is reached', () => {
+    const { queryByTestId } = render(
+      <StreamingProductCard
+        testID="card"
+        stage="specs"
+        product={{
+          name: 'Sauvage',
+          price: { amount: 45, currency: 'BHD', source_method: 'converted_usd' },
+        }}
+      />
+    );
+    expect(queryByTestId('card-converted')).toBeNull();
+  });
 });

--- a/SmartCompareApp/__tests__/services/sourceMethod.test.ts
+++ b/SmartCompareApp/__tests__/services/sourceMethod.test.ts
@@ -8,7 +8,7 @@
  * Critical rule #3 — NO "estimated" / "reference price" / "indicative"
  * (EN) or "تقدير" / "مُقدَّر" (AR) in any returned phrase.
  */
-import { parseSourceMethod, anyEstimated } from '../../src/services/sourceMethod';
+import { parseSourceMethod, anyEstimated, isConvertedUsd } from '../../src/services/sourceMethod';
 
 test.each([
   ['local_bhd', 'Direct local listing'],
@@ -75,4 +75,21 @@ test('parseSourceMethod NEVER returns forbidden words across all approved method
     expect(phrase!).not.toMatch(forbidden);
     expect(phrase!).not.toMatch(forbiddenAr);
   }
+});
+
+// Display-honesty: converted-from-USD prices must be distinguishable from
+// genuine local prices. `isConvertedUsd` gates the caption on those surfaces.
+test('isConvertedUsd is true only for a converted_usd price', () => {
+  expect(isConvertedUsd({ source_method: 'converted_usd' })).toBe(true);
+});
+
+test('isConvertedUsd is false for genuine, estimated, and missing methods', () => {
+  expect(isConvertedUsd({ source_method: 'local_bhd' })).toBe(false);
+  expect(isConvertedUsd({ source_method: 'shopify_json' })).toBe(false);
+  expect(isConvertedUsd({ source_method: 'page_scrape' })).toBe(false);
+  expect(isConvertedUsd({ source_method: 'firecrawl' })).toBe(false);
+  expect(isConvertedUsd({ source_method: 'estimated' })).toBe(false);
+  expect(isConvertedUsd({})).toBe(false);
+  expect(isConvertedUsd(undefined)).toBe(false);
+  expect(isConvertedUsd(null)).toBe(false);
 });

--- a/SmartCompareApp/src/components/PrioritiesPicker.tsx
+++ b/SmartCompareApp/src/components/PrioritiesPicker.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react-native';
 import { OptionRow } from './primitives/OptionRow';
 import { colors, spacing, typography } from '../theme';
+import { toCanonicalPriorities } from '../utils/priorities';
 
 const PRIORITIES = [
   'price',
@@ -87,15 +88,21 @@ export default function PrioritiesPicker({
 }: Props) {
   const { t } = useTranslation();
 
+  // Normalize cohort-seeded priorities to canonical display keys so they
+  // render as selected rows here instead of sitting INVISIBLE while still
+  // consuming the 3-selection cap (which made priorities un-choosable for
+  // demographics-seeded users — device bug 2026-07-04).
+  const selected = toCanonicalPriorities(value);
+
   const toggle = (key: string) => {
-    if (value.includes(key)) {
-      onChange(value.filter((k) => k !== key));
+    if (selected.includes(key)) {
+      onChange(selected.filter((k) => k !== key));
       return;
     }
     // Silent cap per Build Principle #4: engaging, never scary. No
     // shake / haptic / toast on overflow — extra taps are simply no-ops.
-    if (value.length >= MAX_SELECTIONS) return;
-    onChange([...value, key]);
+    if (selected.length >= MAX_SELECTIONS) return;
+    onChange([...selected, key]);
   };
 
   return (
@@ -105,7 +112,7 @@ export default function PrioritiesPicker({
       </Text>
       <View style={styles.list}>
         {PRIORITIES.map((p) => {
-          const active = value.includes(p);
+          const active = selected.includes(p);
           const iconColor = active ? colors.accentDark : colors.text.primary;
           return (
             <OptionRow

--- a/SmartCompareApp/src/components/StreamingProductCard.tsx
+++ b/SmartCompareApp/src/components/StreamingProductCard.tsx
@@ -21,9 +21,12 @@
 
 import React from 'react';
 import { View, Text, StyleSheet, I18nManager, Pressable } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { addScreenshotListener } from 'expo-screen-capture';
 import { CounterTicker } from './CounterTicker';
 import { colors, spacing, typography, radii } from '../theme';
+import { isConvertedUsd } from '../services/sourceMethod';
+import type { SourceMethod } from '../types';
 
 /**
  * Pain-workflow signals the card can emit (B.1 F3.5). The parent threads
@@ -50,6 +53,7 @@ export interface StreamingProductLike {
     amount?: number;
     currency?: string;
     retailer?: string;
+    source_method?: SourceMethod;
   };
   rating?: number;
   reviewCount?: number;
@@ -86,6 +90,7 @@ function reached(current: StreamingStage, target: StreamingStage): boolean {
 
 export function StreamingProductCard({ stage, product, testID, onSignal }: Props) {
   const tid = (suffix: string) => (testID ? `${testID}-${suffix}` : undefined);
+  const { t } = useTranslation();
 
   const showTitle = !!product?.name;
   const showSpecs = reached(stage, 'specs') && !!product?.specs;
@@ -177,19 +182,32 @@ export function StreamingProductCard({ stage, product, testID, onSignal }: Props
 
       {/* Price slot — counter ticker for the BHD value. */}
       {showPrice ? (
-        <View testID={tid('price')} style={styles.priceRow}>
-          <CounterTicker
-            target={Math.round(product!.price!.amount!)}
-            duration={800}
-            suffix={` ${product!.price!.currency ?? 'BHD'}`}
-            style={styles.priceText}
-          />
-          {product!.price!.retailer ? (
-            <Text style={styles.retailerText} numberOfLines={1}>
-              {product!.price!.retailer}
+        <>
+          <View testID={tid('price')} style={styles.priceRow}>
+            <CounterTicker
+              target={Math.round(product!.price!.amount!)}
+              duration={800}
+              suffix={` ${product!.price!.currency ?? 'BHD'}`}
+              style={styles.priceText}
+            />
+            {product!.price!.retailer ? (
+              <Text style={styles.retailerText} numberOfLines={1}>
+                {product!.price!.retailer}
+              </Text>
+            ) : null}
+          </View>
+          {/* Display-honesty: mark a converted-from-USD price so it is not
+              read as a genuine local BHD listing. */}
+          {isConvertedUsd(product?.price) ? (
+            <Text
+              testID={tid('converted')}
+              style={styles.convertedText}
+              numberOfLines={1}
+            >
+              {t('results.convertedUSD')}
             </Text>
           ) : null}
-        </View>
+        </>
       ) : null}
 
       {/* Rating slot — star + numeric value. */}
@@ -270,6 +288,11 @@ const styles = StyleSheet.create({
   retailerText: {
     ...typography.caption,
     color: colors.text.secondary,
+  },
+  convertedText: {
+    ...typography.caption,
+    color: colors.text.secondary,
+    marginTop: spacing.xs,
   },
   ratingRow: {
     flexDirection: 'row',

--- a/SmartCompareApp/src/components/results/ResultsContent.tsx
+++ b/SmartCompareApp/src/components/results/ResultsContent.tsx
@@ -67,7 +67,7 @@ import { RevealBurst } from '../hero/RevealBurst';
 // accordion (ResultsAccordion), not as a standalone block here.
 import { ResultsAccordion } from './ResultsAccordion';
 import { SCORE_INTERNALS_RE } from './_deltaText';
-import { anyEstimated } from '../../services/sourceMethod';
+import { anyEstimated, isConvertedUsd } from '../../services/sourceMethod';
 import { ProductImage } from '../primitives/ProductImage';
 
 type SheetLeg = 'price' | 'reviews' | 'specs' | null;
@@ -286,6 +286,19 @@ export function ResultsContent({
                   >
                     {formatPrice(product.price)}
                   </Text>
+                  {/* Display-honesty: a converted-from-USD price is a real
+                      listing priced in USD then converted to BHD — flag it so
+                      it isn't read as a genuine local BHD price. Suppressed
+                      when the price is pending (no number is shown). */}
+                  {isConvertedUsd(product.price) && !product.price?.unavailable ? (
+                    <Text
+                      testID={`results-product-converted-${idx}`}
+                      style={styles.convertedCaption}
+                      numberOfLines={1}
+                    >
+                      {t('results.convertedUSD')}
+                    </Text>
+                  ) : null}
                 </View>
               </Animated.View>
             );
@@ -637,6 +650,13 @@ const styles = StyleSheet.create({
   productPriceUnavailable: {
     color: colors.text.secondary,
     fontSize: 14,
+  },
+  // Display-honesty caption under a converted-from-USD price.
+  convertedCaption: {
+    fontSize: 11,
+    color: colors.text.secondary,
+    lineHeight: 11 * 1.4,
+    marginTop: 2,
   },
 
   vsPillAbs: {

--- a/SmartCompareApp/src/i18n/ar.json
+++ b/SmartCompareApp/src/i18n/ar.json
@@ -723,7 +723,7 @@
   "results.emptyState.cta": "العودة إلى السجل",
   "results.emptyState.notFound": "المقارنة غير موجودة",
   "results.emptyState.needMorePhotos": "وجدنا منتجاً واحداً. ضع المنتجين معاً في الصورة لمقارنة جنباً إلى جنب.",
-  "results.emptyState.visionFailed": "صوّر مرة أخرى بإضاءة أفضل ونرتّبها لك.",
+  "results.emptyState.visionFailed": "صوّر كل منتج في صورة خاصة به وسنرتّبها لك جنباً إلى جنب.",
   "results.loading.fromHistory": "نحضّر مقارنتك",
   "results.loading.fromCamera": "نتعرّف على منتجاتك",
 

--- a/SmartCompareApp/src/i18n/en.json
+++ b/SmartCompareApp/src/i18n/en.json
@@ -726,7 +726,7 @@
   "results.emptyState.cta": "Back to history",
   "results.emptyState.notFound": "Comparison not found",
   "results.emptyState.needMorePhotos": "We spotted one product. Bring both items into the frame for a side-by-side.",
-  "results.emptyState.visionFailed": "Snap one more in better light and we'll line them up.",
+  "results.emptyState.visionFailed": "Snap each product in its own photo and we'll line them up side by side.",
   "results.loading.fromHistory": "Loading your comparison",
   "results.loading.fromCamera": "Identifying your products",
 

--- a/SmartCompareApp/src/screens/EditPreferencesFlow.tsx
+++ b/SmartCompareApp/src/screens/EditPreferencesFlow.tsx
@@ -23,6 +23,7 @@ import BudgetPicker, { type BudgetValue } from '../components/BudgetPicker';
 import LifestylePicker from '../components/LifestylePicker';
 import BrandAttitudePicker, { type BrandAttitudeValue } from '../components/BrandAttitudePicker';
 import { getPreferences, savePreferences } from '../services/api';
+import { toCanonicalPriorities } from '../utils/priorities';
 import type { RootStackParamList, UserPreferences } from '../types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'EditPreferences'>;
@@ -49,7 +50,11 @@ export default function EditPreferencesFlow({ navigation }: Props) {
     (async () => {
       try {
         const p = await getPreferences();
-        setPrefs(p ?? DEFAULT_PREFS);
+        const base = p ?? DEFAULT_PREFS;
+        // Map any cohort-seeded priorities to canonical display keys so the
+        // picker shows them as selected (otherwise they're invisible yet
+        // still fill the 3-cap, blocking selection — device bug 2026-07-04).
+        setPrefs({ ...base, priorities: toCanonicalPriorities(base.priorities) });
       } catch {
         setPrefs(DEFAULT_PREFS);
       } finally {

--- a/SmartCompareApp/src/screens/onboarding/Step08Priorities.tsx
+++ b/SmartCompareApp/src/screens/onboarding/Step08Priorities.tsx
@@ -62,6 +62,7 @@ import {
 } from 'lucide-react-native';
 import { OptionRow } from '../../components/primitives/OptionRow';
 import { colors, spacing, typography } from '../../theme';
+import { toCanonicalPriorities } from '../../utils/priorities';
 
 const PRIORITIES = [
   'price',
@@ -112,18 +113,22 @@ interface Props {
 export function Step08Priorities({ value, onChange }: Props) {
   const { t } = useTranslation();
 
+  // Normalize any cohort-seeded priorities to canonical display keys so
+  // they render as selected rows instead of invisibly consuming the cap.
+  const selected = toCanonicalPriorities(value);
+
   const toggle = (key: string) => {
-    if (value.includes(key)) {
-      onChange(value.filter((k) => k !== key));
+    if (selected.includes(key)) {
+      onChange(selected.filter((k) => k !== key));
       return;
     }
-    if (value.length >= MAX_SELECTIONS) {
+    if (selected.length >= MAX_SELECTIONS) {
       // Silent cap per Build Principle #4: engaging, never scary. No
       // tooltip, no shake, no haptic on overflow. Selecting another
       // simply does nothing.
       return;
     }
-    onChange([...value, key]);
+    onChange([...selected, key]);
   };
 
   return (
@@ -135,7 +140,7 @@ export function Step08Priorities({ value, onChange }: Props) {
 
       <View style={styles.list}>
         {PRIORITIES.map((p) => {
-          const active = value.includes(p);
+          const active = selected.includes(p);
           // Active row's circle bg flips to accentLight; icon glyph
           // adopts accentDark to maintain stroke contrast. Inactive
           // rows use text.primary on bg.secondary per OptionRow's

--- a/SmartCompareApp/src/services/sourceMethod.ts
+++ b/SmartCompareApp/src/services/sourceMethod.ts
@@ -41,3 +41,21 @@ export function parseSourceMethod(method: SourceMethod | undefined): string | nu
 export function anyEstimated(products: Array<Pick<Product, 'price'>>): boolean {
   return products.some((p) => p?.price?.source_method === 'estimated');
 }
+
+/**
+ * A `converted_usd` price is a REAL retailer listing that was priced in USD
+ * (or another non-BHD currency) and converted to BHD by the backend — it is
+ * NOT a genuine local BHD listing. Any surface that shows a converted price
+ * MUST render the `results.convertedUSD` caption ("(converted from USD)")
+ * beside the amount, so a converted price is never presented as identical to
+ * a genuine local price (the display-honesty gap this closes).
+ *
+ * Accepts any object carrying an optional `source_method`, so it works for
+ * both the full `ProductPrice` (Results screen) and the narrow streaming
+ * price shape (StreamingProductCard).
+ */
+export function isConvertedUsd(
+  price: { source_method?: SourceMethod } | null | undefined,
+): boolean {
+  return price?.source_method === 'converted_usd';
+}

--- a/SmartCompareApp/src/utils/__tests__/priorities.test.ts
+++ b/SmartCompareApp/src/utils/__tests__/priorities.test.ts
@@ -1,0 +1,46 @@
+import { toCanonicalPriorities, CANONICAL_PRIORITIES } from '../priorities';
+
+describe('toCanonicalPriorities', () => {
+  it('is identity for canonical keys', () => {
+    expect(toCanonicalPriorities(['price', 'quality'])).toEqual(['price', 'quality']);
+  });
+
+  it('maps cohort-derived priorities to canonical display keys', () => {
+    expect(
+      toCanonicalPriorities(['best_price', 'quality_reliability', 'trusted_brand']),
+    ).toEqual(['price', 'quality', 'brand_reputation']);
+  });
+
+  it('maps warranty_support + design_aesthetics to their nearest canonical', () => {
+    expect(toCanonicalPriorities(['warranty_support', 'design_aesthetics'])).toEqual([
+      'durability',
+      'latest_features',
+    ]);
+  });
+
+  it('de-duplicates collapsed mappings (best_price + value_for_money → price)', () => {
+    expect(toCanonicalPriorities(['best_price', 'value_for_money'])).toEqual(['price']);
+  });
+
+  it('drops unknown keys', () => {
+    expect(toCanonicalPriorities(['price', 'totally_unknown'])).toEqual(['price']);
+  });
+
+  it('caps at 3 by default, preserving order', () => {
+    expect(
+      toCanonicalPriorities(['price', 'quality', 'durability', 'eco_friendly']),
+    ).toEqual(['price', 'quality', 'durability']);
+  });
+
+  it('returns [] for null / undefined / empty', () => {
+    expect(toCanonicalPriorities(null)).toEqual([]);
+    expect(toCanonicalPriorities(undefined)).toEqual([]);
+    expect(toCanonicalPriorities([])).toEqual([]);
+  });
+
+  it('every canonical priority round-trips as identity', () => {
+    for (const k of CANONICAL_PRIORITIES) {
+      expect(toCanonicalPriorities([k])).toEqual([k]);
+    }
+  });
+});

--- a/SmartCompareApp/src/utils/priorities.ts
+++ b/SmartCompareApp/src/utils/priorities.ts
@@ -1,0 +1,65 @@
+// Priority-key normalization (device bug fix 2026-07-04).
+//
+// The FE PrioritiesPicker / Step08Priorities render + toggle only the 8
+// CANONICAL priority keys. The backend, however, also accepts 6
+// cohort-derived priority enums (see auth_routes VALID_PRIORITIES) which
+// `cohort_service.seed_preferences` writes into `users.preferences.priorities`
+// for users who completed the demographics modal.
+//
+// Left unmapped, a cohort-seeded priority sits INVISIBLE in the picker (no
+// row matches it) yet still consumes the MAX_SELECTIONS=3 cap — so the user
+// cannot select or change their priorities ("priorities can't be chosen").
+// `toCanonicalPriorities` maps each cohort-derived value to its closest
+// canonical display key so seeded priorities render as selected, editable
+// rows.
+
+export const CANONICAL_PRIORITIES = [
+  'price',
+  'quality',
+  'brand_reputation',
+  'durability',
+  'latest_features',
+  'ease_of_use',
+  'eco_friendly',
+  'health_safety',
+] as const;
+
+const CANONICAL_SET = new Set<string>(CANONICAL_PRIORITIES);
+
+// Best-effort cohort-derived → canonical mapping. Four are exact in spirit
+// (best_price→price, quality_reliability→quality, trusted_brand→
+// brand_reputation, warranty_support→durability); value_for_money and
+// design_aesthetics have no exact canonical, so map to the nearest
+// (price / latest_features). The mapping only provides a sensible starting
+// selection — the user can freely re-pick once the rows are visible.
+const COHORT_TO_CANONICAL: Record<string, string> = {
+  best_price: 'price',
+  value_for_money: 'price',
+  quality_reliability: 'quality',
+  trusted_brand: 'brand_reputation',
+  warranty_support: 'durability',
+  design_aesthetics: 'latest_features',
+};
+
+/**
+ * Normalize a stored priorities array to canonical display keys: map any
+ * cohort-derived value to its canonical equivalent, drop unknown keys,
+ * de-duplicate, and cap at `max` (default 3 — matches the backend
+ * max_length and the picker MAX_SELECTIONS).
+ *
+ * Identity for an all-canonical input, so onboarding (which starts empty)
+ * and any already-canonical selection are unaffected.
+ */
+export function toCanonicalPriorities(
+  value: string[] | null | undefined,
+  max = 3,
+): string[] {
+  if (!value) return [];
+  const out: string[] = [];
+  for (const raw of value) {
+    const canon = CANONICAL_SET.has(raw) ? raw : COHORT_TO_CANONICAL[raw];
+    if (canon && !out.includes(canon)) out.push(canon);
+    if (out.length >= max) break;
+  }
+  return out;
+}


### PR DESCRIPTION
Three frontend fixes from the 2026-07-04 device walkthrough. All backend-independent (display/UX only); ship to phones via `eas update`.

## 1. Converted-USD honesty caption (`88c678b`)
A `converted_usd` price (a USD/GCC listing converted to BHD) rendered **identical** to a genuine local BHD price. `results.convertedUSD` ("(converted from USD)") existed in EN/AR but was dead code — referenced by zero components.

- Add `isConvertedUsd()` to `sourceMethod.ts`.
- Render the caption on the **two live price surfaces** — `ResultsContent` (`results-product-converted-{idx}`) and `StreamingProductCard` (`{testID}-converted`) — only when `source_method === 'converted_usd'`.
- Recon confirmed Home/History render no product price (their `formatPrice` helpers are dead code), and `converted_usd` is the only non-genuine-local `source_method` per the backend contract.
- Updated the 9 `ResultsContent` test mocks + added helper/component tests.

## 2. Image-compare no longer blames lighting (`46143e2`)
A screenshot of two products yields backend `action="error"` (vision can't isolate two products from one image), which the FE mapped to the catch-all **"Snap one more in better light"** — misleading, since lighting isn't the problem. Reworded `results.emptyState.visionFailed` (EN + AR) to guide toward the supported flow (one product per photo); no lighting blame; copy-contract compliant (no `couldn't`/`try again`/`failed`, no `تعذر`/`فشل`).

## 3. Cohort-seeded priorities are selectable again (`610f19f`)
`cohort_service.seed_preferences` writes cohort-derived priority enums (`best_price`, `quality_reliability`, `trusted_brand`, `value_for_money`, `warranty_support`, `design_aesthetics`) into `users.preferences.priorities`, but `PrioritiesPicker`/`Step08` only render the **8 canonical keys**. A seeded value sat **invisible** in the picker yet still consumed the `MAX_SELECTIONS=3` cap → priorities could not be chosen or changed (**reported: "priorities can't be chosen when I hit save," Profile → Edit Preferences**).

- New `toCanonicalPriorities()` maps each cohort-derived value → its nearest canonical display key (dedup + cap 3; identity for canonical input).
- Wired into both pickers + canonicalize on load in `EditPreferencesFlow`, so seeded priorities render as **selected, editable** rows and save as valid canonical values.

## Verification
- `npx tsc --noEmit` clean.
- Targeted jest green: converted-caption 290 tests; priorities/EditPreferences/Step08/StyleProfileCard 56 tests; ResultsScreen + `copy-policy` (forbidden-word scanner) + `i18n` parity 234 tests.
- Adversarial review workflow (regression / completeness / copy-i18n-rtl) — clean.

## Not covered here (needs a device + EAS)
Backend is already live on phones; these are display/UX changes that reach devices only via `eas update`. Ahmed to run the EAS update + a device walkthrough to confirm each fix visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
