### PR TITLE
fix(price): gender contradiction — "Her" vs "Him" fragrance flankers (pronoun-decoupled)

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -4142,24 +4142,57 @@ _FRAGRANCE_PADDING_TOKENS = frozenset({
 # Gender CONTRADICTION axis — a fragrance is the WRONG product only when the query and
 # the candidate state OPPOSITE genders (Eros Pour Homme vs Eros Pour Femme). A one-sided
 # gender (query states it, candidate omits, or vice versa) is the canonical single-gender
-# title and must NOT reject (the dominant genuine case). Markers are unambiguous gender
-# words only — "her"/"him"/"ladies"/"gents" are excluded (a brand/name like Burberry
-# "Her" must not read as a gender).
+# title and must NOT reject (the dominant genuine case). These base sets hold the
+# unambiguous STRICT gender words — they feed BOTH the contradiction axis AND the
+# femme-asymmetry / identity logic, so the flanker pronouns "him"/"her" are NOT added here
+# (that would extend the asymmetry to a "For Her" query and collapse "Woman" vs "Her").
+# him/her feed ONLY the contradiction axis, via _pronoun_gender_of + _vd_gender_mismatch.
+# "ladies"/"gents" remain excluded.
 _GENDER_MEN_TOKENS = frozenset({"homme", "hommes", "men", "man", "mens", "uomo", "herren"})
 _GENDER_WOMEN_TOKENS = frozenset({"femme", "femmes", "women", "woman", "womens", "donna", "damen"})
 # Gender markers are STRIPPED from the identity token set (like the concentration
 # phrase) for fragrance/beauty, so the subset/flanker checks ignore a one-sided
 # "Pour Homme"; the _gender_mismatch CONTRADICTION axis does the real discrimination.
-# "her"/"him" are deliberately NOT here (a name like Burberry "Her"/"Him" must stay
-# a distinctive identity token).
+# "him"/"her" are NOT in the strict gender sets and NOT stripped from identity here — they
+# feed ONLY the contradiction axis via _pronoun_gender_of (flag-gated), so a name like
+# Burberry "Her"/"Him" keeps its distinctive-token behaviour AND the femme-asymmetry is
+# unchanged (no "For Her"-query over-rejection, no "Woman" vs "Her" collapse).
 _GENDER_IDENTITY_STRIP = _GENDER_MEN_TOKENS | _GENDER_WOMEN_TOKENS | frozenset({"pour"})
 
 
 def _gender_of(text: str) -> Optional[str]:
-    """'men' / 'women' / None (none or BOTH → ambiguous/unisex) for `text`."""
+    """'men' / 'women' / None (none or BOTH → ambiguous/unisex) for `text`, from the
+    STRICT gender words only. This is the general gender axis — it feeds the
+    femme-asymmetry (_vd_feminine_query_unconfirmed) and the empty-core/identity logic, so
+    it must NOT include the flanker pronouns him/her: doing so would over-reject a "For Her"
+    query vs its gender-omitting base AND collapse "Woman" vs "Her". Pronoun contradiction
+    is handled SEPARATELY by _pronoun_gender_of + _vd_gender_mismatch."""
     toks = set(re.findall(r"[a-z0-9]+", _fold_identity(text or "")))
     m = bool(toks & _GENDER_MEN_TOKENS)
     w = bool(toks & _GENDER_WOMEN_TOKENS)
+    if m and not w:
+        return "men"
+    if w and not m:
+        return "women"
+    return None
+
+
+def _pronoun_gender_of(text: str) -> Optional[str]:
+    """Flanker-pronoun gender for the CONTRADICTION axis ONLY: 'men' for a bare "him",
+    'women' for a bare "her" (both/neither → None). Gated behind
+    variant_descriptor_axes_enabled() so it is inert (None) flag-OFF → byte-identical.
+
+    DECOUPLED from _gender_of on purpose: him/her feed ONLY _vd_gender_mismatch (so
+    "Burberry Her" vs "Burberry Him" is rejected as a gender contradiction), NOT the
+    femme-asymmetry nor the identity/empty-core collapse — so a one-sided "X For Her" query
+    still tolerates its gender-omitting base and "X Woman" vs "X Her" stays rejected by the
+    STRICT asymmetry (no new over-rejection, no new empty-core leak). Tokenized on WORD
+    boundaries (_fold_identity + [a-z0-9]+), so "Cher"/"Hermes"/"his"/"hers" never trigger."""
+    if not variant_descriptor_axes_enabled():
+        return None
+    toks = set(re.findall(r"[a-z0-9]+", _fold_identity(text or "")))
+    m = "him" in toks
+    w = "her" in toks
     if m and not w:
         return "men"
     if w and not m:
@@ -5752,7 +5785,8 @@ class VariantDescriptor:
     qualifiers: FrozenSet[str]           # _quals_in vs the category's variant qualifiers
     plus_stems: FrozenSet[str]           # _plus_stems (symbol + spelled '+' variants)
     # --- categorical axes ---
-    gender: Optional[str]                # _gender_of ('men'/'women'/None=unisex-or-unstated)
+    gender: Optional[str]                # _gender_of ('men'/'women'/None) STRICT — asymmetry + identity
+    gender_pronoun: Optional[str]        # _pronoun_gender_of (him/her; contradiction axis ONLY; flag-gated, None flag-OFF)
     form: Optional[str]                  # _extract_product_form (brand-stripped)
     flavours: FrozenSet[str]             # fold tokens & _FLAVOUR_TOKENS
     finishes: FrozenSet[str]             # fold tokens & _MAKEUP_FINISH_TOKENS
@@ -5905,6 +5939,7 @@ def _build_variant_descriptor(text: str, category: Optional[str],
         qualifiers=frozenset(_quals_in(capped, quals_set)) if quals_set else frozenset(),
         plus_stems=frozenset(_plus_stems(capped)),
         gender=_gender_of(capped),
+        gender_pronoun=_pronoun_gender_of(capped),
         form=_extract_product_form(capped, brand),
         flavours=fold_tokens & _FLAVOUR_TOKENS,
         finishes=fold_tokens & _MAKEUP_FINISH_TOKENS,
@@ -6220,8 +6255,20 @@ def _vd_category_type_added(q: VariantDescriptor, c: VariantDescriptor, cat: str
 
 
 def _vd_gender_mismatch(q: VariantDescriptor, c: VariantDescriptor) -> bool:
-    """Gender CONTRADICTION (_gender_mismatch): both stated and conflicting."""
-    return bool(q.gender and c.gender and q.gender != c.gender)
+    """Gender CONTRADICTION (_gender_mismatch): both stated and conflicting. Combines the
+    STRICT gender with the flag-gated flanker-pronoun gender (him/her) so "Her" vs "Him"
+    rejects — WITHOUT the pronoun leaking into the femme-asymmetry, which reads q.gender/
+    c.gender STRICT. gender_pronoun is None flag-OFF → byte-identical to the strict check."""
+    def _combined(d: VariantDescriptor) -> Optional[str]:
+        men = d.gender == "men" or d.gender_pronoun == "men"
+        women = d.gender == "women" or d.gender_pronoun == "women"
+        if men and not women:
+            return "men"
+        if women and not men:
+            return "women"
+        return None
+    qg, cg = _combined(q), _combined(c)
+    return bool(qg and cg and qg != cg)
 
 
 def _vd_feminine_query_unconfirmed(q: VariantDescriptor, c: VariantDescriptor) -> bool:

--- a/tests/test_gender_contradiction_fix.py
+++ b/tests/test_gender_contradiction_fix.py
@@ -1,0 +1,161 @@
+"""Fragrance gender-flanker CONTRADICTION fix — pronoun-decoupled him/her.
+
+GROUND TRUTH (reproduced through the SAME runtime selector the orchestrator runs,
+`price_service._selection_match`): fragrance gender flankers "Burberry Her" vs
+"Burberry Him" WRONGLY MATCHED (=True) because "him"/"her" sit in
+`_FRAGRANCE_PADDING_TOKENS` (subset ignores them) AND were EXCLUDED from
+`_GENDER_MEN_TOKENS`/`_GENDER_WOMEN_TOKENS` — so the `_gender_mismatch` CONTRADICTION
+axis never fired on Her/Him.
+
+THE FIX (flag-gated behind `variant_descriptor_axes_enabled()` /
+ENABLE_VARIANT_DESCRIPTOR_AXES, ON in prod): a SEPARATE `_pronoun_gender_of` (him→men,
+her→women) feeds ONLY the contradiction axis (`_vd_gender_mismatch`, via the new
+`VariantDescriptor.gender_pronoun` field). `_gender_of` stays STRICT — so the
+femme-asymmetry (`_vd_feminine_query_unconfirmed`) and the empty-core/identity logic are
+UNCHANGED. That decoupling is why Her≡Him is fixed WITHOUT (a) over-rejecting a "For Her"
+query vs its base and (b) leaking "Woman" vs "Her". Flag OFF → gender_pronoun is None →
+byte-identical old behaviour (Her vs Him still leaks True).
+
+Env monkeypatch + LRU-cache-clear style mirrors tests/test_serper_multikey_failover.py.
+"""
+import pytest
+
+from app.services import price_service
+from app.services.price_service import _selection_match
+
+
+def _clear_descriptor_cache():
+    price_service._extract_variant_descriptor_cached.cache_clear()
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    """Prod configuration: exact gate + variant-descriptor axes both ON."""
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "1")
+    monkeypatch.setenv("ENABLE_VARIANT_DESCRIPTOR_AXES", "1")
+    _clear_descriptor_cache()
+    yield
+    _clear_descriptor_cache()
+
+
+@pytest.fixture
+def flag_off(monkeypatch):
+    """Axes flag UNSET (default) — the pre-fix behaviour (gender_pronoun is None)."""
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "1")
+    monkeypatch.delenv("ENABLE_VARIANT_DESCRIPTOR_AXES", raising=False)
+    _clear_descriptor_cache()
+    yield
+    _clear_descriptor_cache()
+
+
+# ---------------------------------------------------------------------------
+# FLAG ON — the fix is active
+# ---------------------------------------------------------------------------
+class TestFlagOnContradiction:
+    def test_burberry_her_vs_him_rejected(self, flag_on):
+        # THE leak, now fixed: opposite-gender flankers contradict -> reject.
+        assert _selection_match(
+            "Burberry Her", "Burberry Him", "fragrances", candidate_brand="Burberry",
+        ) is False
+
+    def test_burberry_him_vs_her_rejected_both_directions(self, flag_on):
+        assert _selection_match(
+            "Burberry Him", "Burberry Her", "fragrances", candidate_brand="Burberry",
+        ) is False
+
+    def test_narciso_for_her_vs_for_him_rejected(self, flag_on):
+        assert _selection_match(
+            "Narciso Rodriguez For Her", "Narciso Rodriguez For Him",
+            "fragrances", candidate_brand="Narciso Rodriguez",
+        ) is False
+
+    def test_pour_homme_vs_pour_femme_rejected(self, flag_on):
+        # Strict-gender contradiction (unchanged) still rejects.
+        assert _selection_match(
+            "Versace Eros Pour Homme", "Versace Eros Pour Femme", "fragrances",
+            candidate_brand="Versace",
+        ) is False
+
+    # --- DECOUPLING GUARDS: no new over-rejection, no new leak -----------------
+    def test_her_flanker_query_vs_base_still_matches(self, flag_on):
+        # DECOUPLING: a "For Her" query must NOT be pushed into the femme-asymmetry by
+        # the pronoun, so it still tolerates its gender-omitting base (no over-rejection).
+        assert _selection_match(
+            "Narciso Rodriguez For Her", "Narciso Rodriguez", "fragrances",
+            candidate_brand="Narciso Rodriguez",
+        ) is True
+
+    def test_her_flagship_vs_base_still_matches(self, flag_on):
+        # Elie Saab Le Parfum IS the canonical women's flagship — "For Her" vs the bare
+        # base is the SAME product and must still match (the deep-review over-rejection).
+        assert _selection_match(
+            "Elie Saab Le Parfum For Her", "Elie Saab Le Parfum", "fragrances",
+            candidate_brand="Elie Saab",
+        ) is True
+
+    def test_woman_query_vs_her_not_leaked(self, flag_on):
+        # DECOUPLING: promoting her->women must NOT collapse a DISTINCT "Woman" product
+        # into "Her"; the strict femme-asymmetry still rejects the empty-core match.
+        assert _selection_match(
+            "Burberry Woman", "Burberry Her", "fragrances", candidate_brand="Burberry",
+        ) is False
+
+    # --- GUARDS: one-sided gender omission must STILL match --------------------
+    def test_sauvage_base_vs_for_him_still_matches(self, flag_on):
+        assert _selection_match(
+            "Dior Sauvage", "Dior Sauvage For Him", "fragrances", candidate_brand="Dior",
+        ) is True
+
+    def test_bleu_de_chanel_base_vs_pour_homme_still_matches(self, flag_on):
+        assert _selection_match(
+            "Bleu de Chanel", "Bleu de Chanel Pour Homme", "fragrances",
+            candidate_brand="Chanel",
+        ) is True
+
+    # --- TOKENIZATION: a brand/name token must NOT false-trigger the pronoun ----
+    def test_cher_name_not_a_gender(self, flag_on):
+        # "Cher" folds to token 'cher' (not 'her') -> gender_pronoun None -> matches self.
+        assert price_service._pronoun_gender_of("Cher Eau de Parfum") is None
+        assert price_service._pronoun_gender_of("Terre d Hermes") is None
+
+    # --- GUARDS: other categories UNCHANGED -----------------------------------
+    def test_makeup_men_vs_for_him_unchanged(self, flag_on):
+        assert _selection_match(
+            "Nivea Men Cream", "Nivea Cream For Him", "makeup", candidate_brand="Nivea",
+        ) is False
+
+    def test_electronics_s24_vs_fe_unchanged(self, flag_on):
+        assert _selection_match(
+            "Galaxy S24", "Galaxy S24 FE", "electronics", candidate_brand="Samsung",
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# FLAG OFF — byte-identical pre-fix behaviour (gender_pronoun is None)
+# ---------------------------------------------------------------------------
+class TestFlagOffByteIdentical:
+    def test_burberry_her_vs_him_still_leaks_true(self, flag_off):
+        assert _selection_match(
+            "Burberry Her", "Burberry Him", "fragrances", candidate_brand="Burberry",
+        ) is True
+
+    def test_woman_vs_her_rejected_same_as_prod(self, flag_off):
+        # The strict femme-asymmetry already rejects this on main (unchanged flag-OFF).
+        assert _selection_match(
+            "Burberry Woman", "Burberry Her", "fragrances", candidate_brand="Burberry",
+        ) is False
+
+    def test_her_query_vs_base_matches_same_as_prod(self, flag_off):
+        assert _selection_match(
+            "Narciso Rodriguez For Her", "Narciso Rodriguez", "fragrances",
+            candidate_brand="Narciso Rodriguez",
+        ) is True
+
+    def test_electronics_s24_vs_fe_unchanged(self, flag_off):
+        assert _selection_match(
+            "Galaxy S24", "Galaxy S24 FE", "electronics", candidate_brand="Samsung",
+        ) is False
+
+    def test_pronoun_gender_of_inert_flag_off(self, flag_off):
+        assert price_service._pronoun_gender_of("Burberry Her") is None
+        assert price_service._pronoun_gender_of("Burberry Him") is None


### PR DESCRIPTION
## What

Fixes a **verified fragrance correctness leak**: gender flankers `Burberry Her` and `Burberry Him` **wrongly matched** (`_selection_match(...)==True`) — a "Her" query could be served "Him"'s price (a wrong-gender SKU/price).

## Root cause (reproduced through the runtime)

`him`/`her` are in `_FRAGRANCE_PADDING_TOKENS` (stripped from the subset check) **and** were excluded from `_GENDER_MEN_TOKENS`/`_GENDER_WOMEN_TOKENS`, so `_gender_of` returned `None` for both — the `_vd_gender_mismatch` **contradiction axis never fired** on the gender flip.

## Fix — pronoun *decoupling* (`ENABLE_VARIANT_DESCRIPTOR_AXES`-gated; ON in prod)

A **separate** `_pronoun_gender_of` (`him`→men, `her`→women) populates a new `VariantDescriptor.gender_pronoun` field, combined **only** into the contradiction axis (`_vd_gender_mismatch`). `_gender_of` stays **strict** — so the femme-asymmetry (`_vd_feminine_query_unconfirmed`) and the empty-core/identity logic are **unchanged**. Flag **OFF → `gender_pronoun` is None → byte-identical**.

**Why decoupled (a deep coverage-driven review caught the naive approach leaking):** promoting `him`/`her` inside `_gender_of` itself would also feed the femme-asymmetry, which (a) **over-rejects** a `For Her` query vs its gender-omitting base (`Elie Saab Le Parfum For Her` vs the base — a genuine same-product case), and (b) **creates a new leak** — `Burberry Woman` vs `Burberry Her` flipping reject→match (empty-core collapse). The decoupling fixes `Her`≡`Him` with **neither** side effect.

Independently reproduced through `_selection_match`:
| case | flag-OFF | flag-ON | |
|---|---|---|---|
| `Her` ↔ `Him` | True (leak) | **False** | leak fixed |
| `Woman` vs `Her` | False | **False** | no new leak |
| `For Her` / `Le Parfum For Her` vs base | True | **True** | no over-rejection |
| `Pour Homme` vs `Pour Femme` | False | **False** | strict contradiction (unchanged) |
| one-sided `Sauvage` ≡ `…For Him` | True | **True** | preserved |
| makeup / electronics | — | unchanged | category-scoped |

## Review gates

- **Comm gate:** branch-only-NEW vs `origin/main` free-unit suite = only the documented `test_retailer_quotes` / `test_prices_endpoint_rate_limited` **serper-budget / rate-limiter shared-state flakes** (proven to fail on `main` too under the same exhausted shared counter).
- **Deep coverage-driven review (2 rounds):** round 1 caught the naive approach's new leak + over-rejection (→ decoupled); round 2 re-verifies the decoupling introduces neither. Flag-OFF byte-identity proven (empty diff over 40+ titles / 24+ pairs vs parent); tokenization clean (`Cher`/`Hermes`/`his`/`hers` never trigger); gender feeds only reject signals (no new-leak path).
- **Pre-existing (out of scope):** `Her` (query) vs `Woman` (candidate) empty-core collapse exists on `main` today (flag-independent) and is neither caused nor worsened here.

## Tests

`tests/test_gender_contradiction_fix.py` — 17 tests: contradiction (both directions, Pour Homme/Femme), decoupling guards (no leak / no over-rejection), tokenization, both flag directions.

## Activation

`ENABLE_VARIANT_DESCRIPTOR_AXES` is already ON in prod → active on merge; flag-OFF is the byte-identical rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
