### PR TITLE
fix(price): brand-implied matching for own-brand stores (5 adapters)

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -2880,6 +2880,30 @@ def _collapse_concentration(text: str) -> str:
     return out
 
 
+def normalize_candidate_brand(raw) -> str:
+    """Best-effort brand STRING from a heterogeneous adapter brand field.
+
+    The price adapters carry the product's own brand in different shapes: a scalar
+    string (unbxd brandEn, beautybooth brand), a ``{"name": ...}`` dict (salla,
+    panda, woo brands[]/pa_brand terms), a list of either, or JSON null. This
+    normalizes all of them to a plain trimmed string ("" when unknown/absent).
+
+    Robustness contract (brand-implied review 2026-07-07): NEVER raises and never
+    stringifies a container into junk tokens — a bare-string `brand` (salla can
+    return `"Ajmal"`, not `{"name": ...}`) no longer AttributeErrors, and a dict/
+    list slipped into a scalar field yields its name/first-element instead of
+    ``"{'id': 1, ...}"``. Unknown shapes → "" → legacy brand-required behaviour."""
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw.strip()
+    if isinstance(raw, dict):
+        return str(raw.get("name") or "").strip()
+    if isinstance(raw, (list, tuple)):
+        return normalize_candidate_brand(raw[0]) if raw else ""
+    return ""
+
+
 def strict_title_match(
     product_name: str, title: str, candidate_brand: str = "",
 ) -> bool:
@@ -9381,14 +9405,25 @@ def _match_shopify_product(
             continue
         if not numbers_match(product_name, title):
             continue
-        if not strict_title_match(product_name, title):
+        # Brand-implied match (2026-07-07) — a brand's OWN Shopify store OMITS its
+        # brand from product titles (en-bh.ajmal.com lists "ARISTOCRAT CORAL EDP",
+        # vendor="Ajmal", NOT "Ajmal Aristocrat"), so requiring the query brand token
+        # rejected the exact SKU and threw away a genuine BHD price. Thread the
+        # Shopify `vendor` (the product's own brand) as candidate_brand so a
+        # brand-omitted title of the QUERY's brand resolves, while a WRONG-brand
+        # candidate keeps the query brand required and is still rejected (no
+        # wrong-match). Mirrors the proven magento_graphql/occ/noon/algolia pattern;
+        # candidate_brand is gated by exact_gate_enabled() inside the matchers, so
+        # flag-OFF (ENABLE_EXACT_PRICE_GATE=false) is byte-identical.
+        _cand_brand = normalize_candidate_brand(product.get("vendor"))
+        if not strict_title_match(product_name, title, candidate_brand=_cand_brand):
             continue
         # S3 #1 (discovery-match) — reject a different model-line variant.
         if variant_mismatch(product_name, title):
             continue
         # Keystone variant-add guard (coverage/independent review) — category-aware
         # superset/axes beyond variant_mismatch's pro/max set. Flag-safe (True when off).
-        if not _selection_match(product_name, title, resolved_category):
+        if not _selection_match(product_name, title, resolved_category, candidate_brand=_cand_brand):
             continue
 
         t_words = normalize_words(title)

--- a/app/services/rest_json_service.py
+++ b/app/services/rest_json_service.py
@@ -30,6 +30,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from app.services.price_service import (
+    normalize_candidate_brand,
     ENABLE_PAGE_SCRAPE,
     _VARIANT_QUALIFIERS,
     _convert_to_bhd,
@@ -105,8 +106,17 @@ def _word_overlap(product_name: str, title: str) -> float:
     return len(p_words & t_words) / len(p_words)
 
 
-def _title_matches(product_name: str, title: str, resolved_category=None) -> bool:
+def _title_matches(product_name: str, title: str, resolved_category=None,
+                   candidate_brand: str = "") -> bool:
     """Strict, no-fab match for a direct-API hit.
+
+    candidate_brand (brand-implied match, 2026-07-07): the candidate's OWN brand
+    (per-store field, derived by the caller). An own-brand store OMITS its brand
+    from titles; threading candidate_brand into strict_title_match /
+    selection_primary_admits / _selection_match lets a brand-omitted title of the
+    query's brand pass, while a WRONG-brand hit keeps the query brand required.
+    Empty (the default, e.g. the brandless ourshopee search path) → legacy
+    behaviour; inert flag-OFF (byte-identical). Mirrors magento/occ.
 
     Uses numbers_match + strict_title_match + word-overlap (the algolia_service
     precedent for a direct-API adapter). variant_mismatch is applied ONLY when
@@ -127,15 +137,17 @@ def _title_matches(product_name: str, title: str, resolved_category=None) -> boo
     # rows carry no brand signal, so a FASHION padding-brand query requires
     # its brand token in the title). Flag OFF (or exact gate OFF) restores
     # the exact pre-change hard gate.
-    if (not strict_title_match(product_name, title)
+    if (not strict_title_match(product_name, title, candidate_brand=candidate_brand)
             and not selection_primary_admits(
-                product_name, title, category=resolved_category)):
+                product_name, title, candidate_brand=candidate_brand,
+                category=resolved_category)):
         return False
     q_words = set(re.findall(r"[a-z]+", (product_name or "").lower()))
     if (q_words & _VARIANT_QUALIFIERS) and variant_mismatch(product_name, title):
         return False
     # Keystone variant-add guard (coverage/independent review). Flag-safe (True when off).
-    if not _selection_match(product_name, title, resolved_category):
+    if not _selection_match(product_name, title, resolved_category,
+                            candidate_brand=candidate_brand):
         return False
     return _word_overlap(product_name, title) >= _MATCH_MIN_OVERLAP
 
@@ -336,7 +348,11 @@ async def _fetch_panda(product_name: str, currency: str, resolved_category: Opti
         if not isinstance(prod, dict):
             continue
         name = prod.get("name") or ""
-        if not _title_matches(product_name, name, resolved_category):
+        # Brand-implied match (2026-07-07) — panda carries brand as a NESTED
+        # object prod["brand"]["name"]; normalize_candidate_brand handles the
+        # dict / null / string shapes safely.
+        _cand_brand = normalize_candidate_brand(prod.get("brand"))
+        if not _title_matches(product_name, name, resolved_category, candidate_brand=_cand_brand):
             continue
         varieties = prod.get("varieties")
         if not isinstance(varieties, list) or not varieties:
@@ -426,7 +442,10 @@ async def _fetch_beautybooth(product_name: str, currency: str, resolved_category
     best_score = -1.0
     for it in items:
         name = it.get("name") or ""
-        if not _title_matches(product_name, name, resolved_category):
+        # Brand-implied match (2026-07-07) — beautybooth carries brand as a FLAT
+        # top-level string it["brand"] ("The Ordinary").
+        _cand_brand = normalize_candidate_brand(it.get("brand"))
+        if not _title_matches(product_name, name, resolved_category, candidate_brand=_cand_brand):
             continue
         price_val = parse_price_string(str(it.get("net_price") or it.get("main_price") or ""))
         if price_val is None or price_val <= 0:

--- a/app/services/salla_service.py
+++ b/app/services/salla_service.py
@@ -33,6 +33,7 @@ import re
 from typing import Any, Dict, Optional
 
 from app.services.price_service import (
+    normalize_candidate_brand,
     strict_title_match,
     _selection_match,
     selection_primary_admits,
@@ -122,6 +123,12 @@ def _select_candidate(
         title = item.get("name") or ""
         if not title:
             continue
+        # Brand-implied match (2026-07-07) — the Salla product carries brand as a
+        # NESTED dict `{"id","url","name"}` (item["brand"] can itself be null).
+        # An own-brand store (Ajmal/Asghar Ali) OMITS its brand from titles;
+        # brand.name lets that pass while a WRONG-brand hit keeps the query brand
+        # required. Null-safe read; inert flag-OFF (byte-identical). Mirrors magento/occ.
+        _cand_brand = normalize_candidate_brand(item.get("brand"))
         if is_counterfeit_listing(title):
             continue
         # Asymmetric accessory guard (review gate-fix): only drop an accessory
@@ -141,9 +148,10 @@ def _select_candidate(
         # padding-brand query requires its brand token in the title). Flag
         # OFF (or exact gate OFF, where _selection_match is a no-op True)
         # restores the exact pre-change hard gate.
-        if (not strict_title_match(product_name, title)
+        if (not strict_title_match(product_name, title, candidate_brand=_cand_brand)
                 and not selection_primary_admits(
-                    product_name, title, category=resolved_category)):
+                    product_name, title, candidate_brand=_cand_brand,
+                    category=resolved_category)):
             continue
         if not numbers_match(product_name, title):
             continue
@@ -153,7 +161,8 @@ def _select_candidate(
         # is SUBSET-based + variant_mismatch covers only pro/max/ultra; the broad
         # variant-add class (Mark II / mineral salt / sub-line) needs the category-aware
         # _selection_match. Flag-safe: returns True when ENABLE_EXACT_PRICE_GATE is off.
-        if not _selection_match(product_name, title, resolved_category):
+        if not _selection_match(product_name, title, resolved_category,
+                                candidate_brand=_cand_brand):
             continue
         # price must be a positive number (MAJOR units).
         try:

--- a/app/services/unbxd_service.py
+++ b/app/services/unbxd_service.py
@@ -31,6 +31,7 @@ from typing import Optional, Dict, Any, List
 from urllib.parse import quote_plus
 
 from app.services.price_service import (
+    normalize_candidate_brand,
     strict_title_match,
     _selection_match,
     selection_primary_admits,
@@ -141,9 +142,18 @@ def _match_unbxd_product(
         # (ENABLE_ADAPTER_SELECTION_PRIMARY) + the same wrong-brand fence
         # (selection_primary_admits; unbxd rows carry no brand signal). Flag
         # OFF (or exact gate OFF) restores the exact pre-change hard gate.
-        if (not strict_title_match(product_name, surface)
+        # Brand-implied match (2026-07-07) — Unbxd carries the product's OWN brand
+        # as a scalar `brandEn` ("APPLE") (list `brand` fallback). Thread it as
+        # candidate_brand so a brand-OMITTING title of the query's brand passes on
+        # the model line, while a WRONG-brand node keeps the query brand required
+        # (candidate_brand drops only the candidate's own tokens; _selection_match
+        # vets the SKU). Mirrors magento/occ; inert flag-OFF (byte-identical).
+        _cand_brand = normalize_candidate_brand(
+            product.get("brandEn") or product.get("brand"))
+        if (not strict_title_match(product_name, surface, candidate_brand=_cand_brand)
                 and not selection_primary_admits(
-                    product_name, surface, category=resolved_category)):
+                    product_name, surface, candidate_brand=_cand_brand,
+                    category=resolved_category)):
             continue
         # Verification F1 (HIGH no-fab fix): reject a different model-line variant.
         # Without this, a base-model query ("iPhone 17 Pro 256GB") matched the
@@ -154,7 +164,8 @@ def _match_unbxd_product(
         # applies this gate; unbxd omitted it.
         if variant_mismatch(product_name, surface):
             continue
-        if not _selection_match(product_name, surface, resolved_category):
+        if not _selection_match(product_name, surface, resolved_category,
+                                candidate_brand=_cand_brand):
             continue
         t_words = normalize_words(surface)
         score = (len(p_words & t_words) / len(p_words)) if p_words else 0.0

--- a/app/services/woocommerce_service.py
+++ b/app/services/woocommerce_service.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional
 from curl_cffi import requests as curl_requests
 
 from app.services.price_service import (
+    normalize_candidate_brand,
     ENABLE_PAGE_SCRAPE,
     _convert_to_bhd,
     _infer_category_from_query,
@@ -155,9 +156,32 @@ def _match_woo_product(
         # field, so a FASHION query's brand must appear in the title). Flag
         # OFF — or the exact gate OFF, which makes _selection_match a no-op
         # True — restores the exact pre-change hard gate.
-        if (not strict_title_match(product_name, title)
+        # Brand-implied match (2026-07-07) — the WooCommerce Store API carries the
+        # product's OWN brand in the top-level `brands` array (brands[0].name) or,
+        # when that taxonomy is unused, in the `pa_brand` product attribute
+        # (terms[0].name). An own-brand store OMITS its brand from titles, so
+        # requiring the query brand word rejected the exact SKU; this lets the
+        # brand-omitted title pass while a WRONG-brand row keeps the query brand
+        # required (candidate_brand drops only the candidate's own tokens;
+        # _selection_match vets the SKU). Mirrors magento/occ; inert flag-OFF.
+        _cand_brand = ""
+        _brands = prod.get("brands")
+        if isinstance(_brands, list) and _brands:
+            _cand_brand = normalize_candidate_brand(_brands[0])
+        if not _cand_brand:
+            for _attr in (prod.get("attributes") or []):
+                if not isinstance(_attr, dict):
+                    continue
+                if (str(_attr.get("taxonomy") or "").strip().lower() == "pa_brand"
+                        or str(_attr.get("name") or "").strip().lower() == "brand"):
+                    _terms = _attr.get("terms")
+                    if isinstance(_terms, list) and _terms:
+                        _cand_brand = normalize_candidate_brand(_terms[0])
+                    break
+        if (not strict_title_match(product_name, title, candidate_brand=_cand_brand)
                 and not selection_primary_admits(
-                    product_name, title, category=_category)):
+                    product_name, title, candidate_brand=_cand_brand,
+                    category=_category)):
             continue
         if not numbers_match(product_name, title):
             continue
@@ -172,7 +196,8 @@ def _match_woo_product(
             continue
         # CORRECTNESS — identity + axis gate (S24->FE / EDP->EDT / 256->128 /
         # related-product leaks). No-op when the rollback flag is OFF.
-        if not _selection_match(product_name, title, _category):
+        if not _selection_match(product_name, title, _category,
+                                candidate_brand=_cand_brand):
             continue
 
         prices = prod.get("prices") or {}

--- a/tests/test_brand_implied_parity.py
+++ b/tests/test_brand_implied_parity.py
@@ -1,0 +1,123 @@
+"""Brand-implied matcher parity (2026-07-07) — the 5 adapters that lacked
+candidate_brand threading now match magento/occ/noon/algolia.
+
+An own-brand store OMITS its brand from titles (Ajmal store: "ARISTOCRAT EDP",
+not "Ajmal Aristocrat"). Each adapter derives the candidate's OWN brand from its
+platform's brand field and threads it as candidate_brand so a brand-omitted title
+of the QUERY's brand resolves, while a WRONG-brand hit keeps the query brand
+required (no wrong-match). These pin each adapter's derivation + threading.
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+
+from app.services.price_service import (
+    strict_title_match, _selection_match, normalize_candidate_brand,
+)
+from app.services.unbxd_service import _match_unbxd_product
+from app.services.salla_service import _select_candidate
+from app.services.rest_json_service import _title_matches
+
+Q = "Ajmal Aristocrat"
+WRONG_Q = "Rasasi Aristocrat"
+TITLE = "Aristocrat Eau de Parfum 75 ML"   # BASE product, brand OMITTED
+CAT = "fragrances"
+
+
+class TestNormalizeCandidateBrand:
+    """The shared brand normalizer — must handle every adapter field shape and
+    NEVER raise (brand-implied review: salla can return a bare-string `brand`,
+    a dict/list slipped into a scalar field must not stringify to junk)."""
+
+    def test_scalar_string(self):
+        assert normalize_candidate_brand("Ajmal") == "Ajmal"
+        assert normalize_candidate_brand("  Ajmal  ") == "Ajmal"
+
+    def test_dict_name(self):
+        assert normalize_candidate_brand({"id": 1, "name": "Ajmal"}) == "Ajmal"
+
+    def test_list_first(self):
+        assert normalize_candidate_brand(["Ajmal", "x"]) == "Ajmal"
+        assert normalize_candidate_brand([{"name": "Ajmal"}]) == "Ajmal"
+
+    def test_none_and_empty(self):
+        assert normalize_candidate_brand(None) == ""
+        assert normalize_candidate_brand([]) == ""
+        assert normalize_candidate_brand({}) == ""
+
+    def test_never_raises_on_junk(self):
+        # a bare int / bool / nested-empty must return "" not raise
+        for junk in (123, True, {"name": None}, [None], [[]]):
+            assert normalize_candidate_brand(junk) == ""
+
+
+class TestSharedMechanism:
+    """The strict_title_match + _selection_match candidate_brand mechanism every
+    adapter now relies on."""
+
+    def test_candidate_brand_recovers_brand_omitted_title(self):
+        assert strict_title_match(Q, TITLE, candidate_brand="Ajmal") is True
+        assert _selection_match(Q, TITLE, CAT, candidate_brand="Ajmal") is True
+
+    def test_no_candidate_brand_rejects(self):
+        assert strict_title_match(Q, TITLE) is False  # brand required, omitted -> reject
+
+    def test_wrong_brand_not_recovered(self):
+        # candidate_brand 'Ajmal' does not drop 'rasasi' -> still required -> reject
+        assert strict_title_match(WRONG_Q, TITLE, candidate_brand="Ajmal") is False
+
+
+class TestRestJsonTitleMatches:
+    def test_brand_omitted_matches_with_candidate_brand(self):
+        assert _title_matches(Q, TITLE, CAT, candidate_brand="Ajmal") is True
+
+    def test_brand_omitted_rejected_without_candidate_brand(self):
+        assert _title_matches(Q, TITLE, CAT) is False
+
+    def test_wrong_brand_rejected(self):
+        assert _title_matches(WRONG_Q, TITLE, CAT, candidate_brand="Ajmal") is False
+
+
+class TestUnbxdBrandEn:
+    def _products(self, brand):
+        return [{"title": TITLE, "brandEn": brand, "price": 22.55}]
+
+    def test_own_brand_omitted_matches(self):
+        r = _match_unbxd_product(self._products("Ajmal"), Q, CAT)
+        assert r is not None, "brandEn did not recover the brand-omitted title"
+
+    def test_wrong_brand_rejected(self):
+        # query 'Ajmal Aristocrat' vs a SAMSUNG-branded node -> None
+        r = _match_unbxd_product(self._products("Samsung"), Q, CAT)
+        assert r is None
+
+    def test_no_brand_field_unchanged(self):
+        r = _match_unbxd_product([{"title": TITLE, "price": 22.55}], Q, CAT)
+        assert r is None  # no brandEn -> brand required -> rejected (legacy)
+
+
+class TestSallaNestedBrand:
+    def _data(self, brand_name):
+        return [{"name": TITLE, "brand": {"id": 1, "name": brand_name}, "price": 22.55}]
+
+    def test_own_brand_omitted_matches(self):
+        r = _select_candidate(self._data("Ajmal"), Q, CAT)
+        assert r is not None
+
+    def test_wrong_brand_rejected(self):
+        r = _select_candidate(self._data("Rasasi"), Q, CAT)
+        assert r is None
+
+    def test_null_brand_dict_safe_and_legacy(self):
+        # brand is the literal null (JSON) -> None -> legacy (brand required) -> reject
+        r = _select_candidate([{"name": TITLE, "brand": None, "price": 22.55}], Q, CAT)
+        assert r is None
+
+    def test_bare_string_brand_does_not_crash_and_matches(self):
+        """Review MEDIUM fix: a Salla store returning brand as a bare STRING
+        (not a {"name":...} dict) must NOT AttributeError — it now normalizes to
+        the string and recovers the own-brand-omitted title."""
+        r = _select_candidate([{"name": TITLE, "brand": "Ajmal", "price": 22.55}], Q, CAT)
+        assert r is not None

--- a/tests/test_shopify_brand_implied_match.py
+++ b/tests/test_shopify_brand_implied_match.py
@@ -1,0 +1,95 @@
+"""Brand-implied matcher fix (2026-07-07) — Shopify own-brand-store coverage.
+
+THE BUG (audit-confirmed live): a brand's OWN Shopify store OMITS its brand from
+product titles — en-bh.ajmal.com lists "ARISTOCRAT CORAL EAU DE PARFUM 75 ML"
+(vendor="Ajmal"), NOT "Ajmal Aristocrat". The app queries "Ajmal Aristocrat", so
+_match_shopify_product's strict_title_match/_selection_match — called WITHOUT a
+candidate_brand — required the "ajmal" token in the title and REJECTED the exact
+SKU. A genuine 22.55 BHD price existed and was thrown away (this is why
+"Ajmal Aristocrat vs Rasasi Hawas" dead-ended).
+
+THE FIX (mirrors the proven magento_graphql / occ / noon / algolia pattern):
+derive _cand_brand from the Shopify product's `vendor` field and thread
+candidate_brand=_cand_brand into BOTH strict_title_match and _selection_match.
+When the candidate's own brand == the query brand, its tokens drop from the
+required set (brand-omitted title recovered); a WRONG-brand candidate keeps the
+query brand required and is still rejected (no wrong-match). Gated by
+exact_gate_enabled() the same way the sibling adapters gate it → flag-OFF
+byte-identical.
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+
+from app.services.price_service import _match_shopify_product
+
+
+def _catalog(title, vendor, price="22.55", currency="BHD", available=True):
+    return {
+        "_store_currency": currency,
+        "products": [{
+            "title": title,
+            "vendor": vendor,
+            "handle": title.lower().replace(" ", "-"),
+            "variants": [{"price": price, "available": available, "title": "75ml"}],
+        }],
+    }
+
+
+class TestBrandImpliedMatch:
+    def test_own_brand_store_brand_omitted_title_matches(self):
+        """en-bh.ajmal.com: query 'Ajmal Aristocrat' vs a BASE title
+        'Aristocrat Eau de Parfum 75 ML' (vendor='Ajmal') -> the vendor supplies
+        the brand, so the brand-omitted title resolves to the genuine 22.55 BHD."""
+        cat = _catalog("Aristocrat Eau de Parfum 75 ML", "Ajmal")
+        r = _match_shopify_product(cat, "Ajmal Aristocrat", "BHD", "en-bh.ajmal.com", "fragrances")
+        assert r is not None, "brand-omitted own-store title was rejected (the bug)"
+        assert r["amount"] == 22.55
+        assert r["currency"] == "BHD"
+        assert r["source_method"] == "shopify_json"
+
+    def test_flanker_still_rejected_no_fab(self):
+        """CORRECTNESS: a base query 'Ajmal Aristocrat' must NOT match a distinct
+        FLANKER 'Aristocrat Coral' — even on the right brand's store — because
+        Coral is a different product. The brand-implied relaxation does NOT open
+        the flanker (the _selection_match axis/superset gate still rejects it)."""
+        cat = _catalog("Aristocrat Coral Eau de Parfum 75 ML", "Ajmal")
+        r = _match_shopify_product(cat, "Ajmal Aristocrat", "BHD", "en-bh.ajmal.com", "fragrances")
+        assert r is None
+
+    def test_wrong_brand_still_rejected(self):
+        """A DIFFERENT query brand must NOT be satisfied by the store's vendor:
+        query 'Rasasi Aristocrat' vs an Ajmal-vendor title -> None (the vendor is
+        Ajmal, so 'rasasi' is never dropped and stays required; the title lacks
+        it). This is the wrong-match guard."""
+        cat = _catalog("Aristocrat Eau de Parfum 75 ML", "Ajmal")
+        r = _match_shopify_product(cat, "Rasasi Aristocrat", "BHD", "en-bh.ajmal.com", "fragrances")
+        assert r is None
+
+    def test_brand_present_title_still_matches(self):
+        """Regression: a title that DOES carry the brand still matches (the fix
+        only RELAXES a brand-omitted title, never rejects a brand-present one)."""
+        cat = _catalog("Ajmal Aristocrat Eau de Parfum 75 ML", "Ajmal")
+        r = _match_shopify_product(cat, "Ajmal Aristocrat", "BHD", "en-bh.ajmal.com", "fragrances")
+        assert r is not None and r["amount"] == 22.55
+
+    def test_no_vendor_field_unchanged(self):
+        """A product with NO vendor field behaves exactly as today (brand
+        required) — the fix reads vendor defensively, empty -> legacy behaviour."""
+        cat = {"_store_currency": "BHD", "products": [{
+            "title": "Aristocrat Eau de Parfum 75 ML", "handle": "x",
+            "variants": [{"price": "22.55", "available": True, "title": "75ml"}],
+        }]}
+        r = _match_shopify_product(cat, "Ajmal Aristocrat", "BHD", "en-bh.ajmal.com", "fragrances")
+        assert r is None  # no vendor -> brand still required -> rejected (as today)
+
+    def test_flag_off_byte_identical(self, monkeypatch):
+        """ENABLE_EXACT_PRICE_GATE=false -> candidate_brand is inert (strict_title_match
+        computes brand_toks only under the gate), so the brand-omitted title is
+        REJECTED exactly as pre-fix."""
+        monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "false")
+        cat = _catalog("Aristocrat Eau de Parfum 75 ML", "Ajmal")
+        r = _match_shopify_product(cat, "Ajmal Aristocrat", "BHD", "en-bh.ajmal.com", "fragrances")
+        assert r is None  # flag-off: brand required, brand-omitted title rejected


### PR DESCRIPTION
## Brand-implied matching: recover genuine prices from own-brand stores

An own-brand store **omits its own brand** from product titles — Ajmal's BH Shopify store lists `ARISTOCRAT HER EDP 75ML` (vendor `Ajmal`), **not** "Ajmal Aristocrat". The app queries "Ajmal Aristocrat", so the strict matcher — called **without** a `candidate_brand` — required the `ajmal` token in the title and **rejected the exact SKU**, throwing away a genuine BHD price. This is a direct cause of the "Ajmal Aristocrat vs Rasasi Hawas" / "Ajmal Wisal" dead-ends surfaced by the scraper-fleet audit.

`magento_graphql` / `occ` / `noon` / `algolia` already handle this via a `candidate_brand` derived from the candidate's own brand field. **5 adapters lacked it** — this PR brings them to parity.

### The fix
Each adapter derives the candidate product's **own** brand from its platform field and threads `candidate_brand` into all three matcher gates (`strict_title_match` + `selection_primary_admits` + `_selection_match`), via a new shared, crash-safe `normalize_candidate_brand` helper:

| adapter | brand field |
|---|---|
| shopify (`_match_shopify_product`) — also fixes `shopify_gcc` | `vendor` |
| unbxd | `brandEn` (list `brand` fallback) |
| salla | nested `brand.name` |
| woo | `brands[0].name` / `pa_brand` attribute term |
| rest_json | per-store: panda `brand.name`, beautybooth `brand` |

**Safety (structural, no wrong-match):** `candidate_brand` only drops the candidate's *own* brand tokens, and only when they alias-match the query brand — a **wrong-brand** candidate keeps the query brand required and is still rejected; `_selection_match(candidate_brand=)` vets the full SKU alongside (a flanker/wrong-SKU is still rejected — verified). Gated by `exact_gate_enabled()` inside the matchers → **flag-OFF (`ENABLE_EXACT_PRICE_GATE=false`) is byte-identical.**

### Verification
- **Live** against the real Ajmal store: `Ajmal Aristocrat` → **22.55 BHD**, `Ajmal Wisal` → **10.25 BHD**, `Ajmal Amber Wood` → **57.0 BHD** — all previously discarded.
- **24 new tests** (shopify + per-adapter parity + wrong-brand rejection + flanker no-fab rejection + flag-OFF + the `normalize_candidate_brand` shape/robustness matrix) + **101 existing adapter-suite tests** green.
- **Comm-gate:** branch-only-NEW == [] vs the `102272d` main baseline.
- **Coverage-driven adversarial review** (2 lenses): core safety CLEAN (no wrong-price accept; flag-OFF byte-identical — both verified empirically). The two findings it raised — a salla `AttributeError` on a bare-string `brand`, and dict/list stringification — are fixed by the shared normalizer and pinned by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)