### PR TITLE
feat(discovery): make the Bright Data SERP fallback self-validating

### DIFF
--- a/app/services/brightdata_service.py
+++ b/app/services/brightdata_service.py
@@ -83,10 +83,36 @@ async def _bd_post(query: str, *, country: str, num: int, shopping: bool) -> Opt
                 json=payload,
             )
         if resp.status_code != 200:
-            logger.warning("[brightdata] HTTP %s for %r", resp.status_code, query[:60])
+            logger.warning(
+                "[brightdata] HTTP %s for %r: %s", resp.status_code, query[:60],
+                (resp.text or "")[:200],
+            )
             return None
-        # format:raw returns the brd_json body directly as JSON text.
-        return resp.json()
+        # format:raw + brd_json=1 returns the PARSED Google SERP as JSON text.
+        try:
+            parsed = resp.json()
+        except Exception:  # noqa: BLE001 — non-JSON (e.g. raw HTML) — self-diagnose
+            # SELF-VALIDATION (2026-07-07) — I could not live-test the response from
+            # the build machine (api.brightdata.com is TLS-blocked there). If brd_json
+            # did NOT yield JSON, log the first 300 chars so the FIRST prod call reveals
+            # whether the zone returns HTML (→ needs data_format:json) instead of a
+            # silent empty fallback.
+            logger.warning(
+                "[brightdata] non-JSON response for %r (brd_json may be off / zone "
+                "returns HTML) — first 300 chars: %s", query[:60], (resp.text or "")[:300],
+            )
+            return None
+        # First-call schema visibility — log the parsed top-level shape at INFO so the
+        # mapper can be validated/tightened from prod logs without a debug flag.
+        if isinstance(parsed, dict):
+            _org = parsed.get("organic")
+            logger.info(
+                "[brightdata] parsed OK for %r: top-keys=%s organic=%s org0_keys=%s",
+                query[:40], list(parsed.keys())[:12],
+                (len(_org) if isinstance(_org, list) else type(_org).__name__),
+                (list(_org[0].keys()) if isinstance(_org, list) and _org and isinstance(_org[0], dict) else None),
+            )
+        return parsed
     except Exception as e:  # noqa: BLE001 — fallback must never break the compare
         logger.warning("[brightdata] request failed for %r: %s", query[:60], e)
         return None

--- a/tests/test_brightdata_fallback.py
+++ b/tests/test_brightdata_fallback.py
@@ -115,6 +115,18 @@ class TestBdSearchWeb:
         out = await bd.bd_search_web("iphone 15")
         assert out["organic"] == []
 
+    async def test_non_json_response_self_diagnoses_returns_empty(self, monkeypatch):
+        """A 200 with a NON-JSON body (e.g. raw HTML if brd_json is off) must not
+        crash — resp.json() raises, _bd_post logs + returns None, fallback is empty."""
+        resp = MagicMock(); resp.status_code = 200
+        resp.json = MagicMock(side_effect=ValueError("no json")); resp.text = "<html>...</html>"
+        client = MagicMock(); client.post = AsyncMock(return_value=resp)
+        cm = MagicMock(); cm.__aenter__ = AsyncMock(return_value=client); cm.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(bd.httpx, "AsyncClient", lambda *a, **k: cm)
+        monkeypatch.setenv("BRIGHTDATA_API_KEY", "tok"); monkeypatch.setenv("BRIGHTDATA_ZONE", "serp_api1")
+        out = await bd.bd_search_web("iphone 15")
+        assert out["organic"] == []
+
     async def test_no_creds_returns_none_shape(self, monkeypatch):
         monkeypatch.delenv("BRIGHTDATA_API_KEY", raising=False)
         monkeypatch.delenv("BRIGHTDATA_ZONE", raising=False)


### PR DESCRIPTION
Make the Bright Data SERP fallback SELF-VALIDATING. api.brightdata.com is TLS-blocked from the build machine, so the brd_json response schema could not be live-tested. The first prod call now logs the actual response shape (non-200 body, non-JSON hint, or parsed top-level+organic[0] keys) so the defensive mapper can be validated/tightened from prod logs — instead of a silent empty fallback. Logging-only, no behavior change, never raises. +1 test.

Activation: ENABLE_BRIGHTDATA_FALLBACK=true, BRIGHTDATA_API_KEY=<key>, BRIGHTDATA_ZONE=serp_api1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)