### PR TITLE
fix(price): salvage specs/price on hard-cap + wire orphaned gcc Shopify rows

### DIFF
--- a/app/services/source_router.py
+++ b/app/services/source_router.py
@@ -812,6 +812,51 @@ def get_noon_sources_for_category(category: str) -> List[Source]:
     return _direct_fetch_sources(category, "noon_catalog")
 
 
+def get_gcc_shopify_pagescrape_sources_for_category(category: str) -> List[Source]:
+    """Launch coverage fix (2026-07-06) — the orphaned Shopify-shaped catalog rows.
+
+    ~40 catalog rows (rasasistore.com / sa.ajmal.com / swissarabian.com / … — the
+    local GCC perfume houses) are Shopify stores the build classifier left with a
+    BLANK mechanism (genuine_method "page_scrape_jsonld", is_shopify=False, because
+    the demotion path flattened every gcc-Shopify store). They therefore matched
+    NONE of the mechanism-keyed direct-fetch selectors and NONE of the
+    is_shopify/is_algolia selectors, so their ONLY consumer was the slow Serper
+    `site:` discovery cascade — which overruns the 15s price race for local-brand
+    pairs and dead-ends the compare.
+
+    Their liveness anchor (`sample_url`) IS the store's `/products.json` catalog
+    endpoint (the exact door `fetch_shopify_price` opens), so selecting on that
+    signal reaches precisely the rows already live-verified for the Shopify
+    mechanism — no re-probe, no data-file change, no reclassification. Routed
+    through `fetch_shopify_price` they resolve $0 / Serper-FREE; every one is
+    gcc-tier + non-BHD today, so `_match_shopify_product` stamps `converted_usd`
+    (never a mis-claimed genuine BHD — the currency is read from the store's own
+    /meta.json). The converted hit is PARKED (never short-circuits a genuine) by
+    `_consume_adapter_prefetch` and surfaces at the §5 tier-7 terminal.
+
+    Predicate: blank mechanism, NOT is_shopify/is_algolia (those have their own
+    bahrain-tier selectors), tier in ("bahrain","gcc") (future-proof; all matches
+    are gcc today), and a `/products.json` liveness anchor. Ordered
+    (bahrain→gcc, priority_rank, registry order) and TOP-K capped (_fanout_k),
+    exactly like `_direct_fetch_sources`. Returns [] flag-OFF: with
+    ENABLE_BH_GCC_CATALOG_SOURCES off SOURCE_REGISTRY == the literals, and NO
+    literal row carries a `/products.json` sample_url — so this whole path is
+    byte-identical to today until the catalog loads. Never raises.
+    """
+    matched = [
+        (idx, s)
+        for idx, s in enumerate(SOURCE_REGISTRY)
+        if (s.mechanism or "") == ""
+        and not s.is_shopify
+        and not s.is_algolia
+        and s.tier in ("bahrain", "gcc")
+        and "/products.json" in (s.sample_url or "")
+        and (not s.categories or category in s.categories)
+    ]
+    matched.sort(key=lambda t: (_TIER_ORDER.index(t[1].tier), t[1].priority_rank, t[0]))
+    return [s for _idx, s in matched[: _fanout_k()]]
+
+
 def source_usage(url: str, category: str) -> str:
     """Return the registry usage ("price"|"review"|"both") for `url` under
     `category`, or "price" for unknown / mis-categorized domains.

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -918,6 +918,9 @@ from app.services.source_router import (
     get_sitemap_sources_for_category,
     get_jsonapi_sources_for_category,
     get_curl_pagescrape_sources_for_category,
+    # Launch coverage fix (2026-07-06) — orphaned Shopify-shaped catalog rows
+    # (local GCC perfume houses) routed through fetch_shopify_price.
+    get_gcc_shopify_pagescrape_sources_for_category,
     # BH/GCC source-build (2026-06-25) — the 6 new $0 direct-fetch selectors.
     get_woo_sources_for_category,
     get_salla_sources_for_category,
@@ -1772,6 +1775,24 @@ def _organic_pdp_harvest_enabled() -> bool:
     )
 
 
+def _early_specs_stash_enabled() -> bool:
+    """Launch degradation fix (2026-07-06) — True iff the early identity+specs
+    stash is active (default ON). Read per-call (not cached) so an env flip /
+    monkeypatch takes effect immediately — mirrors _organic_pdp_harvest_enabled.
+
+    When ON, `_fetch_product_data` registers each product's `result` dict into a
+    per-request buffer the instant it is built and writes `result['specs']` from a
+    specs-task done-callback the moment specs land — so a hard-cap cancel DURING
+    the Phase-1 gather (both local-brand prices hanging) can still salvage the
+    completed specs into a best-available PARTIAL instead of a bare 503/TIMEOUT.
+    When OFF the buffer is never populated, the partial paths fall back to an empty
+    list, and BOTH the sync and streaming timeout handlers return their exact
+    pre-fix bodies (byte-identical rollback lever)."""
+    return os.getenv("ENABLE_EARLY_SPECS_STASH", "true").strip().lower() not in (
+        "false", "0", "no", "off", "",
+    )
+
+
 # BF5 (sweep OR-8) — BH-locale URL-path prefixes that mark a page as the
 # retailer's BAHRAIN storefront (namshi.com/bahrain-en, boutiqaat-style
 # /bh-en). Anchored + segment-bounded: "/bahrain-english-deals" or a mid-path
@@ -2233,6 +2254,16 @@ class StructuredComparisonService:
         self._partial_scoring_result: Optional[Dict[str, Any]] = None
         self._partial_product_names: Optional[List[str]] = None
         self._partial_comparison: Optional[Dict[str, Any]] = None
+        # Launch degradation fix (2026-07-06) — the EARLY identity+specs buffer.
+        # Holds each product's `result` dict BY REFERENCE the instant
+        # _fetch_product_data builds it (indexed by product position 0/1), so a
+        # hard-cap cancel that fires DURING the Phase-1 gather (before
+        # _partial_product_data is set at the post-gather stash) still exposes the
+        # landed identity + specs. `_partial_has_usable_data`/`_build_partial_response`
+        # fall back to this buffer when the post-gather stash is still None. Reset
+        # per-request on BOTH the sync and streaming paths; only populated when
+        # _early_specs_stash_enabled() (default ON) — empty ⇒ byte-identical.
+        self._early_specs_buffer: Optional[List[Optional[Dict[str, Any]]]] = None
 
     # ============================================
     # Static method wrappers for backward compat
@@ -2467,14 +2498,27 @@ class StructuredComparisonService:
     # Main entry points
     # ============================================
 
+    def _early_specs_buffer_list(self) -> List[Dict[str, Any]]:
+        """Launch degradation fix (2026-07-06) — the compacted early buffer: the
+        per-product `result` dicts registered by _fetch_product_data, dropping any
+        slot never filled (None). Empty when the buffer was never populated (flag
+        OFF or no _fetch_product_data ran), so it is a safe FALLBACK source that
+        the partial paths consult only when the post-gather stash is still None."""
+        return [pd for pd in (self._early_specs_buffer or []) if isinstance(pd, dict)]
+
     def _partial_has_usable_data(self) -> bool:
         """WS1 (D1) — True when at least one product has usable Phase-1 data
         (specs OR a price) stashed. Mirrors the inverse of
         `_phase1_completely_failed`: a product is usable if EITHER specs or
         price landed. When neither product has anything, the timeout handler
         falls through to the existing INSUFFICIENT_DATA error instead of
-        shipping an empty 'partial'."""
-        pd_list = self._partial_product_data
+        shipping an empty 'partial'.
+
+        Launch degradation fix (2026-07-06) — falls back to the EARLY buffer
+        (identity+specs stashed the instant each product started) when the
+        post-gather stash (_partial_product_data, set only AFTER the pair gather
+        completes) is still None — i.e. a cancel DURING the gather."""
+        pd_list = self._partial_product_data or self._early_specs_buffer_list()
         if not pd_list:
             return False
         for pd in pd_list:
@@ -2505,7 +2549,9 @@ class StructuredComparisonService:
         DATA path via the try/except in `compare_from_text`.
         """
         ctx = self._partial_build_ctx or {}
-        product_data = self._partial_product_data or []
+        # Launch degradation fix (2026-07-06) — fall back to the EARLY buffer when
+        # the post-gather stash is still None (cancel DURING the Phase-1 gather).
+        product_data = self._partial_product_data or self._early_specs_buffer_list() or []
         scoring_result = self._partial_scoring_result or {}
         comparison = self._partial_comparison or {}
         product_names = self._partial_product_names or [
@@ -2656,7 +2702,12 @@ class StructuredComparisonService:
                 "— no usable partial; returning graceful timeout",
                 STREAM_HARD_CAP_SECONDS, query,
             )
-            if self._partial_product_data:
+            # BLOCKER 3 (2026-07-06) — products RESOLVED (identity stashed in the
+            # early buffer or the post-gather stash) but neither carried usable
+            # specs/price ⇒ INSUFFICIENT_DATA (not the bare TIMEOUT). Consult the
+            # early buffer too so a both-price-hang mid-gather cancel (which never
+            # reaches the post-gather stash) is still classified as resolved-but-empty.
+            if self._partial_product_data or self._early_specs_buffer_list():
                 return {
                     "success": False,
                     "error": "Comparison data was incomplete — choose different products.",
@@ -2748,6 +2799,10 @@ class StructuredComparisonService:
         self._partial_scoring_result = None
         self._partial_product_names = None
         self._partial_comparison = None
+        # Launch degradation fix (2026-07-06) — reset the early identity+specs
+        # buffer to two empty slots so a reused per-request instance never leaks a
+        # prior run's stashed products.
+        self._early_specs_buffer = [None, None]
 
         # L1 content safety pre-filter (spec sec 5.2). Runs on the canonical query
         # string — for explicit_pair shape, this is the concatenated "A vs B"
@@ -2868,8 +2923,8 @@ class StructuredComparisonService:
 
             # Step 2: Fetch data for each product (parallel)
             product_data = await asyncio.gather(
-                self._fetch_product_data(products[0], region, include_specs, include_reviews, nocache),
-                self._fetch_product_data(products[1], region, include_specs, include_reviews, nocache)
+                self._fetch_product_data(products[0], region, include_specs, include_reviews, nocache, partial_slot=0),
+                self._fetch_product_data(products[1], region, include_specs, include_reviews, nocache, partial_slot=1)
             )
 
             # WS1 (D1) — stash the assembled product data the moment Phase 1
@@ -3225,6 +3280,21 @@ class StructuredComparisonService:
         # the sync path; published on the module ContextVar). Always-on, $0.
         self._init_provider_attempts()
 
+        # Launch degradation fix (2026-07-06) — the streaming path previously had
+        # NO partial stash at all, so a hard-cap on the data-fetch yielded a
+        # zero-product STREAM_TIMEOUT that DISCARDED completed specs. Reset the same
+        # best-available partial stash the sync path uses (+ the early buffer) so
+        # the streaming TimeoutError handler can assemble a specs-carrying PARTIAL.
+        # _partial_build_ctx is seeded below once the pair category resolves. Inert
+        # (buffer empty) until the new TimeoutError branch reads it, and byte-
+        # identical when _early_specs_stash_enabled() is OFF.
+        self._partial_build_ctx = None
+        self._partial_product_data = None
+        self._partial_scoring_result = None
+        self._partial_product_names = None
+        self._partial_comparison = None
+        self._early_specs_buffer = [None, None]
+
         # L1 content safety pre-filter (spec sec 5.2). Same gate as sync path —
         # blocked queries terminate the stream with an error event before any
         # parse/scrape work runs.
@@ -3312,6 +3382,23 @@ class StructuredComparisonService:
             for _p in products:
                 _p["category"] = category_used
 
+            # Launch degradation fix (2026-07-06) — seed the partial build ctx now
+            # that the pair category is resolved, so a hard-cap on the data fetch
+            # below assembles a correctly-categorized PARTIAL (mirrors the sync
+            # path's ctx). Minimal shape (_build_partial_response defaults the rest);
+            # demographics_profile is intentionally absent — the _profile_task is
+            # cancelled in the timeout handler before any partial build, so the
+            # cohort badge simply hides on a stream partial.
+            self._partial_build_ctx = {
+                "query": query,
+                "region": region,
+                "from_cache": not nocache,
+                "user_preferences": user_preferences,
+                "category_used": category_used,
+                "category_switched": category_switched,
+                "original_category": original_category,
+            }
+
             # Step 2: Fetch product data
             yield ("status", {"message": "Fetching specs and prices...", "progress": 20})
 
@@ -3335,8 +3422,8 @@ class StructuredComparisonService:
             try:
                 product_data = await asyncio.wait_for(
                     asyncio.gather(
-                        self._fetch_product_data(products[0], region, include_specs, include_reviews, nocache),
-                        self._fetch_product_data(products[1], region, include_specs, include_reviews, nocache),
+                        self._fetch_product_data(products[0], region, include_specs, include_reviews, nocache, partial_slot=0),
+                        self._fetch_product_data(products[1], region, include_specs, include_reviews, nocache, partial_slot=1),
                     ),
                     timeout=STREAM_HARD_CAP_SECONDS,
                 )
@@ -3347,6 +3434,35 @@ class StructuredComparisonService:
                     STREAM_HARD_CAP_SECONDS, query,
                 )
                 await _cancel_profile_task(_profile_task)
+                # Launch degradation fix (2026-07-06) — SALVAGE the specs the LLM
+                # already produced. If any product landed usable Phase-1 data
+                # (identity+specs via the early buffer, or a price), assemble a
+                # best-available success:true PARTIAL (mirrors the sync hard-cap
+                # path) rather than the zero-product STREAM_TIMEOUT that discarded
+                # completed specs — this is what stops the "This one's not loading"
+                # dead-end for local-brand pairs. Guarded: any build failure (and
+                # the flag-OFF / empty-buffer / both-hang paths, where
+                # _partial_has_usable_data() is False) falls through to the EXISTING
+                # STREAM_TIMEOUT body below verbatim → byte-identical when no specs
+                # landed.
+                if self._partial_has_usable_data():
+                    try:
+                        _partial = self._build_partial_response(
+                            elapsed_seconds=(datetime.now() - start_time).total_seconds()
+                        )
+                        logger.warning(
+                            "[stream] hard cap %.1fs hit for %r — returning "
+                            "best-available PARTIAL (success:true)",
+                            STREAM_HARD_CAP_SECONDS, query,
+                        )
+                        yield ("settle_complete", _partial)
+                        yield ("complete", _partial)
+                        return
+                    except Exception as _pe:  # noqa: BLE001 — fall through to STREAM_TIMEOUT
+                        logger.error(
+                            "[stream] partial build failed after hard-cap for %r: %s",
+                            query, _pe, exc_info=True,
+                        )
                 # WS1 (D2) — STREAM_TIMEOUT keeps its distinct code (the FE SSE
                 # error branch handles both TIMEOUT and STREAM_TIMEOUT), but the
                 # copy now obeys the no-scary-copy contract (was "Comparison
@@ -3896,9 +4012,18 @@ class StructuredComparisonService:
             logger.warning(f"Failed to update behavior profile: {e}")
 
     async def _fetch_product_data(
-        self, product_info: Dict, region: str, include_specs: bool, include_reviews: bool, nocache: bool = False
+        self, product_info: Dict, region: str, include_specs: bool, include_reviews: bool, nocache: bool = False,
+        partial_slot: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Fetch all data for a single product."""
+        """Fetch all data for a single product.
+
+        partial_slot (launch degradation fix, 2026-07-06): when 0/1 AND
+        _early_specs_stash_enabled(), this product's `result` dict is registered
+        into self._early_specs_buffer[partial_slot] the instant it is built and its
+        specs are written back from a specs-task done-callback the moment they land
+        — so a hard-cap cancel during the Phase-1 gather can still salvage them.
+        None (the default, and every non-orchestrator caller) → no stash, exact
+        pre-fix behaviour."""
         brand = product_info.get("brand", "")
         name = product_info.get("name", "")
         variant = product_info.get("variant")
@@ -3920,6 +4045,24 @@ class StructuredComparisonService:
             "brand": brand, "name": display_name, "full_name": full_name,
             "variant": variant, "category": category, "query": search_query,
         }
+
+        # Launch degradation fix (2026-07-06) — register this product's `result`
+        # dict into the per-request early buffer BY REFERENCE the instant it is
+        # built (identity only; specs/price land later). The specs-task
+        # done-callback (attached below) writes result['specs'] the moment specs
+        # resolve, and the Phase-1 gather loop writes result['specs']/['price']
+        # with the identical values on the happy path — so on a hard-cap cancel
+        # DURING the gather the timeout handler can salvage whatever landed. Gated
+        # by the flag + an explicit slot so every other caller (partial_slot None)
+        # is byte-identical.
+        _stash_early = (
+            _early_specs_stash_enabled()
+            and partial_slot is not None
+            and isinstance(self._early_specs_buffer, list)
+            and 0 <= partial_slot < len(self._early_specs_buffer)
+        )
+        if _stash_early:
+            self._early_specs_buffer[partial_slot] = result
 
         # Phase 2A.1 — per-product stage timings (only allocated when flag is on)
         stage_timings = {} if _debug_timings_enabled() else None
@@ -3965,6 +4108,22 @@ class StructuredComparisonService:
             timeout=_PHASE1_TIMEOUTS["price"],
         ))
 
+        # Launch degradation fix (2026-07-06) — MIRROR the specs done-callback for
+        # price, so the OPPOSITE salvage direction (price lands, specs hang) also
+        # works: a mid-gather cancel that fires after the price resolved but before
+        # the Phase-1 loop assigned result['price'] still exposes the landed price
+        # (and a genuine BH price is exactly what the local-brand pairs resolve via
+        # the new shopify_gcc adapter). Guarded identically: on a price
+        # timeout/cancel _t.result() raises -> write nothing (same as today), and on
+        # the happy path the Phase-1 loop overwrites with the identical value.
+        if _stash_early:
+            def _stash_price_cb(_t, _res=result):
+                try:
+                    _res["price"] = _t.result()
+                except (asyncio.TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            _price_task.add_done_callback(_stash_price_cb)
+
         async def _cleanup_orphan_price_task() -> None:
             """L5.3 (S3) — cancel + drain the speculative lever-1 price task if it
             never made it into (or through) the Phase-1 gather. Between the
@@ -3987,6 +4146,10 @@ class StructuredComparisonService:
         # the speculative price task. On the happy path _price_task is done by the
         # time the gather returns, so the cleanup is a no-op and the result/timing
         # path below is unchanged.
+        # Launch degradation fix (2026-07-06) — bound to None so the except-drain
+        # below can reference it even when include_specs is False / a raise fires
+        # before the hoist.
+        _specs_task = None
         try:
             # === Unified web search === (runs CONCURRENTLY with the price task
             # started above — I5.6: the price Serper round-trip is already in flight
@@ -4034,10 +4197,31 @@ class StructuredComparisonService:
             # post-D2 floor is 4-5s, per memory/feedback_measure_before_optimize.md.)
 
             if include_specs:
-                phase1_tasks.append(asyncio.wait_for(
+                # Launch degradation fix (2026-07-06) — HOIST the specs task into a
+                # named ensure_future (mirrors _price_task) so a done-callback can
+                # write result['specs'] into the early buffer the instant specs land.
+                # Kept in the SAME phase1_tasks position / wrapping / result-key
+                # order, and the gather awaits it identically, so this is a pure
+                # refactor: flag-OFF (or partial_slot None) no callback is attached
+                # and the 4105-loop writes result['specs'] with the identical value.
+                _specs_task = asyncio.ensure_future(asyncio.wait_for(
                     _timed_task("specs", self._get_specs(brand, name, variant, category, search_query, nocache, search_results=unified_search, drug_context=drug_context), stage_timings),
                     timeout=_PHASE1_TIMEOUTS["specs"],
                 ))
+                if _stash_early:
+                    def _stash_specs_cb(_t, _res=result):
+                        # Write the resolved specs into the SAME dict the buffer
+                        # holds, the instant they land. Guarded: on timeout/cancel/
+                        # error _t.result() raises → write nothing (specs stays None)
+                        # so the both-hang case still degrades to INSUFFICIENT_DATA.
+                        # On the happy path the gather loop overwrites with the
+                        # identical value (deterministic — no observable divergence).
+                        try:
+                            _res["specs"] = _t.result()
+                        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001
+                            pass
+                    _specs_task.add_done_callback(_stash_specs_cb)
+                phase1_tasks.append(_specs_task)
                 phase1_keys.append("specs")
 
             # I5.6 — price already started above (concurrent with the unified
@@ -4094,6 +4278,15 @@ class StructuredComparisonService:
             # drain it, then re-raise so the caller's error/cancel semantics
             # are unchanged.
             await _cleanup_orphan_price_task()
+            # Launch degradation fix (2026-07-06) — the hoisted specs task gets the
+            # same orphan drain so a pre-gather raise never strands an in-flight GPT
+            # specs call. No-op on the happy path / when include_specs is False.
+            if _specs_task is not None and not _specs_task.done():
+                _specs_task.cancel()
+                try:
+                    await _specs_task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
             raise
         if stage_timings is not None:
             # phase1_wall_ms = gather wall (max of parallel tasks);
@@ -5003,6 +5196,16 @@ class StructuredComparisonService:
                 # page_scrape_jsonld BHD; ONE bounded K-capped literal source,
                 # per-source _timeout_none like every sibling).
                 ("noon", get_noon_sources_for_category(category), fetch_noon_price),
+                # Launch coverage fix (2026-07-06) — the orphaned Shopify-shaped
+                # gcc perfume-house rows (rasasistore/sa.ajmal/swissarabian/…)
+                # routed through fetch_shopify_price ($0/Serper-FREE). Same
+                # (domain, product_name, currency, resolved_category) call shape as
+                # every other adapter below, so the shared prefetch+consume machinery
+                # handles it with no special-casing: a gcc store yields converted_usd
+                # → parked (never a genuine short-circuit) → surfaces at tier-7.
+                # Empty (→ dropped by the `if srcs` filter) until the catalog loads
+                # under ENABLE_BH_GCC_CATALOG_SOURCES → byte-identical flag-OFF.
+                ("shopify_gcc", get_gcc_shopify_pagescrape_sources_for_category(category), fetch_shopify_price),
             )
             if srcs
         ]

--- a/tests/test_explicit_pair_integration_mocked.py
+++ b/tests/test_explicit_pair_integration_mocked.py
@@ -104,10 +104,10 @@ def _run_compare(spy_holder):
     Returns (response, captured_scoring_result)."""
     svc = get_comparison_service()
 
-    async def fake_fetch(product_info, region, include_specs, include_reviews, nocache=False):
+    async def fake_fetch(product_info, region, include_specs, include_reviews, nocache=False, **kwargs):
         # Echo the category the orchestrator wrote onto the input dict — the
         # whole point of the fix. Pre-fix this is None/"other"; post-fix
-        # "fragrances".
+        # "fragrances". (**kwargs swallows the early-specs-stash partial_slot arg.)
         cat = product_info.get("category") or "other"
         brand = product_info.get("brand") or "Tom Ford"
         name = product_info.get("name") or product_info.get("search_query") or "Fragrance"
@@ -254,7 +254,7 @@ def test_explicit_pair_category_switched_surfaces_on_response_e2e():
     overrides a conflicting electronics chip."""
     svc = get_comparison_service()
 
-    async def fake_fetch(product_info, region, include_specs, include_reviews, nocache=False):
+    async def fake_fetch(product_info, region, include_specs, include_reviews, nocache=False, **kwargs):
         cat = product_info.get("category") or "other"
         name = product_info.get("name") or product_info.get("search_query") or "Fragrance"
         amount = 78.0 if "Sauvage" in str(name) else 64.0

--- a/tests/test_partial_specs_stash_on_price_timeout.py
+++ b/tests/test_partial_specs_stash_on_price_timeout.py
@@ -1,0 +1,278 @@
+"""Launch degradation fix (2026-07-06) — EARLY identity+specs stash salvage.
+
+The "This one's not loading" dead-end: a compare of two local-brand products
+(e.g. "Ajmal Aristocrat vs Rasasi Hawas") whose prices both hang past the
+STREAM_HARD_CAP was returning HTTP 503 / STREAM_TIMEOUT with ZERO products —
+discarding the specs the LLM had ALREADY produced. The fix stashes each
+product's identity+specs into a per-request buffer the instant they land, so the
+hard-cap handler assembles a best-available PARTIAL (success:true, specs +
+templated verdict) instead of a scary dead-end.
+
+Unlike tests/test_timeout_partial_integration.py (which mocks _fetch_product_data
+WHOLESALE and so never exercises the in-method stash), these tests mock only the
+INNER phase-1 methods (_get_specs fast, _get_price hangs) so the REAL
+_fetch_product_data runs its buffer registration + specs done-callback — the
+exact machinery the salvage depends on.
+
+Covers, both directions:
+  - specs land + price hangs  -> success:true PARTIAL with specs (sync + stream)
+  - specs AND price hang       -> INSUFFICIENT_DATA (sync) / STREAM_TIMEOUT (stream)
+                                  (the fix salvages only what LANDED; it is not a
+                                  deadline extension)
+  - flag OFF (ENABLE_EARLY_SPECS_STASH=false) -> byte-identical pre-fix bodies
+  - the _partial_* buffer fallback predicate in isolation
+No network: Serper/GPT/Redis/image are all mocked.
+"""
+import asyncio
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+os.environ.setdefault("ADMIN_API_KEY", "test-admin-key")
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.services.structured_comparison_service as scs
+from app.services.structured_comparison_service import get_comparison_service
+
+
+_SPECS = {"concentration": "EDP", "volume_ml": 100, "scent_family": "woody"}
+
+
+@contextmanager
+def _mock_phase1(svc, *, specs_hangs=False, price_hangs=True):
+    """Patch ONLY the inner phase-1 machinery so the REAL _fetch_product_data
+    runs (and its early-stash buffer + specs done-callback fire). Category
+    resolution is stubbed to a fixed fragrances pair; every network touch is
+    mocked. `explicit_pair` at the call site skips parse_product_query (no GPT)."""
+
+    async def _specs(*_a, **_k):
+        if specs_hangs:
+            await asyncio.sleep(40)
+        return dict(_SPECS)
+
+    async def _price(*_a, **_k):
+        if price_hangs:
+            await asyncio.sleep(40)
+        return {"amount": 42.0, "currency": "BHD", "source_method": "shopify_json",
+                "title": "x", "url": "https://x/p", "retailer": "x", "in_stock": True}
+
+    async def _reviews(*_a, **_k):
+        return None
+
+    async def _resolve(*_a, **_k):
+        return ("fragrances", False, None)
+
+    with patch.object(svc, "_get_specs", side_effect=_specs), \
+            patch.object(svc, "_get_price", side_effect=_price), \
+            patch.object(svc, "_get_reviews", side_effect=_reviews), \
+            patch.object(svc, "_track_serper_cost", lambda *a, **k: None), \
+            patch.object(svc, "_track_gpt_cost", lambda *a, **k: None), \
+            patch.object(scs, "_resolve_pair_category", side_effect=_resolve), \
+            patch.object(scs, "search_web", AsyncMock(return_value={"organic": [], "shopping": []})), \
+            patch.object(scs, "get_cached", lambda *a, **k: None), \
+            patch.object(scs, "get_product_image_url", AsyncMock(return_value=None)):
+        yield
+
+
+# ===========================================================================
+# Layer A — the buffer-fallback predicate in isolation (no pipeline).
+# ===========================================================================
+class TestEarlyBufferFallbackPredicate:
+    def test_has_usable_falls_back_to_early_buffer(self):
+        svc = get_comparison_service()
+        svc._partial_product_data = None  # post-gather stash never set (mid-gather cancel)
+        svc._early_specs_buffer = [
+            {"name": "A", "specs": dict(_SPECS), "price": None},
+            {"name": "B", "specs": None, "price": None},
+        ]
+        assert svc._partial_has_usable_data() is True  # A has specs
+
+    def test_both_empty_early_buffer_is_not_usable(self):
+        svc = get_comparison_service()
+        svc._partial_product_data = None
+        svc._early_specs_buffer = [
+            {"name": "A", "specs": None, "price": None},
+            {"name": "B", "specs": None, "price": None},
+        ]
+        assert svc._partial_has_usable_data() is False
+
+    def test_post_gather_stash_takes_precedence(self):
+        """When _partial_product_data IS set it wins over the early buffer, so
+        the existing sync tests (which seed _partial_product_data directly) are
+        unaffected."""
+        svc = get_comparison_service()
+        svc._partial_product_data = [{"name": "P", "specs": None, "price": {"amount": 5.0}}]
+        svc._early_specs_buffer = [{"name": "Q", "specs": None, "price": None}]
+        assert svc._partial_has_usable_data() is True  # from _partial_product_data
+
+    def test_empty_slots_compacted(self):
+        svc = get_comparison_service()
+        svc._early_specs_buffer = [None, {"name": "B", "specs": dict(_SPECS)}]
+        got = svc._early_specs_buffer_list()
+        assert len(got) == 1 and got[0]["name"] == "B"
+
+    def test_build_partial_response_uses_early_buffer(self):
+        svc = get_comparison_service()
+        svc._partial_build_ctx = {"query": "A vs B", "region": "bahrain",
+                                  "category_used": "fragrances"}
+        svc._partial_product_data = None
+        svc._partial_scoring_result = None
+        svc._partial_comparison = None
+        svc._partial_product_names = None
+        svc._shopping_items_cache = {}
+        svc._early_specs_buffer = [
+            {"brand": "Ajmal", "name": "Aristocrat", "full_name": "Ajmal Aristocrat",
+             "category": "fragrances", "specs": dict(_SPECS), "price": None},
+            {"brand": "Rasasi", "name": "Hawas", "full_name": "Rasasi Hawas",
+             "category": "fragrances", "specs": dict(_SPECS), "price": None},
+        ]
+        resp = svc._build_partial_response(elapsed_seconds=30.0)
+        assert resp["success"] is True
+        assert resp["metadata"]["partial"] is True
+        assert len(resp["overview"]["products"]) == 2
+
+
+# ===========================================================================
+# Layer C — SYNC wrapper hard-cap: the real _fetch_product_data runs, specs
+# land, price hangs -> the timeout handler salvages a success:true PARTIAL.
+# ===========================================================================
+@pytest.mark.asyncio
+class TestSyncHardCapSalvagesSpecs:
+    async def test_specs_land_price_hangs_returns_partial(self, monkeypatch):
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        svc = get_comparison_service()
+        with _mock_phase1(svc, price_hangs=True):
+            result = await svc.compare_from_text(
+                "Ajmal Aristocrat vs Rasasi Hawas", region="bahrain",
+                explicit_pair=("Ajmal Aristocrat", "Rasasi Hawas"),
+            )
+        assert result["success"] is True
+        assert result["metadata"]["partial"] is True
+        assert result.get("code") not in ("TIMEOUT", "STREAM_TIMEOUT", "INSUFFICIENT_DATA")
+        assert len(result["overview"]["products"]) == 2
+        # The salvage came from the early buffer: both slots carry the landed specs.
+        assert svc._early_specs_buffer[0]["specs"] == _SPECS
+        assert svc._early_specs_buffer[1]["specs"] == _SPECS
+        # Specs surface in the rendered response.
+        assert any(p.get("specs") for p in result["specs"]["products"])
+
+    async def test_price_lands_specs_hang_returns_partial(self, monkeypatch):
+        """OPPOSITE direction (coverage-review MEDIUM): specs hang but a genuine
+        price lands -> the price done-callback stashes it -> success:true PARTIAL
+        carrying the price, NOT a dead-end. (BLOCKER 2 makes local-brand prices
+        land fast via shopify_gcc while the GPT specs call lags, so this direction
+        is real.)"""
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        svc = get_comparison_service()
+        with _mock_phase1(svc, specs_hangs=True, price_hangs=False):
+            result = await svc.compare_from_text(
+                "Ajmal Aristocrat vs Rasasi Hawas", region="bahrain",
+                explicit_pair=("Ajmal Aristocrat", "Rasasi Hawas"),
+            )
+        assert result["success"] is True
+        assert result["metadata"]["partial"] is True
+        assert result.get("code") not in ("TIMEOUT", "STREAM_TIMEOUT", "INSUFFICIENT_DATA")
+        # The salvage came from the price done-callback: both slots carry the price.
+        assert svc._early_specs_buffer[0]["price"]["amount"] == 42.0
+        assert svc._early_specs_buffer[1]["price"]["amount"] == 42.0
+
+    async def test_both_hang_falls_through_to_insufficient_data(self, monkeypatch):
+        """specs AND price hang -> identity stashed (products resolved) but no
+        usable data -> INSUFFICIENT_DATA, NOT a fake partial and NOT a bare TIMEOUT."""
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        svc = get_comparison_service()
+        with _mock_phase1(svc, specs_hangs=True, price_hangs=True):
+            result = await svc.compare_from_text(
+                "Ajmal Aristocrat vs Rasasi Hawas", region="bahrain",
+                explicit_pair=("Ajmal Aristocrat", "Rasasi Hawas"),
+            )
+        assert result["success"] is False
+        assert result["code"] == "INSUFFICIENT_DATA"
+
+    async def test_flag_off_is_byte_identical_timeout(self, monkeypatch):
+        """ENABLE_EARLY_SPECS_STASH=false -> buffer never populated -> the pre-fix
+        body (graceful TIMEOUT, no salvage) exactly as before the change."""
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        monkeypatch.setenv("ENABLE_EARLY_SPECS_STASH", "false")
+        svc = get_comparison_service()
+        with _mock_phase1(svc, price_hangs=True):
+            result = await svc.compare_from_text(
+                "Ajmal Aristocrat vs Rasasi Hawas", region="bahrain",
+                explicit_pair=("Ajmal Aristocrat", "Rasasi Hawas"),
+            )
+        assert result["success"] is False
+        assert result["code"] == "TIMEOUT"
+        assert "partial" not in (result.get("metadata") or {})
+        # Buffer stayed empty (flag off) — no registration happened.
+        assert svc._early_specs_buffer == [None, None]
+
+
+# ===========================================================================
+# Layer D — STREAM hard-cap: the SSE path now yields a success:true PARTIAL
+# carrying specs (was: zero-product STREAM_TIMEOUT).
+# ===========================================================================
+@pytest.mark.asyncio
+class TestStreamHardCapSalvagesSpecs:
+    async def _drive(self, svc):
+        events = []
+        async for ev, data in svc.compare_from_text_streaming(
+            query="Ajmal Aristocrat vs Rasasi Hawas", region="bahrain",
+            explicit_pair=("Ajmal Aristocrat", "Rasasi Hawas"),
+        ):
+            events.append((ev, data))
+            if ev == "complete":
+                break
+        return events
+
+    async def test_specs_land_price_hangs_yields_partial(self, monkeypatch):
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        svc = get_comparison_service()
+        with _mock_phase1(svc, price_hangs=True):
+            events = await self._drive(svc)
+        terminal = [d for (t, d) in events if t in ("settle_complete", "complete")]
+        assert terminal, f"no terminal event; got {[t for t, _ in events]}"
+        body = terminal[-1]
+        assert body["success"] is True
+        assert body["metadata"]["partial"] is True
+        assert len(body["overview"]["products"]) == 2
+        assert body.get("code") not in ("TIMEOUT", "STREAM_TIMEOUT", "INSUFFICIENT_DATA")
+
+    async def test_price_lands_specs_hang_yields_partial(self, monkeypatch):
+        """Stream OPPOSITE direction: specs hang, price lands -> success:true
+        PARTIAL carrying the price (via the price done-callback)."""
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        svc = get_comparison_service()
+        with _mock_phase1(svc, specs_hangs=True, price_hangs=False):
+            events = await self._drive(svc)
+        body = [d for (t, d) in events if t in ("settle_complete", "complete")][-1]
+        assert body["success"] is True
+        assert body["metadata"]["partial"] is True
+        assert body.get("code") not in ("TIMEOUT", "STREAM_TIMEOUT", "INSUFFICIENT_DATA")
+        assert svc._early_specs_buffer[0]["price"]["amount"] == 42.0
+
+    async def test_both_hang_yields_stream_timeout(self, monkeypatch):
+        """specs AND price hang on the stream path -> the EXISTING STREAM_TIMEOUT
+        body (success:false, partial:true, zero products) is preserved."""
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        svc = get_comparison_service()
+        with _mock_phase1(svc, specs_hangs=True, price_hangs=True):
+            events = await self._drive(svc)
+        terminal = [d for (t, d) in events if t in ("settle_complete", "complete")]
+        assert terminal
+        body = terminal[-1]
+        assert body["success"] is False
+        assert body["code"] == "STREAM_TIMEOUT"
+
+    async def test_flag_off_stream_is_byte_identical(self, monkeypatch):
+        monkeypatch.setattr(scs, "STREAM_HARD_CAP_SECONDS", 1.0)
+        monkeypatch.setenv("ENABLE_EARLY_SPECS_STASH", "false")
+        svc = get_comparison_service()
+        with _mock_phase1(svc, price_hangs=True):
+            events = await self._drive(svc)
+        body = [d for (t, d) in events if t in ("settle_complete", "complete")][-1]
+        assert body["success"] is False
+        assert body["code"] == "STREAM_TIMEOUT"
+        assert svc._early_specs_buffer == [None, None]

--- a/tests/test_shopify_gcc_orphan_wiring.py
+++ b/tests/test_shopify_gcc_orphan_wiring.py
@@ -1,0 +1,137 @@
+"""Launch coverage fix (2026-07-06) — orphaned Shopify-shaped catalog rows.
+
+~40 gcc catalog rows (rasasistore.com / sa.ajmal.com / swissarabian.com / … —
+the local GCC perfume houses) are Shopify stores the build classifier left with a
+BLANK mechanism (page_scrape_jsonld, is_shopify=False), so NO direct-fetch
+selector reached them and their only consumer was the slow Serper `site:`
+discovery — the "Ajmal Aristocrat vs Rasasi Hawas" dead-end. Their liveness
+anchor `sample_url` IS the store's /products.json endpoint, so
+get_gcc_shopify_pagescrape_sources_for_category selects exactly them (already
+live-verified for the Shopify mechanism) and routes them through
+fetch_shopify_price ($0 / Serper-free; gcc → converted_usd, currency-honest).
+
+These pin the SELECTOR contract (the wiring into _new_adapter_specs +
+_consume_adapter_prefetch reuses the existing shared machinery unchanged) and the
+flag-OFF byte-identity guarantee.
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+
+from app.services import source_router
+from app.services.source_router import (
+    Source,
+    get_gcc_shopify_pagescrape_sources_for_category,
+    get_curl_pagescrape_sources_for_category,
+    _fanout_k,
+)
+
+
+def _src(domain, tier="gcc", cats=("fragrances",), **kw):
+    """Build a Source with the given kwargs; `mechanism` defaults to '' (blank)."""
+    weight = kw.pop("weight", 1.5)
+    return Source(domain, tier, tuple(cats), weight, **kw)
+
+
+class TestShopifyGccSelector:
+    def test_matches_only_products_json_blank_rows(self, monkeypatch):
+        reg = [
+            _src("rasasistore.com", sample_url="https://rasasistore.com/products.json",
+                 priority_rank=62, currency="AED"),
+            _src("swissarabian.com", sample_url="https://swissarabian.com/products.json",
+                 priority_rank=64, currency="USD"),
+            # PDP-only blank row -> NOT a /products.json anchor -> excluded (a bare
+            # apex has no domain->price path, so firing shopify at it is wasteful).
+            _src("pdponly.com", sample_url="https://pdponly.com/products/slug", priority_rank=10),
+            # literal-like row (no sample_url) -> excluded.
+            _src("lit.com", tier="bahrain", cats=(), sample_url=""),
+        ]
+        monkeypatch.setattr(source_router, "SOURCE_REGISTRY", reg)
+        got = [s.domain for s in get_gcc_shopify_pagescrape_sources_for_category("fragrances")]
+        assert got == ["rasasistore.com", "swissarabian.com"]  # priority_rank order
+
+    def test_excludes_shopify_algolia_mechanism_tier_category(self, monkeypatch):
+        reg = [
+            _src("shop.com", is_shopify=True, sample_url="https://shop.com/products.json"),
+            _src("alg.com", is_algolia=True, sample_url="https://alg.com/products.json"),
+            _src("glob.com", tier="global", sample_url="https://glob.com/products.json"),
+            _src("woo.com", mechanism="woo_store_json", sample_url="https://woo.com/products.json"),
+            _src("elec.com", cats=("electronics",), sample_url="https://elec.com/products.json"),
+        ]
+        monkeypatch.setattr(source_router, "SOURCE_REGISTRY", reg)
+        assert get_gcc_shopify_pagescrape_sources_for_category("fragrances") == []
+
+    def test_bahrain_ordered_before_gcc_then_priority(self, monkeypatch):
+        reg = [
+            _src("gcc-a.com", tier="gcc", sample_url="https://gcc-a.com/products.json", priority_rank=5),
+            _src("bh-b.com", tier="bahrain", sample_url="https://bh-b.com/products.json", priority_rank=99),
+        ]
+        monkeypatch.setattr(source_router, "SOURCE_REGISTRY", reg)
+        got = [s.domain for s in get_gcc_shopify_pagescrape_sources_for_category("fragrances")]
+        assert got == ["bh-b.com", "gcc-a.com"]  # bahrain first despite larger rank
+
+    def test_k_capped(self, monkeypatch):
+        reg = [
+            _src(f"s{i}.com", sample_url=f"https://s{i}.com/products.json", priority_rank=i)
+            for i in range(20)
+        ]
+        monkeypatch.setattr(source_router, "SOURCE_REGISTRY", reg)
+        got = get_gcc_shopify_pagescrape_sources_for_category("fragrances")
+        assert len(got) == _fanout_k()
+
+    def test_empty_categories_matches_all(self, monkeypatch):
+        reg = [_src("all.com", cats=(), sample_url="https://all.com/products.json")]
+        monkeypatch.setattr(source_router, "SOURCE_REGISTRY", reg)
+        got = [s.domain for s in get_gcc_shopify_pagescrape_sources_for_category("fragrances")]
+        assert got == ["all.com"]
+
+
+class TestFlagOffByteIdentity:
+    def test_no_literal_row_carries_products_json_anchor(self):
+        """The flag-OFF byte-identity guarantee: SOURCE_REGISTRY == _LITERAL_ROWS,
+        and the selector matches ONLY rows with a /products.json sample_url — no
+        literal carries one, so the selector returns [] until the catalog loads."""
+        for s in source_router._LITERAL_ROWS:
+            assert "/products.json" not in (s.sample_url or ""), s.domain
+
+    def test_selector_empty_against_literals_only_registry(self, monkeypatch):
+        monkeypatch.setattr(source_router, "SOURCE_REGISTRY", source_router._LITERAL_ROWS)
+        for cat in ("fragrances", "skincare", "makeup", "supplements", "other"):
+            assert get_gcc_shopify_pagescrape_sources_for_category(cat) == []
+
+
+class TestSupplementsSelectorUnchanged:
+    def test_curl_pagescrape_still_bahrain_only(self, monkeypatch):
+        """The pre-existing supplements curl-pagescrape selector stays bahrain-only
+        (the new selector is additive, not a replacement) — a gcc blank row is NOT
+        admitted by it."""
+        reg = [
+            _src("bh-supp.com", tier="bahrain", cats=("supplements",),
+                 sample_url="https://bh-supp.com/product/x"),
+            _src("gcc-supp.com", tier="gcc", cats=("supplements",),
+                 sample_url="https://gcc-supp.com/products.json"),
+        ]
+        monkeypatch.setattr(source_router, "SOURCE_REGISTRY", reg)
+        got = [s.domain for s in get_curl_pagescrape_sources_for_category("supplements")]
+        assert got == ["bh-supp.com"]
+
+
+class TestCatalogDataContract:
+    """Pin the real data-file expectation the wiring relies on: the failing
+    pair's houses are present as blank-mechanism /products.json rows."""
+
+    def test_failing_pair_houses_are_products_json_rows(self):
+        import json
+        from pathlib import Path
+        path = Path(__file__).resolve().parents[1] / "data" / "bh_gcc_sources.json"
+        rows = json.loads(path.read_text(encoding="utf-8"))
+        by_domain = {r.get("domain"): r for r in rows}
+        for dom in ("rasasistore.com", "sa.ajmal.com", "swissarabian.com"):
+            r = by_domain.get(dom)
+            assert r is not None, f"{dom} missing from catalog"
+            assert (r.get("mechanism") or "") == "", f"{dom} not blank-mechanism"
+            assert not r.get("is_shopify"), f"{dom} unexpectedly is_shopify"
+            assert "/products.json" in (r.get("sample_url") or ""), f"{dom} not a /products.json anchor"
+            assert "fragrances" in (r.get("categories") or []), f"{dom} not a fragrance row"


### PR DESCRIPTION
## Pre-launch price-discovery coverage — two SAFE launch blockers

Fixes the **"This one's not loading"** dead-end that real customers hit when comparing local GCC perfume brands (Ajmal / Rasasi / Asghar Ali / Swiss Arabian). Both fixes are strictly additive, flag-gated, and **byte-identical with the flags OFF**. Plan: `docs/plans/2026-07-06-price-discovery-coverage-launch-plan.md`.

### BLOCKER 1 — graceful degradation: salvage completed specs/price on a hard-cap (`ENABLE_EARLY_SPECS_STASH`, default ON)

The sync path already salvages a `success:true` partial on the hard cap, but stashed product data only **after** the pair gather — so a mid-gather cancel (both local-brand prices hanging) lost it. The **streaming path (what the mobile app uses)** had no salvage at all: it yielded `STREAM_TIMEOUT` with **zero products**, discarding specs the LLM had already produced → the dead-end.

- New per-request `_early_specs_buffer`: each product's `result` dict is registered the instant it's built; **specs *and* price done-callbacks** write into it the moment each lands (both directions salvaged).
- `_partial_has_usable_data()` / `_build_partial_response()` fall back to the buffer when the post-gather stash is still `None`.
- The streaming `TimeoutError` handler now assembles a `success:true` PARTIAL (specs + templated verdict) when any usable data landed; otherwise it keeps the **exact** existing `STREAM_TIMEOUT` body.
- Sync `INSUFFICIENT_DATA` branch now consults the buffer (products-resolved-but-empty ⇒ `INSUFFICIENT_DATA`, not bare `TIMEOUT`).
- The hoisted specs task gets the same orphan-drain as the price task.

Flag-OFF: the buffer is never populated → every fallback reduces to the pre-change expression, and both timeout handlers return their pre-fix bodies verbatim.

### BLOCKER 2 — wire the orphaned Shopify-shaped GCC rows (`ENABLE_BH_GCC_CATALOG_SOURCES`, already ON in prod)

The literal plan (a curl page-scrape selector from a domain) is a **no-op** — `fetch_page_price` needs a full PDP URL and these apex-domain rows have none. The rows that *can* be fetched $0/Serper-free are the **40 gcc `/products.json` Shopify stores** the catalog build left with a blank mechanism (`rasasistore.com`, `sa.ajmal.com`, `swissarabian.com`, … — the failing pair's houses). Their liveness anchor **is** the `/products.json` endpoint.

- New `get_gcc_shopify_pagescrape_sources_for_category` selects exactly those rows (blank mechanism, not shopify/algolia, bahrain+gcc, `/products.json` anchor), K-capped + tier/priority ordered like the other direct-fetch selectors.
- Routed through the existing `fetch_shopify_price` via one `("shopify_gcc", …)` tuple in `_new_adapter_specs` — reuses the shared prefetch + `_consume_adapter_prefetch` machinery unchanged. Currency is stamped from the store's real `/meta.json` (all 40 are non-BHD → `converted_usd`, **parked, never a genuine short-circuit, never mis-stamped**). Self-verifying (graceful miss), no data-file regeneration.

Flag-OFF: no literal row carries a `/products.json` anchor → the selector returns `[]` → the tuple is dropped by the `if srcs` filter → byte-identical.

### Verification
- 27 new tests (`test_partial_specs_stash_on_price_timeout.py`, `test_shopify_gcc_orphan_wiring.py`) + fixed 2 mock signatures (`test_explicit_pair_integration_mocked.py`).
- Comm-gate: branch-only-NEW failures == [] vs the 46-line main baseline (`.qa-correctness/main-baseline-failed.txt`).
- 4-lens coverage-driven adversarial review: flag-OFF byte-identity, BLOCKER 1 concurrency, BLOCKER 2 correctness/latency all CLEAN; the one coverage-gap finding (price-lands/specs-hang direction) was fixed with the price done-callback + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)