### PR TITLE
feat(price): genuine-BHD coverage for local Arabic perfume houses

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -951,11 +951,15 @@ _FRAGRANCE_MIN_FLOOR_BHD = 5.0
 # common), so this never lowers protection there. Tokens are unambiguous multi-
 # char house names (no generic/collision-prone token — e.g. NOT "my perfumes",
 # which substring-pollutes a "Chanel my perfumes" query).
+# ONLY the houses that are ALSO in FRAGRANCE_BRAND_KEYWORDS (so
+# is_implausible_low_fragrance_price actually floors them and the bypass is
+# load-bearing). Other budget houses (Armaf, Swiss Arabian, Maison Alhambra,
+# Afnan, ...) are NOT in the designer set -> never floored -> their genuine cheap
+# price already shows without this bypass, so listing them here would be dead
+# config that weakens no guard but misleads. Keep this set == the Arabic houses in
+# FRAGRANCE_BRAND_KEYWORDS.
 BUDGET_FRAGRANCE_BRAND_KEYWORDS = {
     "lattafa", "rasasi", "al haramain", "ajmal", "asghar ali", "asgharali",
-    "armaf", "swiss arabian", "ard al zaafaran", "ardalzaafaran",
-    "maison alhambra", "afnan", "al wataniah", "khadlaj", "lattafa pride",
-    "paris corner", "fragrance world", "zimaya",
 }
 # The SAME budget houses ALSO sell genuinely-expensive concentrated lines (pure
 # dehn-al-oud / mukhallat / perfume-oil / attar, 40-150+ BHD). A wrong-cheap price
@@ -974,6 +978,12 @@ _BUDGET_HOUSE_PREMIUM_LINE_TOKENS = {
     "oud oil", "oudh oil", "oud perfume oil", "perfume oil", "oil perfume",
     "concentrated perfume", "concentrated oud", "attar", "ittar", "cpo",
 }
+# WORD-BOUNDARY match (not bare substring) so a short token can't collide with a
+# name fragment — e.g. "attar" must NOT hit "muattar"/"moattar" (معطر = "scented",
+# a cheap EDP name), "cpo" must not hit a larger word. \b around each phrase.
+_BUDGET_HOUSE_PREMIUM_LINE_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(t) for t in sorted(_BUDGET_HOUSE_PREMIUM_LINE_TOKENS, key=len, reverse=True)) + r")\b"
+)
 
 
 def is_fragrance_query(product_name: str) -> bool:
@@ -1402,7 +1412,7 @@ def is_price_showable(
     # runs on the loose Serper-shopping path (unaffected). Flag OFF / non-genuine /
     # listing-URL / expensive-oil-line -> the floor applies unchanged.
     if is_implausible_low_fragrance_price(product_name, amount, title=title) and not (
-        _budget_house_trusted_price(product_name, price, category)
+        _budget_house_trusted_price(product_name, price)
     ):
         return False
     # F1.2b — premium haircare wrong-cheap leak (K18 4.51 BHD).
@@ -3443,7 +3453,7 @@ def _budget_fragrance_floor_enabled() -> bool:
 
 
 def _budget_house_trusted_price(
-    product_name: str, price: Optional[Dict[str, Any]], category: Optional[str] = None
+    product_name: str, price: Optional[Dict[str, Any]]
 ) -> bool:
     """True iff `price` is a TRUSTWORTHY genuine budget-Arabic-house price for which
     the fragrance low-price FLOOR is a false positive (so the display chokepoint may
@@ -3457,18 +3467,29 @@ def _budget_house_trusted_price(
     real PDP URL, the store's listed price IS authoritative — the 25/100ml designer
     floor then WRONGLY pends it (Lattafa Khamrah 12 BHD, even from the wired
     alhajisbahrain source). This bypass is applied ONLY at the display chokepoint;
-    the floor STILL runs on the loose Serper-shopping extract, so wrong-cheap
-    mislabels there are unaffected.
+    the floor STILL runs on the loose Serper-shopping extract AND on the pre-
+    selection internal floor sites (noon `_select_offer`, scs fan-out/Tier-2
+    winners), so wrong-cheap mislabels there are unaffected (a documented coverage
+    limit — a genuine budget price resolved ONLY via those looser paths is dropped
+    before display; the exact-gated direct-adapter path surfaces it).
 
-    Guards keep it tight: flag-gated (OFF -> always False -> the floor applies,
-    byte-identical); requires a GENUINE native-BHD source_method (never estimated/
-    converted) AND a real non-listing PDP URL AND a budget-house brand token; and
-    EXCLUDES the houses' genuinely-expensive concentrated dehn-al-oud/mukhallat/
-    attar OIL lines (_BUDGET_HOUSE_PREMIUM_LINE_TOKENS keep the floor, so a wrong-
-    cheap oil scrape is still caught)."""
-    if not _budget_fragrance_floor_enabled():
+    Guards keep it tight: gated on BOTH _budget_fragrance_floor_enabled() AND
+    exact_gate_enabled() — the trust is PREMISED on the exact-gate's identity
+    guarantee, so a full ENABLE_EXACT_PRICE_GATE=false rollback (which disables the
+    identity/PDP backstops) also disables this bypass, keeping the rollback
+    byte-identical to pre-PR. Requires a GENUINE native-BHD source_method (never
+    estimated/converted), a real non-listing PDP URL, an IN-STOCK price (an OOS
+    below-floor price stays floored), an amount >= the 5 BHD artifact floor (a
+    fils/decimal glitch never trusted), a budget-house brand token, and NOT one of
+    the houses' genuinely-expensive concentrated dehn-al-oud/mukhallat/attar OIL
+    lines (word-boundary matched so "attar" can't hit "muattar")."""
+    if not (_budget_fragrance_floor_enabled() and exact_gate_enabled()):
         return False
     if not isinstance(price, dict):
+        return False
+    # OUT-OF-STOCK — never trust an OOS below-floor price (the legacy floor dropped
+    # it at the adapter; keep that defense so the bypass can't re-admit it).
+    if price.get("in_stock") is False:
         return False
     # ABSOLUTE artifact floor — the bypass lowers the fragrance floor from the 25/
     # 100ml designer floor to this sanity bound, NEVER to 0. A trusted budget price
@@ -3482,9 +3503,10 @@ def _budget_house_trusted_price(
     name_lower = (product_name or "").lower()
     if not any(b in name_lower for b in BUDGET_FRAGRANCE_BRAND_KEYWORDS):
         return False
-    # An expensive concentrated-oil line keeps the floor (belt-and-suspenders).
+    # An expensive concentrated-oil line keeps the floor (belt-and-suspenders,
+    # word-boundary matched so a short token can't collide with a name fragment).
     hay = name_lower + " " + str(price.get("title") or price.get("name") or "").lower()
-    if any(tok in hay for tok in _BUDGET_HOUSE_PREMIUM_LINE_TOKENS):
+    if _BUDGET_HOUSE_PREMIUM_LINE_RE.search(hay):
         return False
     if (price.get("source_method") or "") not in _GENUINE_BH_SOURCE_METHODS:
         return False

--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -939,6 +939,42 @@ PREMIUM_FRAGRANCE_FULL_SIZE_FLOOR_BHD = 50.0
 # any labelled size is a scrape artifact, not a real perfume).
 _FRAGRANCE_MIN_FLOOR_BHD = 5.0
 
+# Budget Arabic/Gulf fragrance houses (Lattafa, Rasasi, Al Haramain, Ajmal,
+# Armaf, Swiss Arabian, ...). Their genuine full 100ml EDP retails for ~8-25 BHD
+# in Bahrain (alhajisbahrain/alibaksh/fragrancebh list Lattafa Khamrah 11-12,
+# Asad 8-9, Armaf Club de Nuit 14-15, Rasasi Hawas 14-17, Al Haramain Amber Oud
+# 22 — all in BHD). The 25/100ml DESIGNER floor (is_implausible_low_fragrance_
+# price) is calibrated for Western designer houses and WRONGLY pends these houses'
+# genuine cheap price — but ONLY on the display chokepoint for a TRUSTWORTHY
+# direct-adapter exact-PDP price (see _budget_house_trusted_price). The floor
+# STILL applies on the loose Serper-shopping path (where a wrong-cheap mislabel is
+# common), so this never lowers protection there. Tokens are unambiguous multi-
+# char house names (no generic/collision-prone token — e.g. NOT "my perfumes",
+# which substring-pollutes a "Chanel my perfumes" query).
+BUDGET_FRAGRANCE_BRAND_KEYWORDS = {
+    "lattafa", "rasasi", "al haramain", "ajmal", "asghar ali", "asgharali",
+    "armaf", "swiss arabian", "ard al zaafaran", "ardalzaafaran",
+    "maison alhambra", "afnan", "al wataniah", "khadlaj", "lattafa pride",
+    "paris corner", "fragrance world", "zimaya",
+}
+# The SAME budget houses ALSO sell genuinely-expensive concentrated lines (pure
+# dehn-al-oud / mukhallat / perfume-oil / attar, 40-150+ BHD). A wrong-cheap price
+# for one of THOSE must stay floored even from a direct adapter, so a title/name
+# carrying one of these line tokens is EXCLUDED from the budget-house trust (it
+# keeps the designer floor). Deliberately specific to the concentrated-OIL lines —
+# NOT bare "oud" (an "Amber Oud" EDP is a cheap mainstream spray, still trusted).
+_BUDGET_HOUSE_PREMIUM_LINE_TOKENS = {
+    # canonical + the common alternate transliterations these houses actually list
+    # (dahn/dehn/dhan; mukhallat/muhallat/mukhalat; attar/ittar). Deliberately NOT
+    # a bare "oud"/"oudh" token — that would over-floor the cheap mainstream "Amber
+    # Oud" EDP sprays (a hero SKU), and NOT a bare "itr" (collides with "citrus").
+    "dahn al", "dehn al", "dhan al", "dhen al", "dahn oud", "dehn oud", "dhan oud",
+    "dahnal", "dehnal", "dhanal", "dahn al oudh", "dehn al oudh", "dhan al oudh",
+    "mukhallat", "mukhallad", "mukhalat", "muhallat", "muhalat",
+    "oud oil", "oudh oil", "oud perfume oil", "perfume oil", "oil perfume",
+    "concentrated perfume", "concentrated oud", "attar", "ittar", "cpo",
+}
+
 
 def is_fragrance_query(product_name: str) -> bool:
     """True iff `product_name` is (almost certainly) a perfume — either a
@@ -1359,7 +1395,15 @@ def is_price_showable(
         price["title"] = title
     # Compose the shipped accuracy guards — a price that fails any is not
     # showable (the guards already encode the "no wrong scrapes" contract).
-    if is_implausible_low_fragrance_price(product_name, amount, title=title):
+    # EXCEPTION (budget Arabic-house coverage) — a genuine direct-adapter exact-PDP
+    # price for a budget house (Lattafa/Rasasi/Al Haramain/...) bypasses the
+    # designer low-price FLOOR: it is the store's authoritative listed price for the
+    # exact SKU, so the 25/100ml floor is a false positive there. The floor still
+    # runs on the loose Serper-shopping path (unaffected). Flag OFF / non-genuine /
+    # listing-URL / expensive-oil-line -> the floor applies unchanged.
+    if is_implausible_low_fragrance_price(product_name, amount, title=title) and not (
+        _budget_house_trusted_price(product_name, price, category)
+    ):
         return False
     # F1.2b — premium haircare wrong-cheap leak (K18 4.51 BHD).
     if is_implausible_low_haircare_price(product_name, amount):
@@ -3381,6 +3425,73 @@ def exact_gate_enabled() -> bool:
     return os.getenv("ENABLE_EXACT_PRICE_GATE", "true").strip().lower() not in (
         "false", "0", "no", "off", "",
     )
+
+
+def _budget_fragrance_floor_enabled() -> bool:
+    """True iff the BUDGET Arabic/Gulf-house fragrance floor is active (default ON).
+
+    When ON, is_implausible_low_fragrance_price applies a much lower price floor to
+    known budget houses (Lattafa/Rasasi/Al Haramain/Ajmal/Armaf/... — see
+    BUDGET_FRAGRANCE_BRAND_KEYWORDS) so their genuine cheap 8-25 BHD full bottles
+    are NOT suppressed as "implausibly low" by the 25/100ml designer floor. Read
+    FRESH per call so a flag flip takes effect without a restart. OFF -> the legacy
+    25/100ml designer floor applies to these houses too (byte-identical to before).
+    """
+    return os.getenv("ENABLE_BUDGET_FRAGRANCE_FLOOR", "true").strip().lower() not in (
+        "false", "0", "no", "off", "",
+    )
+
+
+def _budget_house_trusted_price(
+    product_name: str, price: Optional[Dict[str, Any]], category: Optional[str] = None
+) -> bool:
+    """True iff `price` is a TRUSTWORTHY genuine budget-Arabic-house price for which
+    the fragrance low-price FLOOR is a false positive (so the display chokepoint may
+    bypass it).
+
+    The low-price floor (is_implausible_low_fragrance_price) is a heuristic for the
+    LOOSE Serper-shopping path — it drops a wrong-cheap mislabel that slipped past
+    matching. But a budget house (Lattafa/Rasasi/Al Haramain/Ajmal/...) genuinely
+    retails a full 100ml EDP for 8-25 BHD, and when the price comes from a DIRECT
+    store adapter (woo/shopify/…) that already exact-matched the SKU and carries a
+    real PDP URL, the store's listed price IS authoritative — the 25/100ml designer
+    floor then WRONGLY pends it (Lattafa Khamrah 12 BHD, even from the wired
+    alhajisbahrain source). This bypass is applied ONLY at the display chokepoint;
+    the floor STILL runs on the loose Serper-shopping extract, so wrong-cheap
+    mislabels there are unaffected.
+
+    Guards keep it tight: flag-gated (OFF -> always False -> the floor applies,
+    byte-identical); requires a GENUINE native-BHD source_method (never estimated/
+    converted) AND a real non-listing PDP URL AND a budget-house brand token; and
+    EXCLUDES the houses' genuinely-expensive concentrated dehn-al-oud/mukhallat/
+    attar OIL lines (_BUDGET_HOUSE_PREMIUM_LINE_TOKENS keep the floor, so a wrong-
+    cheap oil scrape is still caught)."""
+    if not _budget_fragrance_floor_enabled():
+        return False
+    if not isinstance(price, dict):
+        return False
+    # ABSOLUTE artifact floor — the bypass lowers the fragrance floor from the 25/
+    # 100ml designer floor to this sanity bound, NEVER to 0. A trusted budget price
+    # must still clear _FRAGRANCE_MIN_FLOOR_BHD (5 BHD): a budget house genuinely
+    # retails 8+ BHD, so a sub-5 amount is a scrape/parse artifact (a mis-parsed
+    # fils/decimal — the exact-gate validates IDENTITY, not the amount), which must
+    # stay pended even for a correctly-titled exact SKU.
+    amount = price.get("amount")
+    if not isinstance(amount, (int, float)) or amount < _FRAGRANCE_MIN_FLOOR_BHD:
+        return False
+    name_lower = (product_name or "").lower()
+    if not any(b in name_lower for b in BUDGET_FRAGRANCE_BRAND_KEYWORDS):
+        return False
+    # An expensive concentrated-oil line keeps the floor (belt-and-suspenders).
+    hay = name_lower + " " + str(price.get("title") or price.get("name") or "").lower()
+    if any(tok in hay for tok in _BUDGET_HOUSE_PREMIUM_LINE_TOKENS):
+        return False
+    if (price.get("source_method") or "") not in _GENUINE_BH_SOURCE_METHODS:
+        return False
+    url = price.get("url")
+    if not (isinstance(url, str) and url.strip()) or _is_listing_url(url):
+        return False
+    return True
 
 
 def frag_reconcile_fix_enabled() -> bool:

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -1793,6 +1793,25 @@ def _early_specs_stash_enabled() -> bool:
     )
 
 
+def _park_listing_url_tier1_enabled() -> bool:
+    """Local-house coverage (2026-07-08) — True iff a GENUINE Tier-1 Serper-shopping
+    price whose URL is a LISTING/search URL (Google-Shopping "local" ibp=oshop /
+    prds=localA, never a merchant PDP) is PARKED as a fallback instead of short-
+    circuiting the cascade (default ON). Read per-call so a flip/monkeypatch is
+    immediate (mirrors _early_specs_stash_enabled).
+
+    Such a price is NON-showable at the display chokepoint (is_price_showable pends
+    a listing URL), so short-circuiting on it GUARANTEES a price-pending AND blocks
+    the real-PDP direct adapters (woo/shopify/algolia — e.g. the alibaksh/
+    fragrancebh BHD price for the local Arabic houses) that could serve a SHOWABLE
+    genuine price. Parking it lets the cascade reach those adapters; if they miss,
+    the parked price still returns (pends, same as before). OFF -> the legacy
+    genuine short-circuit fires for a listing URL too (byte-identical)."""
+    return os.getenv("ENABLE_PARK_LISTING_URL_TIER1", "true").strip().lower() not in (
+        "false", "0", "no", "off", "",
+    )
+
+
 # BF5 (sweep OR-8) — BH-locale URL-path prefixes that mark a page as the
 # retailer's BAHRAIN storefront (namshi.com/bahrain-en, boutiqaat-style
 # /bh-en). Anchored + segment-bounded: "/bahrain-english-deals" or a mid-path
@@ -5667,12 +5686,35 @@ class StructuredComparisonService:
                 # Approach A — PARK a CONVERTED_USD Tier-1 price; defer to the
                 # genuine-BH Tier-1.5 curl tier below. A genuine Tier-1 price
                 # (local_bhd / page_scrape / any non-converted) short-circuits now.
+                _tier1_is_listing_url = False
+                if _park_listing_url_tier1_enabled():
+                    try:
+                        from app.services.price_service import _is_listing_url
+                        _t1_url = price.get("url") or ""
+                        _tier1_is_listing_url = bool(_t1_url) and _is_listing_url(_t1_url)
+                    except Exception:  # noqa: BLE001 — never break the cascade on a guard
+                        _tier1_is_listing_url = False
                 if price.get("source_method") == "converted_usd":
                     converted_fallback = dict(price)
                     # Fix A — ALSO stash on self (survives an outer 15s wait_for
                     # cancel of this coroutine, unlike the local above). This is
                     # the EARLY stash, before the Tier-1.5 render wave that could
                     # time out — so the Phase-1 handler can return it, never None.
+                    self._parked_price[full_name] = dict(price)
+                elif _tier1_is_listing_url:
+                    # Local-house coverage (2026-07-08) — a GENUINE Tier-1 price on
+                    # a Google-Shopping "local" LISTING url (ibp=oshop / prds=localA)
+                    # is NON-showable at the display chokepoint, so short-circuiting
+                    # on it GUARANTEES a price-pending AND blocks the real-PDP direct
+                    # adapters (woo/shopify/algolia) that could serve a SHOWABLE
+                    # genuine BHD price (the alibaksh/fragrancebh Lattafa/Rasasi/Al
+                    # Haramain price was being hidden by a Google-Shopping local hit
+                    # winning the race). Park it as the last-resort fallback (like a
+                    # converted price) and let the cascade run; a direct-adapter PDP
+                    # hit wins, else this parked price returns (still pends at
+                    # display, same as the legacy path). Flag-gated (byte-identical
+                    # when OFF — the genuine short-circuit below fires unchanged).
+                    converted_fallback = dict(price)
                     self._parked_price[full_name] = dict(price)
                 else:
                     # Genuine Tier-1 short-circuit — the speculative discovery

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -6695,9 +6695,14 @@ class StructuredComparisonService:
             # structural dead-end. Record it so the next call skips the cascade.
             self._record_negative_price_cache(cache_key, converted_fallback)
             converted_fallback["_cached"] = False
+            # The parked slot now also carries a genuine local_bhd price on a
+            # listing URL (ENABLE_PARK_LISTING_URL_TIER1) — log the ACTUAL
+            # source_method so ops reading genuine-share from Railway logs aren't
+            # told a native-BHD shelf price is converted_usd.
             logger.info(
-                "[PRICE] parked converted_usd fallback used for %s (BH curl+render "
-                "missed; beats GPT estimate)", full_name,
+                "[PRICE] parked %s fallback used for %s (BH curl+render "
+                "missed; beats GPT estimate)",
+                converted_fallback.get("source_method") or "converted_usd", full_name,
             )
             return converted_fallback
 

--- a/data/bh_gcc_sources.json
+++ b/data/bh_gcc_sources.json
@@ -1059,7 +1059,7 @@
   "genuine_method": "woo_store_api",
   "sample_url": "https://fragrancebh.com/wp-json/wc/store/products?per_page=2",
   "priority_rank": 21,
-  "status": "provider-test-candidate"
+  "status": "live"
  },
  {
   "domain": "iworld.bh",
@@ -1113,7 +1113,7 @@
   "genuine_method": "woo_store_api",
   "sample_url": "https://alibaksh.com/product/carolina-herrera-good-girl-edp-80ml/",
   "priority_rank": 23,
-  "status": "provider-test-candidate"
+  "status": "live"
  },
  {
   "domain": "miniso-bh.com",

--- a/data/warmer_catalog.json
+++ b/data/warmer_catalog.json
@@ -144,7 +144,7 @@
       "query": "Lattafa Khamrah vs Armaf Club de Nuit Intense Man",
       "category": "fragrances",
       "region": "bahrain",
-      "note": "Local-house coverage (2026-07-08). Genuine BHD reachable: Lattafa Khamrah 11-12 (alhajisbahrain shopify_json / alibaksh+fragrancebh woo_store_api), Armaf Club de Nuit Intense Man 14-25 (alhajisbahrain / alibaksh). Both < 25/100ml designer floor -> needs the budget-fragrance-floor fix to SHOW; both slow on the 15s cold race -> warmer-only genuine."
+      "note": "Local-house coverage (2026-07-08). Genuine BHD reachable: Lattafa Khamrah 11-12 (alhajisbahrain shopify_json / alibaksh+fragrancebh woo_store_api; Lattafa IS designer-floored -> needs the budget-fragrance-floor bypass to SHOW), Armaf Club de Nuit Intense Man 14-25 (alhajisbahrain / alibaksh; Armaf is NOT designer-floored -> already shows). Both slow on the 15s cold race -> warmer-only genuine."
     },
     {
       "id": "warm-frag-lh-002",
@@ -158,7 +158,7 @@
       "query": "Swiss Arabian Shaghaf Oud vs Al Haramain Amber Oud Gold Edition",
       "category": "fragrances",
       "region": "bahrain",
-      "note": "Local-house coverage (2026-07-08). Al Haramain Amber Oud Gold 22-25 (alibaksh/fragrancebh woo_store_api, budget-floored), Swiss Arabian Shaghaf (alibaksh carries Swiss Arabian in BHD). Warmer-only genuine (slow cold race)."
+      "note": "Local-house coverage (2026-07-08). Al Haramain Amber Oud Gold 22-25 (alibaksh/fragrancebh woo_store_api; Al Haramain IS designer-floored -> needs the budget-fragrance-floor bypass), Swiss Arabian Shaghaf (alibaksh carries Swiss Arabian in BHD; NOT designer-floored -> already shows). Warmer-only genuine (slow cold race)."
     },
     {
       "id": "warm-frag-lh-004",

--- a/data/warmer_catalog.json
+++ b/data/warmer_catalog.json
@@ -137,6 +137,63 @@
       "category": "grocery",
       "region": "bahrain",
       "note": "A2 (2026-06-15). Premium dates/gourmet — genuine BH reachable via bateel.bh (registry, BHD product pages) but a multi-candidate gourmet scrape is slow; warmer-only genuine. Real GCC gifting-season traffic."
+    },
+
+    {
+      "id": "warm-frag-lh-001",
+      "query": "Lattafa Khamrah vs Armaf Club de Nuit Intense Man",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house coverage (2026-07-08). Genuine BHD reachable: Lattafa Khamrah 11-12 (alhajisbahrain shopify_json / alibaksh+fragrancebh woo_store_api), Armaf Club de Nuit Intense Man 14-25 (alhajisbahrain / alibaksh). Both < 25/100ml designer floor -> needs the budget-fragrance-floor fix to SHOW; both slow on the 15s cold race -> warmer-only genuine."
+    },
+    {
+      "id": "warm-frag-lh-002",
+      "query": "Rasasi Hawas For Him vs Lattafa Asad",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house coverage (2026-07-08). Rasasi Hawas 14-17 (alibaksh/fragrancebh woo_store_api, candidate_brand match), Lattafa Asad 8-9 (fragrancebh Dynasty / alibaksh Asad Bourbon). Budget houses -> budget-floor fix + warmer."
+    },
+    {
+      "id": "warm-frag-lh-003",
+      "query": "Swiss Arabian Shaghaf Oud vs Al Haramain Amber Oud Gold Edition",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house coverage (2026-07-08). Al Haramain Amber Oud Gold 22-25 (alibaksh/fragrancebh woo_store_api, budget-floored), Swiss Arabian Shaghaf (alibaksh carries Swiss Arabian in BHD). Warmer-only genuine (slow cold race)."
+    },
+    {
+      "id": "warm-frag-lh-004",
+      "query": "Lattafa Yara vs Rasasi Hawas Viper",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house coverage (2026-07-08). High-traffic Arabic-house compare; both genuine BHD via alhajisbahrain / alibaksh / fragrancebh."
+    },
+    {
+      "id": "warm-frag-lh-005",
+      "query": "Lattafa Khamrah",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house single-SKU seed (2026-07-08). alhajisbahrain shopify_json 12.000 BHD (wired) + alibaksh/fragrancebh woo_store_api. Single-product warm caches the genuine BHD at its own key for a live cache-read."
+    },
+    {
+      "id": "warm-frag-lh-006",
+      "query": "Armaf Club de Nuit Intense Man",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house single-SKU seed (2026-07-08). Genuine BHD via alhajisbahrain / alibaksh (Armaf not designer-floored)."
+    },
+    {
+      "id": "warm-frag-lh-007",
+      "query": "Al Haramain Amber Oud Gold Edition",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house single-SKU seed (2026-07-08). alibaksh/fragrancebh woo_store_api 22-25 BHD (budget-floored). alhajisbahrain does NOT stock Al Haramain -> the new woo rows are the genuine path."
+    },
+    {
+      "id": "warm-frag-lh-008",
+      "query": "Rasasi Hawas For Him",
+      "category": "fragrances",
+      "region": "bahrain",
+      "note": "Local-house single-SKU seed (2026-07-08). alibaksh/fragrancebh woo_store_api Rasasi Hawas 14-17 BHD (candidate_brand match on the brand-omitting title). alhajisbahrain stocks only 1 Rasasi SKU -> the new woo rows are the genuine path."
     }
   ]
 }

--- a/tests/test_budget_fragrance_floor.py
+++ b/tests/test_budget_fragrance_floor.py
@@ -1,0 +1,143 @@
+"""Budget Arabic/Gulf-house fragrance floor bypass (source-aware).
+
+The designer low-price floor (is_implausible_low_fragrance_price, 25 BHD/100ml)
+wrongly pended the genuine cheap price of budget Arabic houses (Lattafa/Rasasi/
+Al Haramain/Ajmal — whose real full 100ml EDP is ~8-25 BHD). The fix does NOT
+change the floor function itself (it still protects the LOOSE Serper-shopping
+path); instead the DISPLAY chokepoint (is_price_showable) BYPASSES the floor for a
+TRUSTWORTHY genuine direct-adapter exact-PDP budget-house price — the store's
+authoritative listed price for the exact SKU. Flag ENABLE_BUDGET_FRAGRANCE_FLOOR
+(default ON; OFF -> the floor applies, byte-identical).
+
+Coverage-driven, BOTH directions + the review-surfaced hazards:
+  A. trusted budget direct-adapter prices now SHOW
+  B. the floor FUNCTION is unchanged (loose-path protection intact)
+  C. non-trusted budget prices STAY floored: loose listing-URL, estimate,
+     converted, and the houses' expensive dehn-al-oud/attar OIL lines
+  D. designer/premium unaffected + no generic-token collision ("my perfumes")
+  E. flag OFF == legacy (floor applies to budget houses again)
+"""
+import pytest
+
+import app.services.price_service as ps
+
+_PDP = "https://alibaksh.com/product/x-100ml"
+_ALHAJIS = "https://alhajisbahrain.com/products/lattafa-khamrah-edp-100ml"
+_LISTING = "https://www.google.com/search?ibp=oshop&q=x&prds=localAnnotations"
+
+
+def _price(amount, source_method="woo_store_api", url=_PDP, title="", in_stock=True):
+    return {"amount": amount, "currency": "BHD", "source_method": source_method,
+            "in_stock": in_stock, "url": url, "title": title}
+
+
+def _show(q, p):
+    return ps.is_price_showable(q, p, "fragrances", enforce_correctness=True)
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(monkeypatch):
+    monkeypatch.setenv("ENABLE_BUDGET_FRAGRANCE_FLOOR", "true")
+
+
+# --- A. trusted budget direct-adapter prices SHOW -------------------------
+@pytest.mark.parametrize("query,amount,title,url,method", [
+    ("Lattafa Khamrah", 12.0, "Lattafa Khamrah Edp 100Ml", _ALHAJIS, "shopify_json"),
+    ("Lattafa Asad", 8.0, "Lattafa Asad Bourbon 100ml", _PDP, "woo_store_api"),
+    ("Rasasi Hawas For Him", 14.0, "Rasasi Hawas For Him EDP 100ml", _PDP, "woo_store_api"),
+    ("Al Haramain Amber Oud Gold Edition", 22.0, "Al Haramain Amber Oud Gold Edition (U) Edp 100ml", _PDP, "woo_store_api"),
+    ("Ajmal Aristocrat", 18.0, "Ajmal Aristocrat For Him EDP 75ml", _PDP, "local_bhd"),
+])
+def test_trusted_budget_price_is_showable(query, amount, title, url, method):
+    assert _show(query, _price(amount, method, url, title)) is True
+
+
+# --- B. the floor FUNCTION itself is UNCHANGED (loose-path protection) -----
+@pytest.mark.parametrize("query,amount,title,expect", [
+    ("Lattafa Khamrah", 12.0, "Lattafa Khamrah 100ml", True),     # budget house STILL floored by the fn
+    ("Rasasi Hawas For Him", 14.0, "Rasasi Hawas 100ml", True),
+    ("Dior Sauvage", 12.0, "Dior Sauvage 100ml", True),
+    ("Tom Ford Tobacco Vanille", 28.2, "Tom Ford Tobacco Vanille 100ml", True),
+])
+def test_floor_function_unchanged(query, amount, title, expect):
+    # is_implausible_low_fragrance_price is reverted to the legacy designer floor —
+    # it is the LOOSE-path guard and must be byte-identical to before.
+    assert ps.is_implausible_low_fragrance_price(query, amount, title=title) is expect
+
+
+# --- C. non-trusted budget prices STAY floored (not showable) -------------
+def test_listing_url_budget_price_stays_floored():
+    assert _show("Lattafa Khamrah", _price(12.0, "local_bhd", _LISTING, "Lattafa Khamrah")) is False
+
+
+def test_estimated_budget_price_stays_floored():
+    assert _show("Lattafa Khamrah", _price(12.0, "estimated", None, "Lattafa Khamrah")) is False
+
+
+def test_converted_budget_price_stays_floored():
+    assert _show("Lattafa Khamrah", _price(12.0, "converted_usd", _PDP, "Lattafa Khamrah")) is False
+
+
+@pytest.mark.parametrize("query,title", [
+    ("Ajmal Dahn Al Oudh", "Ajmal Dahn Al Oudh 100ml"),
+    ("Ajmal Dahn Al Oudh Moattaq", "Ajmal Dahn Al Oudh Moattaq"),
+    ("Rasasi Mukhallat", "Rasasi Mukhallat Oud Perfume Oil"),
+    ("Lattafa Oud Mood Perfume Oil", "Lattafa Oud Mood Elixir Perfume Oil"),
+    # alternate transliterations the round-2 review surfaced (must ALSO stay floored)
+    ("Ajmal Dhan Al Oudh Moattaq", "Ajmal Dhan Al Oudh Moattaq 100ml"),
+    ("Rasasi Muhallat Oud", "Rasasi Muhallat Oud Oil"),
+    ("Al Haramain Ittar Al Kaaba", "Al Haramain Ittar Al Kaaba"),
+    ("Ajmal Concentrated Oil CPO", "Ajmal Concentrated Perfume Oil CPO"),
+])
+def test_expensive_oil_line_stays_floored(query, title):
+    # the houses' concentrated dehn-al-oud/mukhallat/oil lines keep the designer
+    # floor even from a direct adapter, so a wrong-cheap oil scrape is still caught.
+    assert _show(query, _price(8.0, "woo_store_api", _PDP, title)) is False
+
+
+@pytest.mark.parametrize("amount", [0.1, 1.9, 3.0, 4.99])
+def test_sub_artifact_floor_budget_price_stays_pended(amount):
+    # ABSOLUTE artifact floor — even a TRUSTED genuine-PDP budget price below 5 BHD
+    # is a scrape/fils-parse glitch (the exact-gate checks identity, not amount) and
+    # must stay pended. The bypass lowers the floor 25 -> 5, never to 0.
+    assert _show("Rasasi Hawas", _price(amount, "scrapedo_rendered", _PDP, "Rasasi Hawas EDP")) is False
+
+
+def test_cheap_amber_oud_edp_still_shows():
+    # "Amber Oud" is a cheap mainstream EDP spray, NOT a concentrated-oil line — a
+    # bare "oud" token must NOT over-floor it (it is a hero SKU).
+    assert _show("Al Haramain Amber Oud Gold Edition",
+                 _price(22.0, "woo_store_api", _PDP, "Al Haramain Amber Oud Gold Edition (U) Edp 100ml")) is True
+
+
+# --- D. designer/premium unaffected + collision token removed -------------
+@pytest.mark.parametrize("query,title", [
+    ("Chanel No 5", "Chanel No 5 EDP 100ml"),
+    ("Dior Sauvage", "Dior Sauvage EDP 100ml"),
+    ("Tom Ford Ombre Leather", "Tom Ford Ombre Leather 100ml"),
+    ("Chanel my perfumes No 5", "Chanel No 5"),   # "my perfumes" must NOT trust a Chanel query
+])
+def test_designer_price_stays_floored(query, title):
+    assert _show(query, _price(12.0, "shopify_json", _PDP, title)) is False
+
+
+def test_my_perfumes_not_in_budget_set():
+    assert "my perfumes" not in ps.BUDGET_FRAGRANCE_BRAND_KEYWORDS
+    assert "myperfumes" not in ps.BUDGET_FRAGRANCE_BRAND_KEYWORDS
+
+
+# --- E. flag OFF == legacy: budget houses floored again --------------------
+def test_flag_off_floors_trusted_budget_price(monkeypatch):
+    monkeypatch.setenv("ENABLE_BUDGET_FRAGRANCE_FLOOR", "false")
+    assert _show("Lattafa Khamrah", _price(12.0, "shopify_json", _ALHAJIS, "Lattafa Khamrah Edp 100Ml")) is False
+    assert _show("Rasasi Hawas For Him", _price(14.0, "woo_store_api", _PDP, "Rasasi Hawas 100ml")) is False
+
+
+# --- helper contract -------------------------------------------------------
+def test_trusted_helper_requires_all_conditions():
+    # genuine + PDP + budget + not oil -> trusted
+    assert ps._budget_house_trusted_price("Lattafa Khamrah", _price(12.0, "woo_store_api", _PDP, "Lattafa Khamrah 100ml")) is True
+    # missing url -> not trusted
+    assert ps._budget_house_trusted_price("Lattafa Khamrah", _price(12.0, "woo_store_api", None, "Lattafa Khamrah")) is False
+    # non-budget brand -> not trusted
+    assert ps._budget_house_trusted_price("Dior Sauvage", _price(12.0, "woo_store_api", _PDP, "Dior Sauvage")) is False

--- a/tests/test_budget_fragrance_floor.py
+++ b/tests/test_budget_fragrance_floor.py
@@ -141,3 +141,38 @@ def test_trusted_helper_requires_all_conditions():
     assert ps._budget_house_trusted_price("Lattafa Khamrah", _price(12.0, "woo_store_api", None, "Lattafa Khamrah")) is False
     # non-budget brand -> not trusted
     assert ps._budget_house_trusted_price("Dior Sauvage", _price(12.0, "woo_store_api", _PDP, "Dior Sauvage")) is False
+
+
+# --- review round-3 hardening --------------------------------------------
+def test_bypass_coupled_to_exact_gate_for_rollback(monkeypatch):
+    # #1 — the bypass is PREMISED on the exact-gate; a full ENABLE_EXACT_PRICE_GATE
+    # rollback must ALSO disable the bypass (else the rollback isn't byte-identical).
+    p = _price(6.0, "local_bhd", _PDP, "Lattafa Khamrah")
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "false")
+    assert ps._budget_house_trusted_price("Lattafa Khamrah", p) is False
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "true")
+    assert ps._budget_house_trusted_price("Lattafa Khamrah", p) is True
+
+
+def test_out_of_stock_budget_price_not_trusted():
+    # #8 — an OOS below-floor budget price stays floored (defense-in-depth).
+    assert ps._budget_house_trusted_price(
+        "Lattafa Khamrah", _price(12.0, "woo_store_api", _PDP, "Lattafa Khamrah 100ml", in_stock=False)
+    ) is False
+    assert _show("Lattafa Khamrah", _price(12.0, "woo_store_api", _PDP, "Lattafa Khamrah 100ml", in_stock=False)) is False
+
+
+@pytest.mark.parametrize("query,title", [
+    ("Al Haramain Musk Muattar", "Al Haramain Musk Muattar EDP 100ml"),   # "attar" must NOT hit "mu-attar"
+    ("Rasasi Moattar Al Aqmisha", "Rasasi Moattar Al Aqmisha EDP 100ml"),
+])
+def test_muattar_not_caught_by_attar_token(query, title):
+    # #3 — word-boundary matching: a cheap EDP whose name merely CONTAINS "attar"
+    # ("Muattar"/"Moattar" = scented) must still SHOW, not be floored as an oil line.
+    assert _show(query, _price(15.0, "woo_store_api", _PDP, title)) is True
+
+
+def test_dead_budget_tokens_removed():
+    # #4 — non-designer-floored houses must NOT be listed (dead config).
+    for dead in ("armaf", "swiss arabian", "maison alhambra", "afnan", "paris corner"):
+        assert dead not in ps.BUDGET_FRAGRANCE_BRAND_KEYWORDS

--- a/tests/test_localhouse_woo_sources.py
+++ b/tests/test_localhouse_woo_sources.py
@@ -1,0 +1,53 @@
+"""Round-5 local-house genuine-BHD WooCommerce sources (alibaksh.com /
+fragrancebh.com).
+
+These two NON-walled Bahrain WooCommerce perfumeries are the durable genuine-BHD
+source for the local Arabic houses (Lattafa/Rasasi/Armaf/Swiss Arabian/Al
+Haramain) the prior catalog only reached via GCC-converted or Cloudflare-walled
+stores. This pins them live + wired so a future `build_source_registry_data`
+regeneration (or a liveness re-probe) can't silently drop or mis-map them.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+_DATA = Path(__file__).resolve().parent.parent / "data" / "bh_gcc_sources.json"
+_TARGETS = ("alibaksh.com", "fragrancebh.com")
+
+
+def _by_domain():
+    return {r["domain"]: r for r in json.loads(_DATA.read_text(encoding="utf-8"))}
+
+
+@pytest.mark.parametrize("domain", _TARGETS)
+def test_localhouse_woo_row_live_and_wired(domain):
+    row = _by_domain().get(domain)
+    assert row is not None, f"{domain} missing from bh_gcc_sources.json (round5 dropped?)"
+    assert row["status"] == "live", f"{domain} not live"
+    assert row["tier"] == "bahrain", f"{domain} must be bahrain-tier (BHD -> genuine)"
+    assert row["currency"] == "BHD"
+    assert row["mechanism"] == "woo_store_json"
+    assert row["genuine_method"] == "woo_store_api"
+    assert "fragrances" in row["categories"]
+
+
+def test_localhouse_woo_rows_loaded_by_catalog_loader(monkeypatch):
+    """The real _load_catalog_rows (flag ON) admits both rows with the woo
+    mechanism — exercises the actual runtime loader, not just the data file."""
+    monkeypatch.setenv("ENABLE_BH_GCC_CATALOG_SOURCES", "true")
+    import app.services.source_router as sr
+
+    loaded = {s.domain: s for s in sr._load_catalog_rows()}
+    for domain in _TARGETS:
+        assert domain in loaded, f"{domain} not admitted by _load_catalog_rows"
+        assert loaded[domain].mechanism == "woo_store_json"
+        assert loaded[domain].tier == "bahrain"
+
+
+def test_localhouse_woo_rows_absent_when_flag_off(monkeypatch):
+    """Flag OFF -> catalog dormant -> the rows do NOT load (ships inert)."""
+    monkeypatch.delenv("ENABLE_BH_GCC_CATALOG_SOURCES", raising=False)
+    import app.services.source_router as sr
+
+    assert sr._load_catalog_rows() == []

--- a/tests/test_park_listing_url_tier1.py
+++ b/tests/test_park_listing_url_tier1.py
@@ -1,0 +1,55 @@
+"""FIX 4 — park a genuine Tier-1 Serper-shopping price that carries a LISTING url
+(Google-Shopping "local": ibp=oshop / prds=localA) instead of short-circuiting,
+so the real-PDP direct adapters (woo/shopify/algolia) can serve a SHOWABLE genuine
+BHD price for the local Arabic houses.
+
+This locks the two contracts the cascade branch relies on:
+  1. the flag `_park_listing_url_tier1_enabled()` (default ON, OFF -> byte-identical)
+  2. `_is_listing_url` classifies the Google-Shopping "local" URLs as listing URLs
+     (so the park branch fires) while a real merchant PDP is NOT a listing url (so a
+     genuine PDP price still short-circuits).
+The end-to-end cascade behaviour (park -> woo wins) is exercised by the warm
+harness; here we pin the branch predicates so a refactor can't silently break them.
+"""
+import pytest
+
+from app.services.price_service import _is_listing_url
+from app.services.structured_comparison_service import _park_listing_url_tier1_enabled
+
+
+# --- flag contract --------------------------------------------------------
+def test_flag_default_on(monkeypatch):
+    monkeypatch.delenv("ENABLE_PARK_LISTING_URL_TIER1", raising=False)
+    assert _park_listing_url_tier1_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["false", "0", "no", "off", ""])
+def test_flag_off_values(monkeypatch, val):
+    monkeypatch.setenv("ENABLE_PARK_LISTING_URL_TIER1", val)
+    assert _park_listing_url_tier1_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["true", "1", "yes", "on"])
+def test_flag_on_values(monkeypatch, val):
+    monkeypatch.setenv("ENABLE_PARK_LISTING_URL_TIER1", val)
+    assert _park_listing_url_tier1_enabled() is True
+
+
+# --- the Google-Shopping "local" URLs ARE listing URLs (park branch fires) ---
+@pytest.mark.parametrize("url", [
+    "https://www.google.com/search?ibp=oshop&q=Lattafa+Khamrah+100ml&prds=localAnnotations",
+    "https://www.google.com/search?ibp=oshop&q=Rasasi+Hawas+For+Him+100ml&prds=localA",
+    "https://www.google.com/search?ibp=oshop&q=Al+Haramain+Amber+Oud+Gold+Edition+100ml&prds=localA",
+])
+def test_google_shopping_local_urls_are_listing(url):
+    assert _is_listing_url(url) is True
+
+
+# --- a real merchant PDP is NOT a listing URL (genuine short-circuit preserved) ---
+@pytest.mark.parametrize("url", [
+    "https://alhajisbahrain.com/products/lattafa-khamrah-edp-100ml",
+    "https://alibaksh.com/product/al-haramain-amber-oud-gold-edition-100ml",
+    "https://fragrancebh.com/product/rasasi-hawas-for-him-edp-100ml",
+])
+def test_merchant_pdp_urls_are_not_listing(url):
+    assert _is_listing_url(url) is False


### PR DESCRIPTION
# Local-house genuine-price coverage (Lattafa / Rasasi / Armaf / Swiss Arabian / Al Haramain)

Real customers comparing local Arabic perfume houses ("Lattafa Khamrah vs Armaf Club de Nuit", "Rasasi Hawas") saw **price-pending** even though genuine Bahrain (BHD) prices exist. Root-caused to a chain of blockers; this PR fixes the three code/data ones (each flag-gated, flag-OFF byte-identical). A fourth ops step (Serper budget reset) was applied out-of-band.

## What was wrong (reproduced through the runtime)

1. **The designer low-price floor suppressed the whole budget-house category.** `is_implausible_low_fragrance_price` treated `lattafa`/`rasasi`/`al haramain`/`ajmal`/`asgharali` (in `FRAGRANCE_BRAND_KEYWORDS`) as *designer* → the 25 BHD/100ml floor → their genuine cheap prices (Lattafa Khamrah **12**, Asad **8-9**, Rasasi Hawas **14-17**, Al Haramain Amber Oud **22** BHD) were flagged "implausibly low" and pended — even the price from the already-wired `alhajisbahrain` Shopify source.
2. **A Google-Shopping "local" hit short-circuited the real-PDP adapters.** A Tier-1 Serper-shopping `local_bhd` price carries a `google.com/search?ibp=oshop…&prds=localA` **listing URL** — always non-showable at the display chokepoint (`is_price_showable` pends a listing URL). Short-circuiting on it *guaranteed* a pend AND blocked the direct woo/shopify adapters that could serve a **showable** genuine BHD price.
3. **Thin direct-BH coverage for the gap brands.** `alhajisbahrain` covers Lattafa/Armaf well but is thin on Rasasi and carries no Al Haramain; the other cataloged stores are GCC-converted (rasasistore AED / swissarabian USD) or Cloudflare-walled.

## Fixes

### 1. Source-aware budget-house floor bypass — `price_service.py` (flag `ENABLE_BUDGET_FRAGRANCE_FLOOR`, default ON)
The fragrance low-price floor (`is_implausible_low_fragrance_price`, 25 BHD/100ml) is a heuristic for the **loose Serper-shopping path** — it drops a wrong-cheap mislabel that slipped past matching. But budget Arabic houses genuinely retail a full 100ml EDP for 8-25 BHD, and when the price comes from a **direct store adapter** (woo/shopify) that already exact-matched the SKU and carries a real PDP URL, the store's listed price is authoritative — the floor is then a false positive. So the floor function is **unchanged** (loose-path protection intact); only the **display chokepoint** (`is_price_showable`) bypasses it for a *trusted* price (`_budget_house_trusted_price`): flag-on + a budget-house brand token + a **genuine native-BHD `source_method`** (never estimated/converted) + a **real non-listing PDP URL** + **not** an expensive dehn-al-oud/mukhallat/attar **oil line** (those keep the floor). Flag OFF → the floor applies (byte-identical); `is_implausible_low_fragrance_price` itself is byte-identical in both flag states.

*(This shape came out of a coverage-driven adversarial review that flagged a naive house-wide floor exposing the houses' bimodal expensive oud/attar lines + a generic-token collision — see Gates.)*

### 2. Park listing-URL Tier-1 prices — `structured_comparison_service.py` (flag `ENABLE_PARK_LISTING_URL_TIER1`, default ON)
A genuine Tier-1 Serper-shopping price whose URL is a listing/search URL (`_is_listing_url`) is PARKED as a last-resort fallback (like a converted price) instead of short-circuiting — so the cascade reaches the real-PDP direct adapters (Shopify → Algolia → woo). A direct-adapter PDP hit then wins with a SHOWABLE price; if none, the parked price returns (still pends, same as before). Flag OFF → the legacy short-circuit (byte-identical). Strictly-improving: a listing-URL price was going to pend at display anyway.

### 3. Genuine-BHD WooCommerce sources — `data/bh_gcc_sources.json` (loads under existing `ENABLE_BH_GCC_CATALOG_SOURCES`, ON in prod)
Promote the two existing catalog candidates `alibaksh.com` + `fragrancebh.com` to `status="live"` (a 2-line status flip — they were already `provider-test-candidate` rows) — native Bahrain WooCommerce perfumeries (mechanism `woo_store_json`, genuine method `woo_store_api`), **liveness re-verified 2026-07-08** (curl_cffi, HTTP 200, `prices.currency_code=BHD`, NOT Cloudflare-walled):
- `alibaksh.com` carries **all 5** houses in BHD (Lattafa Asad 9, Rasasi Hawas 17, Armaf 15, Swiss Arabian 22, Al Haramain Amber Oud 22).
- `fragrancebh.com` covers 4/5 (Lattafa/Rasasi/Armaf/Al Haramain) as redundancy.

### 4. Warmer coverage — `data/warmer_catalog.json`
8 local-house entries (4 realistic pairs + 4 single hero SKUs) so the off-clock warmer caches these genuine BHD prices (bypassing the 15s cold-race latency — the warmer is the visibility lever).

## End-to-end proof (60s warmer budget, all fixes active)
| Query | Before | After |
|---|---|---|
| Lattafa Khamrah | pended (floored) | **12.0 BHD `woo_store_api` @ theperfumesclub**, showable |
| Rasasi Hawas For Him | estimate | **11.0 BHD `woo_store_api` @ fragrancebh.com**, showable |
| Al Haramain Amber Oud Gold | localA listing-URL (non-showable) | **22.0 BHD `woo_store_api` @ alibaksh.com**, showable |
| Armaf Club de Nuit Intense Man | localA listing-URL (non-showable) | **15.0 BHD `woo_store_api` @ theperfumesclub**, showable |

## Gates
- **Flag-OFF byte-identical** verified: the budget bypass (Khamrah 12 → floored again) and `is_implausible_low_fragrance_price` unchanged in both flag states; the listing-URL park (legacy short-circuit).
- **Coverage-driven adversarial review** (2 rounds). Round 1 (naive house-wide floor) reproduced real leaks — bimodal expensive oud/attar lines shown at wrong-cheap, dead-code budget tokens, a `"my perfumes"` collision. The fix was **reworked** to the source-aware bypass above (loose-path floor preserved, oil-lines excluded, collision tokens removed). Round 2 re-swept the reworked code.
- **Dispatcher gate** (both directions, through the runtime): trusted budget prices show; loose listing-URL / estimate / converted / oil-line / designer / collision all stay floored.
- New tests: `test_budget_fragrance_floor.py`, `test_localhouse_woo_sources.py`, `test_park_listing_url_tier1.py`.
- Comm gate: branch-only-NEW == [] vs `origin/main` (46-failure baseline).

## Guards inside the trust bypass (round-2 review hardening)
- **Absolute artifact floor:** a trusted budget price must still clear `_FRAGRANCE_MIN_FLOOR_BHD` (5 BHD) — the bypass lowers the floor 25→5, never to 0. So a mis-parsed fils/decimal glitch (e.g. 1.9 BHD Rasasi Hawas) stays pended even on a correct exact SKU.
- **Expanded oil-line exclusion:** the concentrated dehn-al-oud/mukhallat/attar lines (which genuinely cost 40-150+) keep the designer floor, across the alternate transliterations these houses actually list (`dhan al`/`muhallat`/`ittar`/`cpo`, …). Bare `oud`/`itr` deliberately excluded (would over-floor the cheap "Amber Oud" EDP / collide with "citrus").

## Known residual (documented tradeoff)
A wrong-cheap price for one of these houses' *expensive spray-EDP* lines (e.g. Rasasi La Yuqawam ~30-45) from a direct adapter with an exact title match would show above the 5 BHD floor — a spray can't be token-carved like an oil, and that price is the store's authoritative listed value for the exact SKU (the exact-gate is the identity guard, consistent with every other category). The loose Serper path still floors the common mislabel. A per-SKU price band (VariantDescriptor) is the real fix — tracked in the price-correctness arc.

## Out of scope (spawned as a separate task)
Premium-only niche brands (`roja`/`nishane`/`clive christian`/`bdk`/`ormonde jayne`) are in `PREMIUM_FRAGRANCE_BRAND_KEYWORDS` but not `FRAGRANCE_BRAND_KEYWORDS`, so `is_designer` excludes them and they escape the floor entirely — **pre-existing** (flag-OFF identical), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
