### PR TITLE
fix(warmer): price-warmer cron runs uvicorn, never warms - separate railway config

### DIFF
--- a/railway.warmer.json
+++ b/railway.warmer.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "startCommand": "python -m scripts.cron_warm_price_cache",
+    "restartPolicyType": "NEVER"
+  }
+}


### PR DESCRIPTION
## Problem
The `price-warmer` cron service has been silently running **`uvicorn app.main:app`** instead of the warmer script `python -m scripts.cron_warm_price_cache`. Verified 2026-07-06: every cron container (00:00 / 12:00 UTC ticks) logs uvicorn startup and **zero `[cron_warm]` output** → the price cache was never warmed on schedule. The "warmed KPI looked green" only because ad-hoc traffic + measurement runs re-resolved misses into the 24h cache; the true cold floor is ~33%.

## Root cause
The shared `railway.json` hard-codes `deploy.startCommand: "uvicorn app.main:app --host 0.0.0.0 --port $PORT"`. Railway **config-as-code always overrides the dashboard start command** (per [docs](https://docs.railway.com/config-as-code)), so the price-warmer service's dashboard command (the warmer) was ignored on every deploy. A plain redeploy could not fix it.

## Fix (web-safe)
Add a dedicated **`railway.warmer.json`** that overrides only the start command + restart policy for the price-warmer service. **`web`'s `railway.json` is untouched** (zero risk to the live API).

## Required follow-up after merge (one dashboard setting)
1. price-warmer → **Settings → Config-as-code** → set the file path to **`/railway.warmer.json`**.
2. Redeploy price-warmer.
3. Verify the next tick: `railway logs --service price-warmer` shows `[cron_warm] done — genuine-share=X%` (not uvicorn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
