### PR TITLE
fix(mobile): cert-pin outage - Railway LE intermediate rotated to YE1 (Network Error hotfix)

### DIFF
--- a/SmartCompareApp/src/i18n/ar.json
+++ b/SmartCompareApp/src/i18n/ar.json
@@ -804,6 +804,7 @@
   "editProfile.dangerZone": "إجراءات الحساب",
   "editProfile.deleteAccount": "حذف الحساب",
   "editProfile.error.deleteTitle": "شيء لم يكتمل",
+  "editProfile.error.saveFailed": "لم يُحفظ بعد. اضغط لإعادة الإرسال.",
   "editprofile.email.appleLabel": "معرّف Apple",
   "editprofile.email.applePrivate": "البريد محمي بواسطة Apple",
 

--- a/SmartCompareApp/src/i18n/en.json
+++ b/SmartCompareApp/src/i18n/en.json
@@ -807,6 +807,7 @@
   "editProfile.dangerZone": "Account actions",
   "editProfile.deleteAccount": "Delete account",
   "editProfile.error.deleteTitle": "Something didn't go through",
+  "editProfile.error.saveFailed": "Save didn't land. Tap to send it again.",
   "editprofile.email.appleLabel": "Apple ID",
   "editprofile.email.applePrivate": "Email kept private by Apple",
 

--- a/SmartCompareApp/src/services/certificatePinning.ts
+++ b/SmartCompareApp/src/services/certificatePinning.ts
@@ -26,6 +26,9 @@ import { initializeSslPinning } from 'react-native-ssl-public-key-pinning';
 const LE_E7_INTERMEDIATE = 'y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=';
 const LE_E8_INTERMEDIATE = 'iFvwVyJSxnQdyaUvUERIf+8qk7gRze3612JMwoO3zdU=';
 const LE_E5_INTERMEDIATE = 'NYbU7PBwV4y9J67c4guWTki8FJ+uudrXL0a4V4aRcrg=';
+// 2026-07-06: Railway rotated to LE intermediate YE1 (E5/E7/E8 no longer in chain) -> app bricked with Network Error; added YE1 + ISRG Root X2 (stable root, survives future intermediate rotations)
+const LE_YE1_INTERMEDIATE = 'brzvtCELCIZUo4sD/qPX0ccRtPsd3DY6RfmxpOU9oB4=';
+const ISRG_ROOT_X2 = 'diGVwiVYbubAI3RW4hB9xU8e/CH2GnkuvVFZE8zmgzI=';
 
 let pinningInitialized = false;
 
@@ -37,9 +40,11 @@ export async function setupCertificatePinning(): Promise<void> {
       'web-production-58776.up.railway.app': {
         includeSubdomains: true,
         publicKeyHashes: [
-          LE_E7_INTERMEDIATE,  // Primary: Let's Encrypt E7 (current active issuer)
+          ISRG_ROOT_X2,        // Stable root: ISRG Root X2 (survives future LE intermediate rotations)
+          LE_YE1_INTERMEDIATE, // Primary: Let's Encrypt YE1 (current active issuer, issued by ISRG Root YE)
+          LE_E7_INTERMEDIATE,  // Backup: Let's Encrypt E7 (legacy — no longer in chain 2026-07-06)
           LE_E8_INTERMEDIATE,  // Backup: Let's Encrypt E8 (legacy / cross-signed)
-          LE_E5_INTERMEDIATE,  // Backup: Let's Encrypt E5
+          LE_E5_INTERMEDIATE,  // Backup: Let's Encrypt E5 (legacy — no longer in chain 2026-07-06)
         ],
       },
     });


### PR DESCRIPTION
## 🚨 Production outage — SSL cert pinning

Every EAS-build user's app has failed **all** backend calls with **"Network Error"** since **~2026-06-21** (saves fail, History shows empty, comparisons look "gone"). Confirmed via `openssl s_client`.

**Root cause:** the app pins Let's Encrypt intermediates **E7/E8/E5**. Railway's cert rotated to a **new LE intermediate "YE1"** (under ISRG Root YE). None of the pinned keys are in the live chain, so `react-native-ssl-public-key-pinning` rejects every HTTPS call to `web-production-58776.up.railway.app`. This is the **2nd** intermediate rotation to cause a total outage (the 2026-05-25 E5→E7 hotfix was the first).

**No data lost** — comparisons are server-only (verified: `HistoryScreen` fetches fresh each focus, no local cache; rows intact in the DB keyed by `user_id`). They reappear once calls succeed.

## Fix (JS-only → ships via `eas update`, no rebuild)
- `certificatePinning.ts` `publicKeyHashes` → `[ISRG_ROOT_X2, YE1, E7, E8, E5]`. **Anchored on the stable ISRG Root X2** (in the live chain, valid ~2035) so a future LE intermediate rotation no longer bricks the app; YE1 matches today's chain; E7/E8/E5 kept as backups.
- Add missing i18n key `editProfile.error.saveFailed` (en+ar) — was rendering as a raw key on Edit Profile.

**OTA-safe:** only the Railway host is pinned; the OTA downloads from `u.expo.dev` (unpinned), so `eas update` reaches the already-bricked builds.

## Ship
```
# merge, then in your working copy:
git checkout main && git pull
cd SmartCompareApp && eas update --branch preview -m "hotfix: cert pin YE1"
```
Then on-device: force-quit → reopen (downloads) → wait 60s → force-quit → reopen (applies). Verify: save, History loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
