### PR TITLE
fix(price): microdata extractor — region-currency default + query-node binding

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -9113,7 +9113,7 @@ def extract_price_from_html(
     # ("BHD 48.332/month"); the old find-first grabbed THAT (wrong). The helper
     # skips installment-context elements + reads the currency paired in the SAME
     # Offer itemscope (not a page-global find), and normalizes lowercase "bhd".
-    micro = _extract_microdata_price(soup, currency, domain, url)
+    micro = _extract_microdata_price(soup, currency, domain, url, product_name, _category)
     if micro:
         # frag-size-capture — size from og:title / page <title> (microdata
         # nodes rarely carry a volume; the name signals do).
@@ -9199,7 +9199,8 @@ _INSTALLMENT_RE = re.compile(
 
 
 def _extract_microdata_price(
-    soup, currency: str, domain: str, url: str
+    soup, currency: str, domain: str, url: str,
+    product_name: str = "", category: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Extract a product price from Schema.org microdata, skipping EPP
     installment nodes and pairing priceCurrency within the same Offer scope.
@@ -9207,12 +9208,26 @@ def _extract_microdata_price(
     Returns a ``page_scrape_microdata`` dict or ``None``. Prefers an
     ``itemprop=price`` inside an ``schema.org/Offer`` (or Product) itemscope;
     a bare/installment one is skipped.
+
+    Under exact_gate_enabled() (ENABLE_EXACT_PRICE_GATE, default ON) three
+    scraping-audit-2026-07-08 correctness fixes engage (flag-OFF byte-identical):
+    (a) a MISSING priceCurrency defaults to the REGION currency, not 'USD' (a BHD
+        page that omits its currency tag was converted DOWN ~2.6x); a genuinely
+        converted foreign price is relabelled source_method='converted_usd';
+        currency is also read from an enclosing Product ancestor, not only the
+        first Offer/Product's descendants.
+    (b) each price is bound to the enclosing Product itemscope's name and matched
+        against the query (_selection_match), so a query-matched node OUTRANKS a
+        pricier related-products/upsell Product node (the max-across-nodes hijack).
+        Demote-only: when no node name matches, the legacy max-in-offer pick stands
+        (single-product / nameless-scope pages are never over-rejected).
     """
     candidates = soup.find_all(attrs={"itemprop": "price"})
     if not candidates:
         return None
 
-    best = None  # (in_offer_scope: bool, amount, currency)
+    gate = exact_gate_enabled()
+    best = None  # legacy: (in_offer, amount, currency); gate: (matched, in_offer, amount, currency)
     for el in candidates:
         raw = el.get("content") or el.get_text(" ", strip=True)
         if not raw:
@@ -9228,22 +9243,34 @@ def _extract_microdata_price(
             continue
 
         # Is this price inside an Offer/Product itemscope? Walk up; also grab the
-        # currency paired within that SAME scope (not a page-global find).
+        # currency paired within that SAME scope (not a page-global find). Under the
+        # gate, keep walking past the first Offer to also capture the enclosing
+        # Product scope (its itemprop=name binds the price to the queried product,
+        # and its priceCurrency covers a currency declared on the Product ancestor).
         in_offer = False
         cur = None
         offer_scope = None
+        product_scope = None
         s = el
-        for _ in range(5):
+        for _ in range(8 if gate else 5):
             if s is None or not hasattr(s, "get"):
                 break
             itemtype = s.get("itemtype") or ""
-            if "Offer" in itemtype or "Product" in itemtype:
+            is_scope = "Offer" in itemtype or "Product" in itemtype
+            if "Product" in itemtype and product_scope is None:
+                product_scope = s
+            if is_scope and not in_offer:
                 in_offer = True
                 offer_scope = s
-                break
+                if not gate:
+                    break
             s = s.parent
         if offer_scope is not None:
             cur_el = offer_scope.find(attrs={"itemprop": "priceCurrency"})
+            if cur_el is not None:
+                cur = cur_el.get("content") or cur_el.get_text(strip=True)
+        if gate and not cur and product_scope is not None and product_scope is not offer_scope:
+            cur_el = product_scope.find(attrs={"itemprop": "priceCurrency"})
             if cur_el is not None:
                 cur = cur_el.get("content") or cur_el.get_text(strip=True)
 
@@ -9260,18 +9287,39 @@ def _extract_microdata_price(
 
         if not cur:
             cur_el = soup.find(attrs={"itemprop": "priceCurrency"})
-            cur = (cur_el.get("content") or cur_el.get_text(strip=True)) if cur_el else "USD"
+            if cur_el is not None:
+                cur = cur_el.get("content") or cur_el.get_text(strip=True)
+            else:
+                # BUG a (gate): a currency-less microdata price is a LOCAL shelf price
+                # on a region-scoped scrape domain, not USD — default to the region
+                # currency so a BHD page is not converted down ~2.6x. Flag-OFF: 'USD'.
+                cur = currency if gate else "USD"
         cur = str(cur).strip().upper()  # lulu lowercase "bhd" -> "BHD"
 
-        # Prefer an Offer-scoped price; among equals, the larger plausible value.
-        key = (in_offer, amount)
-        if best is None or key > (best[0], best[1]):
-            best = (in_offer, amount, cur)
+        # BUG b (gate): bind the price to the enclosing Product node's name and match
+        # it to the query, so a query-matched node outranks a pricier unmatched upsell.
+        matched = False
+        if gate and product_name and product_scope is not None:
+            nm = product_scope.find(attrs={"itemprop": "name"})
+            node_name = (nm.get("content") or nm.get_text(" ", strip=True)) if nm is not None else ""
+            if node_name:
+                matched = _selection_match(product_name, node_name, category)
+
+        # Prefer a query-matched node, then an Offer-scoped price, then the larger value.
+        if gate:
+            if best is None or (matched, in_offer, amount) > (best[0], best[1], best[2]):
+                best = (matched, in_offer, amount, cur)
+        else:
+            if best is None or (in_offer, amount) > (best[0], best[1]):
+                best = (in_offer, amount, cur)
 
     if best is None:
         return None
 
-    _in_offer, amount, cur = best
+    if gate:
+        _matched, _in_offer, amount, cur = best
+    else:
+        _in_offer, amount, cur = best
     result = {
         "amount": amount, "original_currency": cur, "currency": cur,
         "retailer": domain, "url": url, "in_stock": True,
@@ -9284,6 +9332,11 @@ def _extract_microdata_price(
     }
     if cur.upper() != currency.upper():
         _convert_gpt_price_currency(result, currency)
+        # A converted FOREIGN price is not a genuine local shelf price — label its
+        # provenance honestly (mirrors the JSON-LD / OG branches) so it stays out of
+        # the genuine-BH KPI and the UI reads "indicative", never a genuine BH price.
+        if gate:
+            result["source_method"] = "converted_usd"
     return result
 
 

--- a/tests/test_microdata_currency_node.py
+++ b/tests/test_microdata_currency_node.py
@@ -1,0 +1,157 @@
+"""Microdata price extractor — currency-default + upsell-node-hijack fixes (audit 2026-07-08).
+
+`_extract_microdata_price` had two correctness bugs, both fixed under exact_gate_enabled()
+(ENABLE_EXACT_PRICE_GATE, default ON; flag-OFF byte-identical):
+  (a) a MISSING priceCurrency defaulted to 'USD' -> a BHD page that omits its currency tag
+      was converted DOWN ~2.6x; a genuinely-converted foreign price kept source_method
+      'page_scrape' (polluting the genuine-BH KPI).
+  (b) the price was the MAX across all in-Offer itemprop=price nodes with NO query binding,
+      so a pricier related-products / upsell Product node hijacked the price.
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+from bs4 import BeautifulSoup
+
+from app.services import price_service as ps
+from app.services.price_service import _extract_microdata_price
+
+
+def _soup(html):
+    return BeautifulSoup(html, "html.parser")
+
+
+def _product(name, price, currency=None, itemtype="http://schema.org/Product"):
+    cur = f'<span itemprop="priceCurrency" content="{currency}">{currency}</span>' if currency else ""
+    return f'''
+    <div itemscope itemtype="{itemtype}">
+      <span itemprop="name">{name}</span>
+      <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+        <span itemprop="price" content="{price}">{price}</span>
+        {cur}
+      </div>
+    </div>'''
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "1")
+    monkeypatch.setenv("ENABLE_VARIANT_DESCRIPTOR_AXES", "1")
+    ps._extract_variant_descriptor_cached.cache_clear()
+    yield
+    ps._extract_variant_descriptor_cached.cache_clear()
+
+
+@pytest.fixture
+def flag_off(monkeypatch):
+    # exact_gate_enabled() DEFAULTS ON, so it must be explicitly disabled (not just unset).
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "0")
+    ps._extract_variant_descriptor_cached.cache_clear()
+    yield
+    ps._extract_variant_descriptor_cached.cache_clear()
+
+
+# --------------------------------------------------------------------------
+# BUG (a) — currency default + converted relabel
+# --------------------------------------------------------------------------
+class TestCurrencyDefault:
+    def test_missing_currency_defaults_to_region_flag_on(self, flag_on):
+        # BHD page, price tag with NO priceCurrency anywhere -> keep BHD, no conversion.
+        html = f'''<div itemscope itemtype="http://schema.org/Product">
+          <span itemprop="name">Dior Sauvage EDT 100ml</span>
+          <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+            <span itemprop="price" content="244.99">244.99</span>
+          </div></div>'''
+        out = _extract_microdata_price(_soup(html), "BHD", "example.bh", "https://example.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert out["amount"] == 244.99
+        assert out["currency"] == "BHD"
+        assert out["source_method"] == "page_scrape"   # not converted
+
+    def test_genuine_usd_offer_converts_and_relabels(self, flag_on, monkeypatch):
+        monkeypatch.setattr(ps, "_convert_to_bhd", lambda amt, cur: round(amt * 0.376, 2))
+        html = _product("Dior Sauvage EDT 100ml", "100", currency="USD")
+        out = _extract_microdata_price(_soup(html), "BHD", "example.bh", "https://example.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert out["currency"] == "BHD"
+        assert out["amount"] == 37.6                    # 100 USD -> BHD (stubbed rate)
+        assert out["source_method"] == "converted_usd"  # provenance honest
+
+    def test_currency_on_product_ancestor_read_flag_on(self, flag_on):
+        # priceCurrency declared on the PRODUCT scope, price in the nested Offer.
+        html = '''<div itemscope itemtype="http://schema.org/Product">
+          <span itemprop="name">Dior Sauvage EDT</span>
+          <span itemprop="priceCurrency" content="BHD">BHD</span>
+          <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+            <span itemprop="price" content="244.99">244.99</span>
+          </div></div>'''
+        out = _extract_microdata_price(_soup(html), "BHD", "example.bh", "https://example.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert out["amount"] == 244.99 and out["currency"] == "BHD"
+        assert out["source_method"] == "page_scrape"
+
+
+# --------------------------------------------------------------------------
+# BUG (b) — upsell/related-product node hijack
+# --------------------------------------------------------------------------
+class TestNodeBinding:
+    def test_matched_node_outranks_pricier_upsell(self, flag_on):
+        # Main product 244.99 (matches query) + a pricier UPSELL 299 (different product).
+        html = (_product("Dior Sauvage EDT 100ml", "244.99", currency="BHD")
+                + _product("Chanel Bleu de Chanel 100ml", "299.00", currency="BHD"))
+        out = _extract_microdata_price(_soup(html), "BHD", "d.bh", "https://d.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert out["amount"] == 244.99   # matched node wins over the pricier upsell
+
+    def test_single_unmatched_product_still_returns_price(self, flag_on):
+        # Only one product; its name does NOT match the query -> demote-only: still return.
+        html = _product("Totally Unrelated Item XZ", "55.00", currency="BHD")
+        out = _extract_microdata_price(_soup(html), "BHD", "d.bh", "https://d.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert out is not None and out["amount"] == 55.00
+
+    def test_nameless_scope_falls_back_to_max(self, flag_on):
+        # No itemprop=name -> matched False everywhere -> legacy max-in-offer pick.
+        html = '''<div itemscope itemtype="http://schema.org/Product">
+          <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+            <span itemprop="price" content="120.00">120.00</span>
+            <span itemprop="priceCurrency" content="BHD">BHD</span>
+          </div></div>'''
+        out = _extract_microdata_price(_soup(html), "BHD", "d.bh", "https://d.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert out is not None and out["amount"] == 120.00
+
+
+# --------------------------------------------------------------------------
+# FLAG OFF — byte-identical pre-fix behaviour
+# --------------------------------------------------------------------------
+class TestFlagOffByteIdentical:
+    def test_missing_currency_defaults_to_usd_flag_off(self, flag_off, monkeypatch):
+        # Pre-fix: no currency -> 'USD' -> converts a BHD-page price DOWN (the bug), and
+        # source_method stays 'page_scrape' (no converted relabel).
+        seen = {}
+
+        def fake_convert(price, target):
+            seen["called"] = True
+            price["currency"] = target
+
+        monkeypatch.setattr(ps, "_convert_gpt_price_currency", fake_convert)
+        html = f'''<div itemscope itemtype="http://schema.org/Product">
+          <span itemprop="name">Dior Sauvage EDT 100ml</span>
+          <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+            <span itemprop="price" content="244.99">244.99</span>
+          </div></div>'''
+        out = _extract_microdata_price(_soup(html), "BHD", "example.bh", "https://example.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert seen.get("called") is True               # USD default -> conversion fired (the bug)
+        assert out["source_method"] == "page_scrape"     # no converted_usd relabel flag-OFF
+
+    def test_max_node_wins_flag_off(self, flag_off):
+        # Pre-fix: no query binding -> the pricier upsell node wins (the bug preserved).
+        html = (_product("Dior Sauvage EDT 100ml", "244.99", currency="BHD")
+                + _product("Chanel Bleu de Chanel 100ml", "299.00", currency="BHD"))
+        out = _extract_microdata_price(_soup(html), "BHD", "d.bh", "https://d.bh/p",
+                                       product_name="Dior Sauvage", category="fragrances")
+        assert out["amount"] == 299.00                  # max-across-nodes, unchanged flag-OFF


### PR DESCRIPTION
## Audit HIGH — microdata extractor: region-currency default + query-node binding

`_extract_microdata_price` had two correctness bugs (both under `exact_gate_enabled()` / `ENABLE_EXACT_PRICE_GATE`, default ON; **flag-OFF byte-identical**):

**(a)** a MISSING `priceCurrency` defaulted to **USD** — a BHD page that omits its currency tag was converted DOWN ~2.6x. Now defaults to the REGION currency; also reads currency from an enclosing Product ancestor (not only the first Offer/Product's descendants); and relabels a genuinely-converted foreign price `source_method='converted_usd'` (mirrors the JSON-LD/OG branches) so it stays out of the genuine-BH KPI.

**(b)** the price was the **MAX across all in-Offer nodes** with no query binding — a pricier related-products/upsell Product node hijacked the price. Now binds each price to its enclosing Product node name + `_selection_match` so a matched node outranks an unmatched upsell. **Demote-only:** nameless/unmatched pages keep the legacy max pick (no over-rejection).

### Gates
- TDD `tests/test_microdata_currency_node.py` (8 cases, both directions + flag-OFF byte-identical).
- **Coverage-driven adversarial review** (reproduced through the real extractor across all 5 directions): the 3 behaviors reproduce, flag-OFF byte-identical, crash-safe, ancestor-currency read is a genuine improvement over legacy page-global scoping. One documented narrow residual (multi-Product page whose genuine main node is *unmatched* + a pricier sibling — strictly-improving over main, `_page_identity_ok`-gated).
- **Comm gate** branch-only-NEW == [] vs origin/main baseline (46 == 46).

Recommend `/code-review ultra` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
