### PR TITLE
fix(security): SSRF redirect hardening on the page-fetch paths

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -9423,7 +9423,11 @@ async def fetch_page_price(
         return None
 
     domain = urlparse(url).netloc.replace("www.", "")
-    html = await curl_fetch_html(url)
+    # SSRF hardening (scraping audit 2026-07-08) — a Serper-discovered storefront
+    # URL is externally-influenced, so validate the initial URL AND every redirect
+    # hop (block private/loopback/link-local/metadata) and pin to the source host
+    # via the same-site helper, instead of the unvalidated curl_fetch_html.
+    html = await curl_fetch_html_same_site(url, domain)
     if html:
         price = extract_price_from_html(html, product_name, currency, domain, url)
         if price:

--- a/app/services/url_extraction_service.py
+++ b/app/services/url_extraction_service.py
@@ -85,11 +85,31 @@ async def fetch_page(url: str) -> Optional[str]:
         "Upgrade-Insecure-Requests": "1",
     }
     
+    # SSRF hardening (scraping audit 2026-07-08) — the public /url/* routes validate
+    # only the initial user URL, so a 30x redirect to a private/loopback/link-local/
+    # cloud-metadata (169.254.169.254) address would otherwise be followed blindly.
+    # Follow redirects MANUALLY, bounded, re-validating EVERY hop with the SSRF guard.
+    from app.utils.url_validator import validate_external_url
+
+    if not validate_external_url(url):
+        logger.warning(f"[SSRF] Blocked initial URL: {url}")
+        return None
     try:
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            return response.text
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            current = url
+            for _ in range(5):  # bounded redirect chain
+                response = await client.get(current, headers=headers)
+                if response.is_redirect and response.next_request is not None:
+                    nxt = str(response.next_request.url)
+                    if not validate_external_url(nxt):
+                        logger.warning(f"[SSRF] Blocked redirect to {nxt}")
+                        return None
+                    current = nxt
+                    continue
+                response.raise_for_status()
+                return response.text
+            logger.warning(f"[SSRF] Too many redirects for {url}")
+            return None
     except Exception as e:
         logger.error(f"Failed to fetch URL {url}: {e}")
         return None

--- a/tests/test_ssrf_redirect_hardening.py
+++ b/tests/test_ssrf_redirect_hardening.py
@@ -1,0 +1,107 @@
+"""SSRF hardening (scraping audit 2026-07-08).
+
+Two fetch paths followed redirects without re-validating each hop, so a
+public URL that 30x-redirects to a private/loopback/link-local/cloud-metadata
+address (169.254.169.254) would be fetched — an exfiltrating SSRF:
+  1. url_extraction_service.fetch_page (public /url/* routes) — now follows
+     redirects MANUALLY, bounded, re-validating every hop with validate_external_url.
+  2. price_service.fetch_page_price — now routes through curl_fetch_html_same_site
+     (validates the initial URL + every hop, pinned to the source host) instead of
+     the unvalidated curl_fetch_html.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import app.services.url_extraction_service as ues
+
+
+class _Resp:
+    def __init__(self, is_redirect=False, next_url=None, text="", status=200):
+        self.is_redirect = is_redirect
+        self.next_request = MagicMock(url=next_url) if next_url else None
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _Client:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None):
+        self.calls.append(url)
+        return self._responses.pop(0)
+
+
+def _patch(monkeypatch, client, validator):
+    monkeypatch.setattr(ues.httpx, "AsyncClient", client)
+    monkeypatch.setattr("app.utils.url_validator.validate_external_url", validator)
+
+
+# --- 1. fetch_page: redirect to internal is BLOCKED (never fetched) ---
+def test_fetch_page_blocks_redirect_to_metadata(monkeypatch):
+    client = _Client([_Resp(is_redirect=True, next_url="http://169.254.169.254/latest/meta-data/")])
+    _patch(monkeypatch, client, lambda u: "169.254" not in u and "127.0.0" not in u)
+    result = asyncio.run(ues.fetch_page("https://attacker.example/p"))
+    assert result is None
+    # the internal target must NEVER be fetched
+    assert not any("169.254.169.254" in c for c in client.calls)
+
+
+def test_fetch_page_blocks_private_initial_url(monkeypatch):
+    client = _Client([_Resp(text="secret")])
+    _patch(monkeypatch, client, lambda u: "127.0.0.1" not in u and "169.254" not in u)
+    result = asyncio.run(ues.fetch_page("http://127.0.0.1/admin"))
+    assert result is None
+    assert client.calls == []  # never even attempted
+
+
+def test_fetch_page_follows_valid_redirect(monkeypatch):
+    client = _Client([
+        _Resp(is_redirect=True, next_url="https://store.example/final"),
+        _Resp(text="<html>ok</html>"),
+    ])
+    _patch(monkeypatch, client, lambda u: True)  # all public
+    result = asyncio.run(ues.fetch_page("https://store.example/p"))
+    assert result == "<html>ok</html>"
+    assert client.calls == ["https://store.example/p", "https://store.example/final"]
+
+
+def test_fetch_page_caps_redirect_chain(monkeypatch):
+    # an endless public redirect loop terminates (bounded), returns None
+    client = _Client([_Resp(is_redirect=True, next_url=f"https://x.example/{i}") for i in range(10)])
+    _patch(monkeypatch, client, lambda u: True)
+    result = asyncio.run(ues.fetch_page("https://x.example/start"))
+    assert result is None
+    assert len(client.calls) <= 6  # bounded (~5 hops)
+
+
+# --- 2. fetch_page_price routes through the VALIDATED same-site helper ---
+def test_fetch_page_price_uses_validated_fetch(monkeypatch):
+    import app.services.price_service as ps
+    monkeypatch.setattr(ps, "ENABLE_PAGE_SCRAPE", True)
+    same_site = AsyncMock(return_value=None)
+    unvalidated = AsyncMock(return_value="<html>should-not-be-called</html>")
+    monkeypatch.setattr(ps, "curl_fetch_html_same_site", same_site)
+    monkeypatch.setattr(ps, "curl_fetch_html", unvalidated)
+    asyncio.run(ps.fetch_page_price("https://alibaksh.com/product/x", "Lattafa Khamrah", "BHD"))
+    same_site.assert_awaited_once()
+    # the unvalidated fetch must NOT be used on this path anymore
+    unvalidated.assert_not_awaited()
+    # called with (url, domain)
+    args = same_site.await_args.args
+    assert args[0] == "https://alibaksh.com/product/x"
+    assert args[1] == "alibaksh.com"


### PR DESCRIPTION
## SSRF redirect hardening (scraping-system audit — P1: security)

A deep audit of the price-discovery/scraping system surfaced two fetch paths that validate only the **initial** URL and then follow redirects blindly — so a public URL that 30x-redirects to a private/loopback/link-local/**cloud-metadata** (`169.254.169.254`) address would be fetched. An exfiltrating **SSRF**.

### Fixes
- **`url_extraction_service.fetch_page`** (the **public, unauthenticated** `/url/extract` + `/url/compare` routes): was `httpx.AsyncClient(follow_redirects=True)` with no per-hop check. Now validates the initial URL and follows redirects **manually, bounded (~5 hops), re-validating every `Location`** with `validate_external_url` (blocks private/loopback/link-local/reserved/metadata; non-http rejected).
- **`price_service.fetch_page_price`** (Tier-1.5 page-scrape, `ENABLE_PAGE_SCRAPE` on): routed the externally-influenced Serper-discovered storefront URL through the **unvalidated** `curl_fetch_html`. Now uses the existing **`curl_fetch_html_same_site`**, which validates the initial URL + every hop and pins to the source host.

### Tests
`tests/test_ssrf_redirect_hardening.py` — redirect-to-metadata blocked (internal never fetched), private initial URL blocked, a valid public redirect is followed, the chain is bounded, and the page-scrape path routes through the validated helper (the unvalidated one is not called).

Comm gate + affected surface green (80 passed). No behavior change for a normal same-host storefront fetch.

*This is P1 (security) of the audit. The remaining HIGH findings (variable-product decant leak, cache-write accuracy-guard gap + dose cache-key collision, microdata USD-default + max-across-nodes, sync-Redis event-loop blocking) are tracked as separate task chips.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
