### PR TITLE
fix(price): cache-write accuracy-guard parity + supplement dose cache-key

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -1359,6 +1359,33 @@ def _is_sample_or_decant_listing(product_name: str, title: Optional[str], amount
     return False
 
 
+def _fails_accuracy_guards(
+    product_name: str, price: Dict[str, Any], amount: Optional[float], title: Optional[str],
+) -> Optional[str]:
+    """The shipped plausibility/decant accuracy guards, in is_price_showable's EXACT
+    order and INCLUDING the budget-Arabic-house floor bypass (_budget_house_trusted_price).
+    Returns the failing-guard reason (for guard_rejected), or None when all pass.
+
+    Extracted (scraping audit 2026-07-08) so BOTH chokepoints enforce the identical set:
+    is_price_showable (display) AND should_cache_price (the 7d cache WRITE) — which
+    previously omitted these, so a below-floor decant / sample / high-value-accessory
+    mis-scrape carrying a title + real PDP URL could be WRITTEN to the genuine cache and
+    poison that slot for the whole TTL (every later cache-hit pends at display, masking a
+    genuine price a fresh resolve could have found). All four guards internally no-op on a
+    None/<=0 amount, so the helper is safe for any amount."""
+    if is_implausible_low_fragrance_price(product_name, amount, title=title) and not (
+        _budget_house_trusted_price(product_name, price)
+    ):
+        return "low_fragrance"
+    if is_implausible_low_haircare_price(product_name, amount):
+        return "low_haircare"
+    if is_implausible_high_value_price(product_name, amount):
+        return "high_value"
+    if _is_sample_or_decant_listing(product_name, title, amount):
+        return "sample_decant"
+    return None
+
+
 def is_price_showable(
     product_name: str, price: Optional[Dict[str, Any]], category: Optional[str] = None,
     *, enforce_correctness: bool = False,
@@ -1403,24 +1430,12 @@ def is_price_showable(
     elif title is not None and not isinstance(title, str):
         title = str(title)
         price["title"] = title
-    # Compose the shipped accuracy guards — a price that fails any is not
-    # showable (the guards already encode the "no wrong scrapes" contract).
-    # EXCEPTION (budget Arabic-house coverage) — a genuine direct-adapter exact-PDP
-    # price for a budget house (Lattafa/Rasasi/Al Haramain/...) bypasses the
-    # designer low-price FLOOR: it is the store's authoritative listed price for the
-    # exact SKU, so the 25/100ml floor is a false positive there. The floor still
-    # runs on the loose Serper-shopping path (unaffected). Flag OFF / non-genuine /
-    # listing-URL / expensive-oil-line -> the floor applies unchanged.
-    if is_implausible_low_fragrance_price(product_name, amount, title=title) and not (
-        _budget_house_trusted_price(product_name, price)
-    ):
-        return False
-    # F1.2b — premium haircare wrong-cheap leak (K18 4.51 BHD).
-    if is_implausible_low_haircare_price(product_name, amount):
-        return False
-    if is_implausible_high_value_price(product_name, amount):
-        return False
-    if _is_sample_or_decant_listing(product_name, title, amount):
+    # Compose the shipped accuracy guards — a price that fails any is not showable
+    # (the guards encode the "no wrong scrapes" contract, and their budget-Arabic-house
+    # floor bypass). Extracted to _fails_accuracy_guards so should_cache_price enforces
+    # the IDENTICAL set at the cache-write gate — byte-identical here (same guards, order,
+    # and _budget_house_trusted_price bypass).
+    if _fails_accuracy_guards(product_name, price, amount, title):
         return False
     # --- correctness backstop (CARDINAL RULE) — OPT-IN via enforce_correctness ---
     # Defense-in-depth at the RESPONSE CHOKEPOINT only (response_builder + streaming
@@ -7969,6 +7984,15 @@ def should_cache_price(
     if ((category or "").lower() == "electronics"
             and _is_device_accessory(title) and not _is_device_accessory(request_name)):
         return False
+    # Scraping audit 2026-07-08 — enforce the SAME plausibility/decant accuracy guards
+    # is_price_showable applies at DISPLAY, so a below-floor decant / sample / high-value-
+    # accessory mis-scrape (it carries a title + real PDP URL + in_stock, so it passed the
+    # checks above) is NOT written to the genuine 7d cache and cannot poison the slot for
+    # the TTL. Includes the budget-Arabic-house floor bypass, so a genuine Lattafa/Rasasi
+    # 12 BHD full bottle still caches (mirrors is_price_showable — no budget-house
+    # double-rejection). Inside the gate-ON body -> flag-OFF byte-identical.
+    if _fails_accuracy_guards(request_name, price, price.get("amount"), title):
+        return False
     if not request_name:
         return True
     if _selection_match(
@@ -8021,14 +8045,45 @@ def public_price_view(price: Any) -> Any:
     }
 
 
+def _dose_token(text: str, category: Optional[str] = None) -> str:
+    """A stable normalized supplement DOSE token (mg/IU/mcg) for the cache key, or ""
+    when there is no dose / it is not a supplement.
+
+    Scraping audit 2026-07-08 — the gate-ON base strip (_strip_identity_axes ->
+    _IDENTITY_MEASURE_STRIP_RE) REMOVES mg/mcg/iu from the cache-key base, but no token
+    re-carried the dose, so "Vitamin C 1000mg" and "Vitamin C 500mg" collided onto ONE
+    cross-user key (the 500mg price served for a 1000mg query). This re-adds the dose as
+    the discriminator. Reuses _doses() — the SAME axis the matcher's _vd_strength_mismatch
+    uses for correctness — so the cache key and the matcher agree. Category-gated to
+    SUPPLEMENTS via _resolve_extractor_category (explicit > ContextVar > inference; 'other'
+    re-inferred) so a stray 'mg' in a non-supplement name never forks its key. Gated on
+    exact_gate_enabled() so it is "" flag-OFF (there the legacy _SIZE_STRIP_RE base keeps
+    the dose anyway -> byte-identical, no collision to fix and no key change)."""
+    if not text or not exact_gate_enabled():
+        return ""
+    doses = _doses(text)
+    if not doses:
+        return ""
+    cat = _resolve_extractor_category(category, text)
+    if (cat or "").lower() != "supplements":
+        return ""
+
+    def _fmt(v: float) -> str:
+        return str(int(v)) if float(v).is_integer() else str(v)
+
+    # SET (sorted) not a single value, so a multi-dose B-complex stays distinct.
+    return "-".join(sorted(f"{_fmt(v)}{u}" for v, u in doses))
+
+
 def _identity_cache_token(text: str, category: Optional[str] = None) -> str:
     """A stable composite cache token of ALL identity-discriminating axes —
     concentration (EDP/EDT/…) + variant qualifier (FE/Pro/Max/…) + size/storage/
-    count/weight — so distinct VARIANTS of the same product never collide on one
-    cache key (EDP 100ml vs EDT 100ml; S24 vs S24 FE) while ALIAS wording maps to
-    the SAME token (EDT ≡ "eau de toilette" via the normalized label; oz snapped to
-    ml by size_variant_token). Empty when NO discriminating axis is present → the
-    caller keeps the legacy size-agnostic key (backward-compatible, no cache-warm
+    count/weight + supplement dose (mg/IU/mcg) — so distinct VARIANTS of the same
+    product never collide on one cache key (EDP 100ml vs EDT 100ml; S24 vs S24 FE;
+    1000mg vs 500mg) while ALIAS wording maps to the SAME token (EDT ≡ "eau de toilette"
+    via the normalized label; oz snapped to ml by size_variant_token). Empty when NO
+    discriminating axis is present → the caller keeps the legacy size-agnostic key
+    (backward-compatible, no cache-warm
     invalidation for plain products). The qualifier set is applied category-agnostically
     here — it only ever ADDS a discriminator, so a brand word that happens to be a
     qualifier (Max Factor) stays consistent across the request and the resolved match."""
@@ -8042,6 +8097,9 @@ def _identity_cache_token(text: str, category: Optional[str] = None) -> str:
     size = size_variant_token(text, category)
     if size:
         parts.append(size)
+    dose = _dose_token(text, category)
+    if dose:
+        parts.append(dose)
     return ".".join(parts)
 
 

--- a/tests/test_cache_write_accuracy_guards.py
+++ b/tests/test_cache_write_accuracy_guards.py
@@ -1,0 +1,145 @@
+"""Cache-WRITE gate parity + supplement dose cache-key (scraping audit 2026-07-08).
+
+(a) should_cache_price OMITTED the plausibility/decant accuracy guards is_price_showable
+    enforces at DISPLAY, so a below-floor decant / sample / high-value-accessory mis-scrape
+    carrying a title + real PDP URL could be WRITTEN to the genuine 7d cache and poison the
+    slot for the TTL. Fixed via the shared _fails_accuracy_guards helper (INCLUDING the
+    PR#33 budget-Arabic-house floor bypass, so a genuine Lattafa/Rasasi 12 BHD full bottle
+    still caches — no double-rejection).
+
+(b) the gate-ON base strip removed mg/mcg/IU from the cache-key base with no token to
+    re-carry it, so "Vitamin C 1000mg" and "Vitamin C 500mg" collided onto ONE key. Fixed
+    with a supplements-gated dose token in _identity_cache_token.
+
+Both under ENABLE_EXACT_PRICE_GATE (default ON); flag-OFF byte-identical.
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+
+from app.services import price_service as ps
+from app.services.price_service import (
+    should_cache_price, is_price_showable, build_size_aware_price_cache_key, _dose_token,
+)
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "1")
+    monkeypatch.setenv("ENABLE_VARIANT_DESCRIPTOR_AXES", "1")
+    ps._extract_variant_descriptor_cached.cache_clear()
+    yield
+    ps._extract_variant_descriptor_cached.cache_clear()
+
+
+@pytest.fixture
+def flag_off(monkeypatch):
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "0")
+    ps._extract_variant_descriptor_cached.cache_clear()
+    yield
+    ps._extract_variant_descriptor_cached.cache_clear()
+
+
+def _price(**kw):
+    d = {
+        "amount": 150.0, "currency": "BHD", "source_method": "woo_store_api",
+        "title": "Tom Ford Oud Wood Eau de Parfum 100ml", "in_stock": True,
+        "url": "https://sephora.bh/products/tom-ford-oud-wood-100ml",
+    }
+    d.update(kw)
+    return d
+
+
+# --------------------------------------------------------------------------
+# (a) cache-write gate must reject what the display gate pends
+# --------------------------------------------------------------------------
+class TestCacheWriteAccuracyGuards:
+    def test_below_floor_designer_fragrance_not_cached(self, flag_on):
+        # A designer fragrance far below the 25/100ml floor -> is_price_showable pends it,
+        # so the cache write MUST also refuse (else it poisons the 7d slot).
+        p = _price(amount=8.0)
+        assert is_price_showable("Tom Ford Oud Wood", p, "fragrances",
+                                 enforce_correctness=True) is False
+        assert should_cache_price("Tom Ford Oud Wood", p, "fragrances") is False
+
+    def test_sample_decant_listing_not_cached(self, flag_on):
+        p = _price(amount=35.0, title="Tom Ford Oud Wood DECANT 5ml Sample")
+        assert should_cache_price("Tom Ford Oud Wood", p, "fragrances") is False
+
+    def test_genuine_on_floor_price_still_caches(self, flag_on):
+        # Positive control — a plausible genuine price with matching identity still caches.
+        p = _price(amount=150.0)
+        assert is_price_showable("Tom Ford Oud Wood", p, "fragrances",
+                                 enforce_correctness=True) is True
+        assert should_cache_price("Tom Ford Oud Wood", p, "fragrances") is True
+
+    def test_budget_house_genuine_low_price_still_caches(self, flag_on):
+        # CRITICAL no-double-rejection: a genuine budget-Arabic-house 12 BHD full bottle
+        # is rescued by _budget_house_trusted_price at BOTH chokepoints — showable AND cached.
+        p = _price(
+            amount=12.0, title="Lattafa Khamrah Eau de Parfum 100ml",
+            url="https://alibaksh.com/product/lattafa-khamrah-edp-100ml",
+            source_method="woo_store_api",
+        )
+        assert is_price_showable("Lattafa Khamrah", p, "fragrances",
+                                 enforce_correctness=True) is True
+        assert should_cache_price("Lattafa Khamrah", p, "fragrances") is True
+
+    def test_flag_off_still_caches_below_floor(self, flag_off):
+        # Byte-identical rollback: with the gate OFF, should_cache_price returns True
+        # unconditionally (the accuracy guard is inside the gate-ON body).
+        p = _price(amount=8.0)
+        assert should_cache_price("Tom Ford Oud Wood", p, "fragrances") is True
+
+
+# --------------------------------------------------------------------------
+# (b) supplement dose cache-key collision
+# --------------------------------------------------------------------------
+class TestDoseCacheKey:
+    def _key(self, name, iden, cat="supplements"):
+        return build_size_aware_price_cache_key("", name, None, "bahrain", iden, category=cat)
+
+    def test_different_mg_dose_distinct_keys_flag_on(self, flag_on):
+        k1000 = self._key("Vitamin C 1000mg", "Vitamin C 1000mg 60 Capsules")
+        k500 = self._key("Vitamin C 500mg", "Vitamin C 500mg 60 Capsules")
+        assert k1000 != k500
+
+    def test_different_iu_dose_distinct_keys_flag_on(self, flag_on):
+        k5000 = self._key("Vitamin D3 5000 IU", "Vitamin D3 5000 IU 120 Softgels")
+        k1000 = self._key("Vitamin D3 1000 IU", "Vitamin D3 1000 IU 120 Softgels")
+        assert k5000 != k1000
+
+    def test_same_dose_different_field_same_key_flag_on(self, flag_on):
+        # Dose in name vs in identity_text -> the strip+re-append collapse yields ONE key.
+        k_a = build_size_aware_price_cache_key("", "Vitamin C 1000mg", None, "bahrain",
+                                               "Vitamin C 60 Capsules", category="supplements")
+        k_b = build_size_aware_price_cache_key("", "Vitamin C", None, "bahrain",
+                                               "Vitamin C 1000mg 60 Capsules", category="supplements")
+        assert k_a == k_b
+
+    def test_other_category_reinfers_supplement(self, flag_on):
+        # category 'other' that infers to supplements still splits by dose.
+        k5000 = self._key("Vitamin D3 5000 IU", "Vitamin D3 5000 IU Softgels", cat="other")
+        k1000 = self._key("Vitamin D3 1000 IU", "Vitamin D3 1000 IU Softgels", cat="other")
+        assert k5000 != k1000
+
+    def test_dose_token_unit(self, flag_on):
+        assert _dose_token("Vitamin C 1000mg", "supplements") == "1000mg"
+        assert _dose_token("Vitamin D3 5000 IU", "supplements") == "5000iu"
+        # multi-dose stays distinct + sorted
+        assert _dose_token("B-Complex 100mg 400mcg", "supplements") == "100mg-400mcg"
+        # not a supplement -> no token
+        assert _dose_token("Dior Sauvage EDT 100ml", "fragrances") == ""
+        # supplement with no dose -> no token
+        assert _dose_token("Vitamin C 60 Capsules", "supplements") == ""
+
+    def test_dose_token_inert_flag_off(self, flag_off):
+        assert _dose_token("Vitamin C 1000mg", "supplements") == ""
+
+    def test_non_supplement_key_unchanged_by_dose(self, flag_on):
+        # A fragrance key must not gain a dose token (no mg/IU in fragrance sizes anyway).
+        k1 = self._key("Dior Sauvage EDT 100ml", "Dior Sauvage EDT 100ml", cat="fragrances")
+        k2 = self._key("Dior Sauvage EDT 100ml", "Dior Sauvage EDT 100ml", cat="fragrances")
+        assert k1 == k2  # deterministic, no dose interference

--- a/tests/test_correctness_coverage_review_findings.py
+++ b/tests/test_correctness_coverage_review_findings.py
@@ -262,9 +262,12 @@ def test_D_should_cache_rejects_form_leak_supplement():
 
 
 def test_D_should_cache_accepts_exact_descriptive():
+    # amount must clear the high-value plausibility floor: should_cache_price now enforces
+    # the SAME accuracy guards is_price_showable applies (audit 2026-07-08), so a placeholder
+    # 30-BHD S24 would (correctly) be refused as an implausibly-low mis-scrape. Use a real price.
     assert ps.should_cache_price(
         "Samsung Galaxy S24 256GB",
-        _cache_price("Samsung Galaxy S24 256GB Dual SIM Phantom Black 5G Smartphone"),
+        _cache_price("Samsung Galaxy S24 256GB Dual SIM Phantom Black 5G Smartphone", amount=299),
         "electronics") is True
 
 

--- a/tests/test_wave_c_fence_bounds.py
+++ b/tests/test_wave_c_fence_bounds.py
@@ -263,10 +263,13 @@ class TestRS7SharedConsumerFence:
 
     def test_cache_gate_electronics_brand_omitted_unaffected(self):
         # (b) applies to FASHION only — the B4 electronics brand-omitted
-        # unlock is untouched at the shared consumers too
+        # unlock is untouched at the shared consumers too. amount clears the high-value
+        # plausibility floor: should_cache_price now enforces the SAME accuracy guards as
+        # is_price_showable (audit 2026-07-08), so the placeholder 45-BHD iPad would be
+        # (correctly) refused as an implausibly-low mis-scrape. Use a real price.
         assert should_cache_price(
             "Apple iPad Air 11-inch M3 128GB",
-            _pdp_price("iPad Air 11-inch M3 Wi-Fi 128GB Space Grey"),
+            _pdp_price("iPad Air 11-inch M3 Wi-Fi 128GB Space Grey", amount=250),
             "electronics") is True
 
 


### PR DESCRIPTION
## Audit HIGH — cache-write accuracy-guard parity + supplement dose cache-key

Two cache correctness bugs (both under `ENABLE_EXACT_PRICE_GATE`, default ON; **flag-OFF byte-identical**):

**(a)** `should_cache_price` OMITTED the plausibility/decant accuracy guards `is_price_showable` enforces at DISPLAY, so a below-floor decant / sample / high-value-accessory mis-scrape with a title + real PDP URL could be WRITTEN to the genuine 7d cache and poison the slot for the TTL (every later cache-hit pends at display, masking a genuine price). Extracted the four guards into a shared `_fails_accuracy_guards` helper — **INCLUDING the PR#33 budget-Arabic-house floor bypass**, so a genuine Lattafa/Rasasi 12 BHD full bottle still caches (no double-rejection) — and call it at the cache-write gate. `is_price_showable` refactored to the same helper (byte-identical: same guards, order, bypass).

**(b)** the gate-ON base strip removed mg/mcg/IU from the cache-key base with no token to re-carry it, so `Vitamin C 1000mg` and `Vitamin C 500mg` collided onto ONE cross-user key (500mg served for a 1000mg query). Added a supplements-gated `_dose_token` (reusing `_doses`, the same axis `_vd_strength_mismatch` uses) to `_identity_cache_token`. Flag-OFF the legacy `_SIZE_STRIP_RE` base already keeps the dose.

Two existing tests used sub-floor placeholder amounts (S24 @ 30, iPad @ 45) to exercise identity matching; `is_price_showable` already rejects those, so the new parity correctly refuses them — updated to plausible amounts (299 / 250) to preserve the identity-testing intent.

### Gates
- TDD `tests/test_cache_write_accuracy_guards.py` (12 cases: both chokepoints reject below-floor/sample; budget-house genuine still caches; dose-key discrimination; flag-OFF byte-identical).
- **Coverage-driven adversarial review** (cross-version diffed vs origin/main): `is_price_showable` 0 diffs; `should_cache_price` exactly 6 changes, all `True→False`, each newly-refused price also non-showable (never stops caching a showable price); budget-house genuine still caches; flag-OFF 0 diffs; `_dose_token` fixes the real collision with no wrong-serve.
- **Comm gate** branch-only-NEW == [] vs origin/main baseline (46 == 46).

**Pre-existing (NOT a regression):** `should_cache_price` crashes on a list-valued `title` — but **main crashes identically** via `_selection_match`. Minor follow-up: coerce the title like `is_price_showable` does.

Recommend `/code-review ultra` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
