### PR TITLE
fix(ios): modular_headers for GoogleUtilities + RecaptchaInterop (fixes pod install)

### DIFF
--- a/SmartCompareApp/app.json
+++ b/SmartCompareApp/app.json
@@ -118,7 +118,11 @@
         "expo-build-properties",
         {
           "ios": {
-            "networkInspector": false
+            "networkInspector": false,
+            "extraPods": [
+              { "name": "GoogleUtilities", "modular_headers": true },
+              { "name": "RecaptchaInterop", "modular_headers": true }
+            ]
           }
         }
       ],


### PR DESCRIPTION
Fresh iOS builds were failing at `pod install`: AppCheckCore (Swift, via @react-native-google-signin) depends on GoogleUtilities + RecaptchaInterop which "do not define modules". A transitive Google pod drifted to a newer version since the last successful build (managed Expo pins no Podfile.lock). Adds `:modular_headers => true` for those two pods via expo-build-properties extraPods — exactly as the CocoaPods error recommends. Verified: iOS preview build 773a9375 FINISHED successfully with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)