### PR TITLE
feat(discovery): fail-fast Serper timeout/rotation + warmer guard observability

### DIFF
--- a/app/services/serper_service.py
+++ b/app/services/serper_service.py
@@ -123,8 +123,13 @@ def _mark_serper_key_exhausted(key: str) -> None:
         )
 
 
-def _active_serper_key() -> Optional[str]:
+def _active_serper_key(exclude: Optional[set] = None) -> Optional[str]:
     """The active Serper key.
+
+    (exclude: keys to skip for THIS selection — used by the fail-fast rotation
+    loop to advance past a key that just timed out WITHOUT persistently marking it
+    credit-exhausted. Defaults None -> byte-identical to the pre-fail-fast
+    selection.)
 
     SINGLE-KEY INERT (the common prod case: only SERPER_API_KEY set, no
     SERPER_API_KEYS): with 0 or 1 resolved keys there is NO exhaustion machinery
@@ -140,6 +145,8 @@ def _active_serper_key() -> Optional[str]:
     if len(keys) <= 1:
         return keys[0] if keys else None
     for key in keys:
+        if exclude and key in exclude:
+            continue
         if not _is_serper_key_exhausted(key):
             return key
     return None
@@ -167,6 +174,58 @@ def _response_signals_exhaustion(status_code: Optional[int], body_text: str) -> 
     ):
         return True
     return False
+
+
+# ============================================
+# FAIL-FAST SERPER TIMEOUT (ENABLE_SERPER_FAIL_FAST — opt-in, default OFF)
+# ============================================
+# The multi-key rotation loop below can stack N x the per-call timeout (3 keys x
+# 15s = 45s) when free keys respond SLOWLY (throttled depletion-400s), starving
+# the Serper-free genuine-BH adapter fan-out inside the price race. Opt-in
+# fail-fast: a tighter connect/read budget + an overall rotation deadline +
+# rotate-on-timeout so a slow key fails fast. Flag OFF -> the timeout stays 15.0
+# and the loop is byte-identical (no deadline, no timeout-catch, no clock read).
+import time as _time
+
+
+def _serper_fail_fast_enabled() -> bool:
+    """Fail-closed flag mirror (same truthy set as the other crons/flags)."""
+    return os.getenv("ENABLE_SERPER_FAIL_FAST", "").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+
+
+def _serper_float_env(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _serper_timeout():
+    """httpx timeout for Serper calls. Flag OFF -> 15.0 (byte-identical to the
+    pre-fail-fast literal). Flag ON -> a split connect/read budget (conservative
+    canary defaults 3s connect / 10s read, env-tunable via SERPER_CONNECT_TIMEOUT
+    / SERPER_READ_TIMEOUT) so a throttled key aborts fast instead of burning the
+    full 15s. Keep SERPER_ROTATION_DEADLINE > SERPER_READ_TIMEOUT so a multi-key
+    run still gets >=2 attempts."""
+    if not _serper_fail_fast_enabled():
+        return 15.0
+    read = _serper_float_env("SERPER_READ_TIMEOUT", 10.0)
+    connect = _serper_float_env("SERPER_CONNECT_TIMEOUT", 3.0)
+    return httpx.Timeout(read, connect=connect)
+
+
+def _serper_rotation_deadline() -> float:
+    """Overall wall-clock budget (seconds) for the whole multi-key rotation loop,
+    so N slow keys cannot stack to N x the per-call timeout. Conservative canary
+    default 14s (> the 10s read default -> multi-key gets >=2 attempts). Env-tunable."""
+    return _serper_float_env("SERPER_ROTATION_DEADLINE", 14.0)
+
+
+def _serper_now() -> float:
+    """Monotonic clock read (indirected so the rotation deadline is testable)."""
+    return _time.monotonic()
 
 
 async def _serper_post(client, path: str, payload: Dict[str, Any]):
@@ -208,21 +267,49 @@ async def _serper_post(client, path: str, payload: Dict[str, Any]):
     attempts = 0
     max_attempts = max(1, len(keys))
     last_response = None
+    # Fail-fast (opt-in) — bound the loop's wall-clock + rotate on a per-call
+    # timeout. Flag OFF: fail_fast=False makes every branch below inert, so the
+    # loop is byte-identical to the pre-fail-fast version (deadline never checked,
+    # a timeout re-raises exactly as an un-caught one would, clock never read).
+    fail_fast = _serper_fail_fast_enabled()
+    deadline = _serper_rotation_deadline() if fail_fast else 0.0
+    start = _serper_now() if fail_fast else 0.0
+    last_timeout_exc: Optional[Exception] = None
+    timed_out: set = set()  # keys that timed out THIS call (fail-fast local skip)
     while attempts < max_attempts:
-        key = _active_serper_key()
+        # Overall deadline — stop rotating once the wall-clock budget is spent so
+        # N slow keys can't stack to N x the per-call timeout.
+        if fail_fast and (_serper_now() - start) >= deadline:
+            break
+        # exclude=timed_out advances past a key that timed out earlier in THIS
+        # call; the set stays empty when the flag is off (byte-identical).
+        key = _active_serper_key(exclude=timed_out)
         if not key:
             # All keys exhausted mid-loop — return the last response (if any) so
             # the caller's existing handling degrades gracefully.
             break
         attempts += 1
-        response = await client.post(
-            f"{SERPER_BASE_URL}{path}",
-            headers={
-                "X-API-KEY": key,
-                "Content-Type": "application/json",
-            },
-            json=payload,
-        )
+        try:
+            response = await client.post(
+                f"{SERPER_BASE_URL}{path}",
+                headers={
+                    "X-API-KEY": key,
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+        except httpx.TimeoutException as exc:
+            # Flag OFF -> re-raise immediately (byte-identical: the timeout
+            # propagates to the caller exactly as before). Flag ON -> a per-call
+            # timeout ROTATES to the next key (a timeout is NOT a depletion
+            # signal, so the key is NOT marked exhausted — a transiently-slow key
+            # may be healthy). If every attempt times out, the last one is
+            # re-raised below so the caller's except-path fires as before.
+            if not fail_fast:
+                raise
+            last_timeout_exc = exc
+            timed_out.add(key)  # skip this key for the rest of THIS call
+            continue
         last_response = response
         # Inspect for credit exhaustion. Reading .text on a MagicMock is cheap;
         # on a real httpx.Response it is the already-buffered body.
@@ -236,6 +323,11 @@ async def _serper_post(client, path: str, payload: Dict[str, Any]):
             _mark_serper_key_exhausted(key)
             continue  # rotate to the next non-exhausted key
         return response
+    # Fail-fast: every attempt timed out (no non-timeout response landed) —
+    # re-raise the last timeout so the caller degrades / falls back to Bright
+    # Data exactly as the pre-fail-fast timeout-propagation did.
+    if fail_fast and last_response is None and last_timeout_exc is not None:
+        raise last_timeout_exc
     return last_response
 
 
@@ -305,7 +397,7 @@ async def search_web(
         return {"organic": [], "error": "Search not configured"}
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
+        async with httpx.AsyncClient(timeout=_serper_timeout()) as client:
             response = await _serper_post(
                 client,
                 "/search",
@@ -380,7 +472,7 @@ async def _do_serper_shopping(product: str, gl: str) -> Dict[str, Any]:
     parsed JSON or {} on error. No retry, no fallback — fallback logic
     lives in the caller (search_product_prices)."""
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
+        async with httpx.AsyncClient(timeout=_serper_timeout()) as client:
             shopping_response = await _serper_post(
                 client,
                 "/shopping",
@@ -555,7 +647,7 @@ async def search_price_organic(
     search_query = f"{product} {location_term}"
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
+        async with httpx.AsyncClient(timeout=_serper_timeout()) as client:
             response = await _serper_post(
                 client,
                 "/search",
@@ -647,7 +739,7 @@ async def search_videos(
         return {"videos": [], "error": "Search not configured"}
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
+        async with httpx.AsyncClient(timeout=_serper_timeout()) as client:
             response = await _serper_post(
                 client,
                 "/videos",
@@ -674,7 +766,7 @@ async def search_images(
         return {"images": [], "error": "Search not configured"}
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
+        async with httpx.AsyncClient(timeout=_serper_timeout()) as client:
             response = await _serper_post(
                 client,
                 "/images",
@@ -710,7 +802,7 @@ async def search_news(
         return {"news": [], "error": "Search not configured"}
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
+        async with httpx.AsyncClient(timeout=_serper_timeout()) as client:
             response = await _serper_post(
                 client,
                 "/news",

--- a/scripts/cron_warm_price_cache.py
+++ b/scripts/cron_warm_price_cache.py
@@ -239,6 +239,19 @@ async def _warm_one(record: Dict[str, Any]) -> Dict[str, int]:
                 tally["estimated"] += 1
             else:
                 tally["none"] += 1
+        # Observability (warmer-only) — surface WHY prices pended so a `none`-heavy
+        # run is diagnosable (not_exact / out_of_stock / non_pdp_url / accessory)
+        # without a code dive. Reads the response's metadata.guard_rejected diag
+        # (response_builder B7). Never affects the tally or the price path.
+        guards = (r.get("metadata") or {}).get("guard_rejected") or []
+        if guards:
+            # guard_rejected is a list of {product_index, reason} dicts
+            # (response_builder B7); log the reason strings (defensive vs a bare
+            # string shape) so the WHY of each pend is grep-able in the run log.
+            reasons = [g.get("reason") if isinstance(g, dict) else g for g in guards]
+            logger.info(
+                "[cron_warm] %r guard_rejected=%s", record.get("query"), reasons
+            )
     except Exception as exc:  # noqa: BLE001 — one bad query must not kill the run
         logger.warning("[cron_warm] warm failed for %r: %s", record.get("query"), exc)
     return tally

--- a/tests/test_cron_warm_price_cache.py
+++ b/tests/test_cron_warm_price_cache.py
@@ -72,6 +72,53 @@ def test_warm_one_never_raises(monkeypatch):
     assert out == {"genuine": 0, "converted": 0, "estimated": 0, "none": 0}
 
 
+def test_warm_one_logs_guard_rejected(monkeypatch, caplog):
+    """Observability (warmer-only): when the response pends prices, `_warm_one`
+    surfaces the correctness-gate reasons (metadata.guard_rejected) in the log so
+    a `none`-heavy run is diagnosable — WITHOUT changing the tally return contract."""
+    import logging
+
+    class _Svc:
+        async def compare_from_text(self, query, region="bahrain", nocache=True):
+            return {
+                "products": [
+                    {"name": "A", "price": {"amount": 21.5, "source_method": "page_scrape_jsonld"}},
+                    {"name": "B", "price": {"amount": None, "source_method": None}},
+                ],
+                "metadata": {"guard_rejected": [
+                    {"product_index": 1, "reason": "not_exact:concentration"},
+                    {"product_index": 1, "reason": "out_of_stock"},
+                ]},
+            }
+
+    import app.services.structured_comparison_service as scs
+    monkeypatch.setattr(scs, "get_comparison_service", lambda: _Svc())
+    caplog.set_level(logging.INFO)
+    out = asyncio.run(warmer._warm_one({"query": "A vs B"}))
+    # return contract preserved (tests + main() depend on the exact 4-key dict)
+    assert out == {"genuine": 1, "converted": 0, "estimated": 0, "none": 1}
+    # the guard reasons are surfaced for diagnosis
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("guard_rejected" in m and "not_exact:concentration" in m for m in msgs), msgs
+
+
+def test_warm_one_no_guard_log_when_none_rejected(monkeypatch, caplog):
+    """No metadata.guard_rejected -> no guard log line (clean runs stay quiet)."""
+    import logging
+
+    class _Svc:
+        async def compare_from_text(self, query, region="bahrain", nocache=True):
+            return {"products": [
+                {"name": "A", "price": {"amount": 21.5, "source_method": "page_scrape_jsonld"}},
+            ]}
+
+    import app.services.structured_comparison_service as scs
+    monkeypatch.setattr(scs, "get_comparison_service", lambda: _Svc())
+    caplog.set_level(logging.INFO)
+    asyncio.run(warmer._warm_one({"query": "A vs B"}))
+    assert not any("guard_rejected" in r.getMessage() for r in caplog.records)
+
+
 def test_rotation_window_bounds_and_wraps(monkeypatch):
     monkeypatch.setattr("app.services.cache_service.redis_client", None, raising=False)
     queries = [{"id": str(i), "query": str(i)} for i in range(5)]

--- a/tests/test_serper_fail_fast.py
+++ b/tests/test_serper_fail_fast.py
@@ -1,0 +1,254 @@
+"""Serper fail-fast timeout/rotation (ENABLE_SERPER_FAIL_FAST).
+
+The multi-key rotation loop in `_serper_post` rotates ONLY on a credit-depletion
+signal; a SLOW (throttled) free key burns the full per-call timeout each attempt,
+so 3 keys can stack to 3x the per-call timeout (~45s) and STARVE the Serper-free
+genuine-BH adapter fan-out. This suite pins the opt-in fail-fast layer:
+
+  - _serper_timeout(): flag OFF -> 15.0 (byte-identical); flag ON -> split
+    connect/read budget (defaults 3s/8s, env-tunable).
+  - _serper_post(): flag OFF -> a timeout PROPAGATES exactly as before (no catch,
+    no rotation, no clock read = byte-identical). Flag ON -> a per-call timeout
+    ROTATES to the next key (NOT marked exhausted — a timeout is not depletion),
+    an overall wall-clock deadline stops the loop stacking, and an all-timeout run
+    RE-RAISES the last timeout so the caller's except-path (Bright Data / degrade)
+    fires exactly as before.
+
+httpx + Redis mocked at the module level exactly as test_serper_multikey_failover.
+"""
+import httpx
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.services import serper_service
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+def _mock_response(status_code: int = 200, json_data: dict | None = None,
+                   text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data if json_data is not None else {"organic": []}
+    resp.text = text
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    return resp
+
+
+class _FakeClient:
+    """A stand-in httpx client whose .post returns / raises `items` in order,
+    recording the X-API-KEY of each attempt."""
+
+    def __init__(self, items):
+        self.items = items
+        self.n = 0
+        self.keys = []
+
+    async def post(self, url, headers=None, json=None):
+        self.keys.append((headers or {}).get("X-API-KEY"))
+        item = self.items[self.n]
+        self.n += 1
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _patch_httpx_seq(items):
+    """Patch httpx.AsyncClient so `async with ... as client` yields a _FakeClient
+    over `items` (responses or exceptions-to-raise). Returns (ctx, holder) where
+    holder['client'] is the live fake for key/attempt assertions."""
+    holder = {}
+
+    class _AsyncClient:
+        def __init__(self, *a, **k):
+            self._c = _FakeClient(items)
+            holder["client"] = self._c
+
+        async def __aenter__(self):
+            return self._c
+
+        async def __aexit__(self, *a):
+            return False
+
+    return patch("app.services.serper_service.httpx.AsyncClient", _AsyncClient), holder
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+
+    def set(self, key, value):
+        self.store[key] = value
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    import app.services.cache_service as cache_service
+    r = _FakeRedis()
+    monkeypatch.setattr(cache_service, "redis_client", r)
+    serper_service._serper_exhausted_logged.clear()
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (
+        "SERPER_API_KEYS", "ENABLE_SERPER_FAIL_FAST", "ENABLE_BRIGHTDATA_FALLBACK",
+        "SERPER_READ_TIMEOUT", "SERPER_CONNECT_TIMEOUT", "SERPER_ROTATION_DEADLINE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    serper_service._serper_exhausted_logged.clear()
+
+
+_NOT_ENOUGH = '{"message":"Not enough credits"}'
+
+
+# --------------------------------------------------------------------------- #
+# _serper_timeout()                                                            #
+# --------------------------------------------------------------------------- #
+def test_serper_timeout_flag_off_is_15():
+    assert serper_service._serper_timeout() == 15.0
+
+
+def test_serper_timeout_flag_on_split(monkeypatch):
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "true")
+    t = serper_service._serper_timeout()
+    assert isinstance(t, httpx.Timeout)
+    assert t.read == 10.0
+    assert t.connect == 3.0
+
+
+def test_serper_timeout_flag_on_env_override(monkeypatch):
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "1")
+    monkeypatch.setenv("SERPER_READ_TIMEOUT", "5")
+    monkeypatch.setenv("SERPER_CONNECT_TIMEOUT", "2")
+    t = serper_service._serper_timeout()
+    assert t.read == 5.0
+    assert t.connect == 2.0
+
+
+# --------------------------------------------------------------------------- #
+# _serper_post — flag OFF is byte-identical (timeout propagates, no clock)     #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_post_flag_off_timeout_propagates(monkeypatch, fake_redis):
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2")
+    client = _FakeClient([httpx.ReadTimeout("slow")])
+    with pytest.raises(httpx.ReadTimeout):
+        await serper_service._serper_post(client, "/search", {"q": "x"})
+    # exactly ONE attempt, no rotation on a timeout when the flag is off
+    assert client.keys == ["k1"]
+    assert not serper_service._is_serper_key_exhausted("k1")
+
+
+@pytest.mark.asyncio
+async def test_post_flag_off_does_not_read_clock(monkeypatch, fake_redis):
+    """Byte-identical: with the flag off, the rotation-deadline clock is never
+    consulted (no added overhead / behavior)."""
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2")
+    now = MagicMock(side_effect=AssertionError("clock must not be read flag-off"))
+    monkeypatch.setattr(serper_service, "_serper_now", now)
+    client = _FakeClient([_mock_response(200, {"organic": [{"ok": 1}]})])
+    resp = await serper_service._serper_post(client, "/search", {"q": "x"})
+    assert resp.status_code == 200
+    now.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# _serper_post — flag ON rotate-on-timeout / reraise / deadline                #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_post_flag_on_rotates_on_timeout(monkeypatch, fake_redis):
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "true")
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2")
+    healthy = _mock_response(200, {"organic": [{"ok": 1}]})
+    client = _FakeClient([httpx.ReadTimeout("slow"), healthy])
+    resp = await serper_service._serper_post(client, "/search", {"q": "x"})
+    assert resp is healthy
+    assert client.keys == ["k1", "k2"], "a timeout on k1 must rotate to k2"
+    # a timeout is NOT a depletion signal — k1 must NOT be flagged exhausted
+    assert not serper_service._is_serper_key_exhausted("k1")
+
+
+@pytest.mark.asyncio
+async def test_post_flag_on_all_timeout_reraises(monkeypatch, fake_redis):
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "true")
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2")
+    client = _FakeClient([httpx.ReadTimeout("slow"), httpx.ConnectTimeout("slow")])
+    with pytest.raises(httpx.TimeoutException):
+        await serper_service._serper_post(client, "/search", {"q": "x"})
+    assert client.keys == ["k1", "k2"], "both keys attempted before giving up"
+    assert not serper_service._is_serper_key_exhausted("k1")
+    assert not serper_service._is_serper_key_exhausted("k2")
+
+
+@pytest.mark.asyncio
+async def test_post_flag_on_deadline_stops_rotation(monkeypatch, fake_redis):
+    """Once the overall wall-clock deadline is hit, the loop STOPS rotating even
+    though healthy keys remain — so N slow keys can't stack to N x per-call."""
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "true")
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2,k3")
+    # clock: start=0, iter1-top=0 (<deadline -> proceed), iter2-top=999 (>=deadline -> break)
+    clock = iter([0.0, 0.0, 999.0])
+    monkeypatch.setattr(serper_service, "_serper_now", lambda: next(clock))
+    depleted = _mock_response(402, {}, text=_NOT_ENOUGH)  # k1 -> exhausted -> continue
+    healthy = _mock_response(200, {"organic": [{"ok": 1}]})  # would be k2 but for the deadline
+    client = _FakeClient([depleted, healthy])
+    resp = await serper_service._serper_post(client, "/search", {"q": "x"})
+    assert client.keys == ["k1"], "deadline must stop the loop before trying k2"
+    assert resp is depleted  # last_response returned after the deadline break
+    assert serper_service._is_serper_key_exhausted("k1")
+
+
+@pytest.mark.asyncio
+async def test_post_flag_on_timeout_then_depletion_returns_depletion(monkeypatch, fake_redis):
+    """A timeout on k1 then a real depletion-402 on k2 must RETURN the 402
+    (last_response), NOT reraise the earlier timeout — a real response beats the
+    timeout-degrade, and the reraise-guard must not shadow it."""
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "true")
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2")
+    depleted = _mock_response(402, {}, text=_NOT_ENOUGH)
+    client = _FakeClient([httpx.ReadTimeout("slow"), depleted])
+    resp = await serper_service._serper_post(client, "/search", {"q": "x"})
+    assert resp is depleted, "a real depletion response beats the timeout reraise"
+    assert client.keys == ["k1", "k2"]
+    assert not serper_service._is_serper_key_exhausted("k1")  # timeout != depletion
+    assert serper_service._is_serper_key_exhausted("k2")      # 402 = depletion
+
+
+@pytest.mark.asyncio
+async def test_post_flag_on_deadline_zero_breaks_before_any_post(monkeypatch, fake_redis):
+    """SERPER_ROTATION_DEADLINE<=0 (operator misconfig) breaks before any POST and
+    degrades gracefully (returns None, no crash) — the documented nit."""
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "true")
+    monkeypatch.setenv("SERPER_ROTATION_DEADLINE", "0")
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2")
+    client = _FakeClient([_mock_response(200, {"organic": []})])
+    resp = await serper_service._serper_post(client, "/search", {"q": "x"})
+    assert resp is None
+    assert client.keys == [], "no POST fires when the rotation deadline is already spent"
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end: search_web degrades gracefully on an all-timeout fail-fast run   #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_search_web_flag_on_all_timeout_degrades(monkeypatch, fake_redis):
+    monkeypatch.setenv("ENABLE_SERPER_FAIL_FAST", "true")
+    monkeypatch.setenv("SERPER_API_KEYS", "k1,k2")
+    ctx, holder = _patch_httpx_seq([httpx.ReadTimeout("s"), httpx.ReadTimeout("s")])
+    with ctx:
+        result = await serper_service.search_web("q")
+    # the reraised timeout reaches search_web's except -> graceful degrade
+    assert result.get("error")
+    assert result.get("organic") == []
+    assert holder["client"].keys == ["k1", "k2"]


### PR DESCRIPTION
## What

Two **flag-OFF-byte-identical** hygiene fixes that unblock the "Bright Data + rest of scrapers" genuine-price strategy (no paid Serper key). Emerged from this session's verified diagnosis of the warmer's `genuine=0` electronics run.

### Fix A — fail-fast Serper timeout/rotation (`ENABLE_SERPER_FAIL_FAST`, default OFF)

**Problem (verified in prod logs):** the multi-key rotation loop in `_serper_post` rotates **only** on a credit-depletion signal. A *slow/throttled* free key returns a slow depletion-400 (~14s) or a slow-200, burning the full `timeout=15.0` each attempt — 3 keys stack to **~45s** (`serper_shopping delta_ms=28006` observed), starving the Serper-free genuine-BH adapter fan-out inside the 15s price race and hitting the 30s cap on cold compares (the "This one's not loading" class).

**Fix (opt-in):**
- `_serper_timeout()` → split connect/read budget (**conservative canary defaults `SERPER_CONNECT_TIMEOUT=3s` / `SERPER_READ_TIMEOUT=10s`**, env-tunable) so a throttled key aborts fast.
- An overall rotation **deadline** (`SERPER_ROTATION_DEADLINE=14s`, kept `> read` so a multi-key run still gets ≥2 attempts) so N slow keys can't stack to N×per-call.
- **rotate-on-timeout**: a per-call timeout advances to the next key **without** marking it credit-exhausted (a timeout ≠ depletion; a transiently-slow key may be healthy). If *every* attempt times out, the last timeout is **re-raised** so the caller's Bright-Data/degrade path fires exactly as before. A depletion response after an earlier timeout is returned (not shadowed by the reraise).

**Flag OFF = byte-identical:** `_serper_timeout()` returns the literal `15.0`; the `exclude` set stays empty (no filtering); no deadline check; the timeout re-raises exactly as an un-caught one would; the monotonic clock is never read.

### Fix B — warmer guard observability (no flag; warmer-only)

`_warm_one` now surfaces the response `metadata.guard_rejected` reasons (a list of `{product_index, reason}` dicts → the reason strings `not_exact` / `out_of_stock` / `non_pdp_url` / `accessory`) so a `none`-heavy warmer run is diagnosable without a code dive — and so we can **measure** the VariantDescriptor work's impact (watch `not_exact` rejections drop). The tally return contract is unchanged (still the exact 4-key dict); zero live-path impact.

## Why now

Session diagnosis (live-probed) showed the warmer's electronics `genuine=0` was: degraded Serper → `converted_usd` (fail-closed-pended, working as designed) + the sharafdg Algolia adapter's **valid** key but a descriptive-variant matcher rejection (the pinned exact-gate tradeoff → a separate VariantDescriptor PR). Bright Data (just activated) covers only the organic path, **not** `_do_serper_shopping`. So the safe lever for "let the scrapers win the race" is bounding the Serper stall.

## Review + risk

Adversarially reviewed via a 4-lens coverage workflow (byte-identical / fail-fast-correctness / coverage-risk / fix-B+tests). Outcome: **0 real bugs** (2 by-design nits). The review **confirmed the change can never produce a wrong price** — it only bounds *how long* a failing Serper call may stall, never the returned data. The one thing to watch on canary is a *coverage* (not correctness) tradeoff: a legitimately-slow-but-valid Serper call could be cut at 10s → empty → a pend where there'd have been a price. The conservative `10s/14s` defaults (up from the initially-proposed `8s/12s`) minimize that for the first exposure; measure via smoke20 + the `usable_exact_genuine` KPI after activation, then tighten if the empty-response rate is flat.

## Tests + gate

- `tests/test_serper_fail_fast.py` — flag-OFF timeout-propagates + no-clock-read (byte-identical); flag-ON rotate-on-timeout / all-timeout-reraise / deadline-stops-rotation / timeout-then-depletion-returns-depletion / deadline-zero-degrades; the `_serper_timeout()` helper.
- `tests/test_cron_warm_price_cache.py` — 2 warmer observability tests (guard log present with the real dict shape / absent; tally unchanged).
- **39 targeted tests pass**; existing `test_serper_multikey_failover.py` green.
- **Comm gate:** `branch-only-NEW` vs `origin/main` free-unit suite = only `test_prices_endpoint_rate_limited` — the documented rate-limiter **shared-state flake**, verified passing in isolation (real regressions: 46 == 46).

## Activation (post-merge, canary)

Set `ENABLE_SERPER_FAIL_FAST=true` on Railway `web` + `price-warmer`; tune `SERPER_READ_TIMEOUT` / `SERPER_ROTATION_DEADLINE` if needed. Flag stays OFF in code → shipping this PR is inert until flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
