### PR TITLE
fix(mobile+prefs): lifestyle save 422 + Edit Preferences scroll + camera-timeout message

### DIFF
--- a/SmartCompareApp/src/screens/EditPreferencesFlow.tsx
+++ b/SmartCompareApp/src/screens/EditPreferencesFlow.tsx
@@ -12,6 +12,7 @@ import {
   StyleSheet,
   SafeAreaView,
   ActivityIndicator,
+  ScrollView,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, X } from 'lucide-react-native';
@@ -138,7 +139,12 @@ export default function EditPreferencesFlow({ navigation }: Props) {
         <View style={styles.headerBtn} />
       </View>
 
-      <View style={styles.body}>
+      <ScrollView
+        style={styles.body}
+        contentContainerStyle={styles.bodyContent}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
         <Text style={styles.pageTitle}>{t(`preferences.${pageKey}.title`)}</Text>
 
         {pageKey === 'priorities' && (
@@ -165,7 +171,7 @@ export default function EditPreferencesFlow({ navigation }: Props) {
             onChange={(v) => update({ brand_attitude: v })}
           />
         )}
-      </View>
+      </ScrollView>
 
       {errorKey ? <Text style={styles.errorText}>{t(errorKey)}</Text> : null}
 
@@ -221,7 +227,10 @@ const styles = StyleSheet.create({
   },
   body: {
     flex: 1,
+  },
+  bodyContent: {
     padding: spacing.lg,
+    paddingBottom: spacing.md,
   },
   pageTitle: {
     ...typography.display,

--- a/SmartCompareApp/src/screens/ResultsScreen.tsx
+++ b/SmartCompareApp/src/screens/ResultsScreen.tsx
@@ -253,7 +253,17 @@ export default function ResultsScreen({ route, navigation }: ResultsScreenProps)
             setLoadError('need_more_photos');
             setLoadingResult(false);
           }
+        } else if (data?.action === 'comparison_failed') {
+          // Both products WERE identified but the comparison itself didn't
+          // finish (usually the cold-compare hard-cap timeout). Show the
+          // retryable "taking longer" state — NOT the "snap each product"
+          // vision-failed copy, which wrongly implies the photos were bad.
+          if (!cancelled) {
+            setLoadError('timeout');
+            setLoadingResult(false);
+          }
         } else {
+          // action === 'error' — vision couldn't identify the products.
           if (!cancelled) {
             setLoadError('vision_failed');
             setLoadingResult(false);

--- a/app/api/auth_routes.py
+++ b/app/api/auth_routes.py
@@ -141,7 +141,20 @@ VALID_PRIORITIES = [
     "design_aesthetics", "value_for_money",
 ]
 VALID_BUDGET = ["budget", "mid", "premium", "luxury", "top_tier"]
-VALID_LIFESTYLE = ["gamer", "photographer", "fitness_enthusiast", "vegan", "sensitive_skin", "parent", "student", "professional", "outdoor_adventurer", "minimalist", "tech_enthusiast"]
+VALID_LIFESTYLE = [
+    # Original backend tags — kept for backwards-compat with any prior-seeded rows.
+    "gamer", "photographer", "fitness_enthusiast", "vegan", "sensitive_skin",
+    "parent", "student", "professional", "outdoor_adventurer",
+    # Shared with the FE LifestylePicker.
+    "minimalist", "tech_enthusiast",
+    # FE LifestylePicker (Bundle E S2.X3) vocabulary — the tags the app actually
+    # emits. These were NOT in the enum, so any lifestyle pick other than
+    # minimalist/tech_enthusiast 422'd on save ("Save didn't land" — device bug
+    # 2026-07-04). Lifestyle is soft free-text context for the GPT prompt +
+    # a personalization label, so accepting the FE vocabulary is safe.
+    "fitness", "budget_conscious", "eco_conscious", "luxury_lover",
+    "family_focused", "frequent_traveler", "home_cook", "outdoors", "creative",
+]
 VALID_BRAND_ATTITUDE = [
     "brand_loyal", "function_first", "best_of_both",
     # Cohort-derived value (Session 41)

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1049,11 +1049,19 @@ class TestValidOptionConstants:
                         "warranty_support", "design_aesthetics", "value_for_money"}
         assert cohort_added.issubset(set(VALID_PRIORITIES))
 
-    def test_valid_lifestyle_has_eleven_options(self):
-        """VALID_LIFESTYLE should have exactly 11 options per design doc."""
+    def test_valid_lifestyle_accepts_fe_picker_vocabulary(self):
+        """VALID_LIFESTYLE must accept the FE LifestylePicker vocabulary so
+        Edit Preferences can save (device bug 2026-07-04 — picks other than
+        minimalist/tech_enthusiast 422'd). It stays a SUPERSET of the original
+        backend tags for backwards-compat with any prior-seeded rows."""
         from app.api.auth_routes import VALID_LIFESTYLE
-        assert len(VALID_LIFESTYLE) == 11
-        expected = {"gamer", "photographer", "fitness_enthusiast", "vegan",
+        original = {"gamer", "photographer", "fitness_enthusiast", "vegan",
                     "sensitive_skin", "parent", "student", "professional",
                     "outdoor_adventurer", "minimalist", "tech_enthusiast"}
-        assert set(VALID_LIFESTYLE) == expected
+        fe_picker = {"fitness", "budget_conscious", "tech_enthusiast",
+                     "eco_conscious", "luxury_lover", "minimalist",
+                     "family_focused", "frequent_traveler", "home_cook",
+                     "outdoors", "creative"}
+        valid = set(VALID_LIFESTYLE)
+        assert original.issubset(valid), "lost backwards-compat lifestyle tags"
+        assert fe_picker.issubset(valid), "FE LifestylePicker vocab must validate"


### PR DESCRIPTION
Follow-ups from the second device walkthrough (after PR #20). Two backend-independent FE fixes + one backend fix.

## 1. "Save didn't land" — lifestyle enum mismatch (`99ca298`, backend)
Same FE↔backend vocabulary drift as the priorities bug, on `lifestyle`. The FE `LifestylePicker` emits `fitness / budget_conscious / eco_conscious / luxury_lover / family_focused / frequent_traveler / home_cook / outdoors / creative`, but backend `VALID_LIFESTYLE` only accepted the old vocabulary — **overlap was just `minimalist` + `tech_enthusiast`**. Any other lifestyle pick → `PUT /auth/preferences` 422 → the app showed **"Save didn't land."** Expanded `VALID_LIFESTYLE` to a superset (original tags kept for backwards-compat). Lifestyle is soft GPT-prompt context + a personalization label, and there's no DB CHECK on it, so accepting the FE vocabulary is safe. Verified: all 11 FE tags now validate; garbage still rejected; `test_personalization.py` green (test updated from an exact-11 pin to a superset assertion).

## 2. Edit Preferences pages can't scroll (`5752984`, FE)
The picker body was a fixed flex `View`, so long lists (lifestyle = 10 rows, priorities = 8) overflowed off-screen and overlapped the error text + footer (options cut off; the error bar landed mid-list). Wrapped the body in a `ScrollView` so every option is reachable and the error/footer stay pinned below.

## 3. Camera compare timeout showed the wrong message (`9b759b4`, FE)
Root cause of "the comparison won't go": a **cold fragrance compare hits the 30s hard cap** (`compare_from_text` → `asyncio.wait_for(30s)`). The camera path uses the same compare, so it times out → backend returns `action="comparison_failed"` → the FE mapped that to the "Snap each product in its own photo" vision-failed copy, which wrongly implies the photos were bad (the products **were** identified). Now `comparison_failed` routes to the retryable "taking longer — try again" timeout state (its retry re-arms the camera identify via `retryNonce`). `action="error"` (genuine identify failure) still shows the snap-each-product copy.

**Caveat:** this fixes the *messaging*, not the underlying latency — cold fragrance compares are slow (the perf/warmer effort's target). A retry can succeed if the first attempt warmed some cache.

## Verification
- `python -m py_compile app/api/auth_routes.py` OK; `test_personalization.py` 52 passed.
- `npx tsc --noEmit` clean; jest EditPreferences + ResultsScreen 134 passed.

## Deploy
- Backend (`VALID_LIFESTYLE`) reaches prod on merge to main (~90s Railway).
- FE (scroll + camera message) reaches phones via `eas update` (preview channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
