### PR TITLE
feat(discovery): Bright Data SERP fallback for Serper depletion (flag-OFF)

### DIFF
--- a/app/services/brightdata_service.py
+++ b/app/services/brightdata_service.py
@@ -1,0 +1,169 @@
+"""Bright Data SERP API fallback provider (2026-07-07).
+
+A drop-in, Serper-SHAPED discovery provider used as a FALLBACK when the Serper
+key is exhausted/erroring (the recurring free-key-depletion class the scraper
+audit surfaced). Bright Data's SERP API has a 5,000-requests/MONTH forever-free
+tier, so this can cover the fallback-of-last-resort volume at $0.
+
+Request shape (verified against docs.brightdata.com/api-reference/serp):
+    POST https://api.brightdata.com/request
+      Authorization: Bearer <BRIGHTDATA_API_KEY>
+      Content-Type: application/json
+      {"zone": "<BRIGHTDATA_ZONE>",
+       "url": "https://www.google.com/search?q=<q>&brd_json=1&gl=bh&hl=en&num=10",
+       "format": "raw"}
+  brd_json=1 → Google's PARSED SERP as JSON (organic[] + shopping[] for tbm=shop).
+
+Returns the SAME shape serper_service does — {"organic": [...], "shopping": [...]}
+— so the pipeline consumes it identically. NEVER raises (best-effort → {} / the
+empty shape on any error), so a Bright Data outage can never break a compare.
+
+ACTIVATION (Ahmed): set 3 Railway env vars — ENABLE_BRIGHTDATA_FALLBACK=true,
+BRIGHTDATA_API_KEY=<token>, BRIGHTDATA_ZONE=<serp zone name>. All OFF/unset →
+this module is inert and the pipeline is byte-identical to Serper-only.
+
+MAPPER NOTE: the brd_json organic/shopping field names are read DEFENSIVELY
+(link|url, description|snippet, seller|source, ...). Validate the mapping on the
+first live call after activation (a one-line probe: `python -c "import asyncio,
+app.services.brightdata_service as b; print(asyncio.run(b.bd_search_web('iphone 15')))"`)
+and tighten `_map_bd_organic` / `_map_bd_shopping` if a field differs.
+"""
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+BRIGHTDATA_URL = "https://api.brightdata.com/request"
+_GOOGLE_SEARCH = "https://www.google.com/search"
+_TIMEOUT = 20.0  # Bright Data SERP is sync but proxies a real Google fetch (1-5s)
+
+
+def _brightdata_enabled() -> bool:
+    """True iff the Bright Data fallback is active: the flag is ON *and* both
+    credentials are present. Read per-call so an env flip takes effect without a
+    restart (mirrors the serper key resolution). All unset → False → inert."""
+    flag = os.getenv("ENABLE_BRIGHTDATA_FALLBACK", "").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+    return flag and bool(os.getenv("BRIGHTDATA_API_KEY")) and bool(os.getenv("BRIGHTDATA_ZONE"))
+
+
+def _google_url(query: str, *, country: str, num: int, shopping: bool) -> str:
+    params = {"q": query, "brd_json": "1", "gl": country, "hl": "en", "num": num}
+    if shopping:
+        params["tbm"] = "shop"
+    return f"{_GOOGLE_SEARCH}?{urlencode(params)}"
+
+
+async def _bd_post(query: str, *, country: str, num: int, shopping: bool) -> Optional[Dict[str, Any]]:
+    """One Bright Data SERP request → the parsed Google SERP JSON, or None on any
+    failure. Never raises."""
+    key = os.getenv("BRIGHTDATA_API_KEY")
+    zone = os.getenv("BRIGHTDATA_ZONE")
+    if not (key and zone):
+        return None
+    payload = {
+        "zone": zone,
+        "url": _google_url(query, country=country, num=num, shopping=shopping),
+        "format": "raw",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                BRIGHTDATA_URL,
+                headers={
+                    "Authorization": f"Bearer {key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+        if resp.status_code != 200:
+            logger.warning("[brightdata] HTTP %s for %r", resp.status_code, query[:60])
+            return None
+        # format:raw returns the brd_json body directly as JSON text.
+        return resp.json()
+    except Exception as e:  # noqa: BLE001 — fallback must never break the compare
+        logger.warning("[brightdata] request failed for %r: %s", query[:60], e)
+        return None
+
+
+def _first(d: Dict[str, Any], *keys) -> Any:
+    for k in keys:
+        v = d.get(k)
+        if v not in (None, ""):
+            return v
+    return None
+
+
+def _map_bd_organic(parsed: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Bright Data parsed `organic` → Serper `organic` shape
+    ({title, link, snippet}). Defensive field reads (link|url, description|
+    snippet). Unknown/empty → []."""
+    if not isinstance(parsed, dict):
+        return []
+    rows = parsed.get("organic")
+    if not isinstance(rows, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        link = _first(r, "link", "url", "display_link")
+        if not link:
+            continue
+        out.append({
+            "title": _first(r, "title") or "",
+            "link": link,
+            "snippet": _first(r, "snippet", "description", "desc") or "",
+        })
+    return out
+
+
+def _map_bd_shopping(parsed: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Bright Data parsed shopping (tbm=shop) → Serper `shopping` shape
+    ({title, source, link, price, ...}). Bright Data may key the array as
+    `shopping` / `pla` / `products`; read defensively. Unknown/empty → []."""
+    if not isinstance(parsed, dict):
+        return []
+    rows = _first(parsed, "shopping", "pla", "products", "shopping_results")
+    if not isinstance(rows, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        link = _first(r, "link", "url", "product_link")
+        title = _first(r, "title", "name")
+        if not (link or title):
+            continue
+        out.append({
+            "title": title or "",
+            "link": link or "",
+            "source": _first(r, "source", "seller", "merchant", "store") or "",
+            "price": _first(r, "price", "extracted_price", "price_raw"),
+        })
+    return out
+
+
+async def bd_search_web(query: str, num_results: int = 10, country: str = "bh") -> Dict[str, Any]:
+    """Serper-shaped web (organic) search via Bright Data. Returns
+    {"organic": [...], "shopping": []} or {"organic": []} on miss. Never raises.
+    Caller should gate on _brightdata_enabled()."""
+    parsed = await _bd_post(query, country=country, num=num_results, shopping=False)
+    if parsed is None:
+        return {"organic": [], "error": "brightdata_unavailable"}
+    return {"organic": _map_bd_organic(parsed), "shopping": []}
+
+
+async def bd_search_shopping(query: str, country: str = "bh") -> Dict[str, Any]:
+    """Serper-shaped shopping search via Bright Data (tbm=shop). Returns
+    {"shopping": [...], "organic": []} or {"shopping": []} on miss. Never raises."""
+    parsed = await _bd_post(query, country=country, num=10, shopping=True)
+    if parsed is None:
+        return {"shopping": [], "error": "brightdata_unavailable"}
+    return {"shopping": _map_bd_shopping(parsed), "organic": _map_bd_organic(parsed)}

--- a/app/services/serper_service.py
+++ b/app/services/serper_service.py
@@ -291,7 +291,16 @@ async def search_web(
     Returns:
         Search results with organic, featured snippets, etc.
     """
+    # Bright Data fallback (2026-07-07) — when the Serper key is exhausted/absent,
+    # fall back to the Bright Data SERP API (same {organic} shape). Inert unless
+    # ENABLE_BRIGHTDATA_FALLBACK + the credentials are set → byte-identical to
+    # Serper-only when off. Local import avoids any import-time coupling.
+    from app.services.brightdata_service import _brightdata_enabled, bd_search_web
+
     if not _active_serper_key():
+        if _brightdata_enabled():
+            logger.info("[brightdata] Serper key unavailable — search_web fallback")
+            return await bd_search_web(query, num_results, country)
         logger.warning("SERPER_API_KEY not set")
         return {"organic": [], "error": "Search not configured"}
 
@@ -313,6 +322,9 @@ async def search_web(
 
     except Exception as e:
         logger.error(f"Search error: {e}")
+        if _brightdata_enabled():
+            logger.info("[brightdata] Serper /search failed (%s) — fallback", str(e)[:60])
+            return await bd_search_web(query, num_results, country)
         return {"organic": [], "error": str(e)}
 
 
@@ -522,7 +534,13 @@ async def search_price_organic(
     Organic search for price context — only called when Tier 1 shopping fails.
     Returns organic results for GPT Tier 2 price extraction.
     """
+    # Bright Data fallback (2026-07-07) — inert unless ENABLE_BRIGHTDATA_FALLBACK
+    # + creds are set (byte-identical Serper-only when off).
+    from app.services.brightdata_service import _brightdata_enabled, bd_search_web
+
     if not _active_serper_key():
+        if _brightdata_enabled():
+            return {**(await bd_search_web(product, 10, country)), "query": product}
         return {"organic": [], "error": "Search not configured"}
 
     country_terms = {
@@ -553,6 +571,10 @@ async def search_price_organic(
             if response.status_code == 200:
                 results = response.json()
                 record_usage("serper")
+            elif _brightdata_enabled():
+                # Serper non-200 (depletion/error) — fall back to Bright Data.
+                logger.info("[brightdata] Serper price-organic HTTP %s — fallback", response.status_code)
+                return {**(await bd_search_web(search_query, 10, country)), "query": search_query}
 
             return {
                 "organic": results.get("organic", []),
@@ -562,6 +584,9 @@ async def search_price_organic(
 
     except Exception as e:
         logger.error(f"Price organic search error: {e}")
+        if _brightdata_enabled():
+            logger.info("[brightdata] Serper price-organic failed (%s) — fallback", str(e)[:60])
+            return {**(await bd_search_web(search_query, 10, country)), "query": search_query}
         return {"organic": [], "error": str(e)}
 
 

--- a/tests/test_brightdata_fallback.py
+++ b/tests/test_brightdata_fallback.py
@@ -1,0 +1,147 @@
+"""Bright Data SERP fallback (2026-07-07) — provider + serper fallback wiring.
+
+Bright Data is a drop-in, Serper-shaped discovery provider used when the Serper
+key is exhausted/erroring (the free-key-depletion class the audit surfaced). It
+ships INERT: unless ENABLE_BRIGHTDATA_FALLBACK + BRIGHTDATA_API_KEY +
+BRIGHTDATA_ZONE are all set, the serper path is byte-identical to Serper-only.
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import brightdata_service as bd
+
+
+# --- a representative Bright Data brd_json=1 Google SERP response ------------
+_BD_ORGANIC = {
+    "organic": [
+        {"rank": 1, "title": "Ajmal Aristocrat EDP", "link": "https://en-bh.ajmal.com/products/aristocrat",
+         "description": "Ajmal Aristocrat 75ml"},
+        {"rank": 2, "title": "No link row", "url": "https://x.com/p", "snippet": "alt fields"},
+        {"rank": 3, "title": "dropme"},  # no link/url -> dropped
+    ],
+}
+_BD_SHOPPING = {
+    "shopping": [
+        {"title": "iPhone 15 128GB", "link": "https://noon.com/x", "seller": "noon", "price": "BHD 245"},
+        {"name": "alt-name", "product_link": "https://y.com/z", "source": "extra"},
+    ],
+}
+
+
+class TestEnabledGate:
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("ENABLE_BRIGHTDATA_FALLBACK", raising=False)
+        assert bd._brightdata_enabled() is False
+
+    def test_flag_on_but_no_creds(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_BRIGHTDATA_FALLBACK", "true")
+        monkeypatch.delenv("BRIGHTDATA_API_KEY", raising=False)
+        monkeypatch.delenv("BRIGHTDATA_ZONE", raising=False)
+        assert bd._brightdata_enabled() is False  # creds required
+
+    def test_fully_configured(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_BRIGHTDATA_FALLBACK", "true")
+        monkeypatch.setenv("BRIGHTDATA_API_KEY", "tok")
+        monkeypatch.setenv("BRIGHTDATA_ZONE", "serp")
+        assert bd._brightdata_enabled() is True
+
+
+class TestUrlBuilder:
+    def test_search_url(self):
+        u = bd._google_url("iphone 15", country="bh", num=10, shopping=False)
+        assert u.startswith("https://www.google.com/search?")
+        assert "q=iphone+15" in u and "gl=bh" in u and "hl=en" in u
+        assert "brd_json=1" in u and "num=10" in u and "tbm=shop" not in u
+
+    def test_shopping_url(self):
+        u = bd._google_url("iphone 15", country="bh", num=10, shopping=True)
+        assert "tbm=shop" in u
+
+
+class TestMappers:
+    def test_map_organic_to_serper_shape(self):
+        rows = bd._map_bd_organic(_BD_ORGANIC)
+        assert len(rows) == 2  # the no-link row is dropped
+        assert rows[0] == {"title": "Ajmal Aristocrat EDP",
+                           "link": "https://en-bh.ajmal.com/products/aristocrat",
+                           "snippet": "Ajmal Aristocrat 75ml"}
+        # defensive field reads: url -> link, snippet stays
+        assert rows[1]["link"] == "https://x.com/p" and rows[1]["snippet"] == "alt fields"
+
+    def test_map_shopping_to_serper_shape(self):
+        rows = bd._map_bd_shopping(_BD_SHOPPING)
+        assert len(rows) == 2
+        assert rows[0]["title"] == "iPhone 15 128GB" and rows[0]["source"] == "noon"
+        assert rows[0]["price"] == "BHD 245"
+        assert rows[1]["link"] == "https://y.com/z" and rows[1]["source"] == "extra"
+
+    def test_mappers_never_raise_on_junk(self):
+        for junk in (None, {}, {"organic": "x"}, {"organic": [1, None, "s"]}):
+            assert bd._map_bd_organic(junk) == []
+        for junk in (None, {}, {"shopping": 5}):
+            assert bd._map_bd_shopping(junk) == []
+
+
+@pytest.mark.asyncio
+class TestBdSearchWeb:
+    async def _mock_post(self, monkeypatch, *, status=200, body=None, raises=False):
+        resp = MagicMock(); resp.status_code = status; resp.json = MagicMock(return_value=body or _BD_ORGANIC)
+        client = MagicMock()
+        if raises:
+            client.post = AsyncMock(side_effect=RuntimeError("boom"))
+        else:
+            client.post = AsyncMock(return_value=resp)
+        cm = MagicMock(); cm.__aenter__ = AsyncMock(return_value=client); cm.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(bd.httpx, "AsyncClient", lambda *a, **k: cm)
+        monkeypatch.setenv("BRIGHTDATA_API_KEY", "tok"); monkeypatch.setenv("BRIGHTDATA_ZONE", "serp")
+
+    async def test_returns_mapped_organic(self, monkeypatch):
+        await self._mock_post(monkeypatch)
+        out = await bd.bd_search_web("iphone 15")
+        assert len(out["organic"]) == 2 and out["organic"][0]["title"] == "Ajmal Aristocrat EDP"
+
+    async def test_non_200_returns_empty(self, monkeypatch):
+        await self._mock_post(monkeypatch, status=402)
+        out = await bd.bd_search_web("iphone 15")
+        assert out["organic"] == [] and out.get("error")
+
+    async def test_exception_returns_empty_never_raises(self, monkeypatch):
+        await self._mock_post(monkeypatch, raises=True)
+        out = await bd.bd_search_web("iphone 15")
+        assert out["organic"] == []
+
+    async def test_no_creds_returns_none_shape(self, monkeypatch):
+        monkeypatch.delenv("BRIGHTDATA_API_KEY", raising=False)
+        monkeypatch.delenv("BRIGHTDATA_ZONE", raising=False)
+        out = await bd.bd_search_web("iphone 15")
+        assert out["organic"] == []
+
+
+@pytest.mark.asyncio
+class TestSerperFallbackWiring:
+    async def test_search_web_falls_back_when_no_key_and_enabled(self, monkeypatch):
+        import app.services.serper_service as ss
+        monkeypatch.setattr(ss, "_active_serper_key", lambda: None)  # Serper unavailable
+        monkeypatch.setenv("ENABLE_BRIGHTDATA_FALLBACK", "true")
+        monkeypatch.setenv("BRIGHTDATA_API_KEY", "tok"); monkeypatch.setenv("BRIGHTDATA_ZONE", "serp")
+        with patch("app.services.brightdata_service.bd_search_web",
+                   new=AsyncMock(return_value={"organic": [{"link": "x"}]})) as m:
+            out = await ss.search_web("iphone 15")
+        m.assert_awaited_once()
+        assert out["organic"] == [{"link": "x"}]
+
+    async def test_search_web_no_fallback_when_disabled_byte_identical(self, monkeypatch):
+        """Flag OFF -> the pre-fix path: no Serper key -> 'Search not configured',
+        Bright Data never called (byte-identical to Serper-only)."""
+        import app.services.serper_service as ss
+        monkeypatch.setattr(ss, "_active_serper_key", lambda: None)
+        monkeypatch.delenv("ENABLE_BRIGHTDATA_FALLBACK", raising=False)
+        with patch("app.services.brightdata_service.bd_search_web", new=AsyncMock()) as m:
+            out = await ss.search_web("iphone 15")
+        m.assert_not_awaited()
+        assert out == {"organic": [], "error": "Search not configured"}


### PR DESCRIPTION
## Bright Data SERP fallback for Serper depletion (flag-OFF, dormant)

The scraper-fleet audit confirmed the recurring cause of "no prices": the **free Serper key depletes** under normal traffic (HTTP 400 "Not enough credits"), and the `site:` discovery fallback dies with it. Research finding: **no SERP vendor recovers GCC Google Shopping** (it's thin at Google's level), but **Bright Data's SERP API** is a drop-in, Serper-shaped organic-discovery provider with a **5,000-request/month forever-free tier** — enough to cover the fallback-of-last-resort at $0.

### What this adds
- `app/services/brightdata_service.py` — `POST api.brightdata.com/request`, `Bearer` auth, `google.com/search?…&brd_json=1&gl=bh&hl=en` (`tbm=shop` for shopping), with a **defensive mapper** to the Serper `{organic, shopping}` shape. Never raises.
- Wired as a **fallback** in `serper_service.search_web` + `search_price_organic`: when the Serper key is absent/exhausted or the call errors **and** the flag+creds are set → Bright Data.

### Safety
Ships **inert** — `ENABLE_BRIGHTDATA_FALLBACK` + `BRIGHTDATA_API_KEY` + `BRIGHTDATA_ZONE` all unset → `_brightdata_enabled()` is False → the fallback branches are skipped → **byte-identical to Serper-only.**

### Activation (Ahmed)
1. Bright Data account (free) → create a **SERP zone** → copy the API token + zone name.
2. Set 3 Railway vars: `ENABLE_BRIGHTDATA_FALLBACK=true`, `BRIGHTDATA_API_KEY=…`, `BRIGHTDATA_ZONE=…`.
3. **Validate the mapper** on the first live call (one-line probe in the module docstring) and tighten `_map_bd_organic`/`_map_bd_shopping` if a field name differs — inherent to a new-provider trial.

### Tests
14 unit tests (flag gating, URL builder, defensive mappers, mocked request, fallback wiring, flag-OFF byte-identity) + 77 serper-suite tests green.

> Note: this is the *discovery* provider. On its own it doesn't make the cold-compare prices visible — the bigger lever is the **warmer** (cache-served, bypasses the 30s cap). This removes the Serper-depletion wall so the discovery + adapters can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)