### PR TITLE
fix(price): variable-product min-variation decant guard (woo + shopify)

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -3437,6 +3437,19 @@ def exact_gate_enabled() -> bool:
     )
 
 
+def variant_min_guard_enabled() -> bool:
+    """Scraping audit 2026-07-08 — gate the variable-product MIN-variation decant guard
+    (a woo/shopify variable product served its cheapest 30ml variation as the full bottle).
+    Default OFF (ships DORMANT); HARD-REQUIRES exact_gate_enabled() so a master rollback also
+    disables it (mirrors the localhouse floor-bypass precedent). Read per-call (env flip, no
+    restart). Flag OFF -> every adapter takes its exact current path -> byte-identical."""
+    if not exact_gate_enabled():
+        return False
+    return os.getenv("ENABLE_VARIANT_MIN_PRICE_GUARD", "").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+
+
 def _budget_fragrance_floor_enabled() -> bool:
     """True iff the BUDGET Arabic/Gulf-house fragrance floor is active (default ON).
 
@@ -9560,6 +9573,56 @@ async def _fetch_shopify_currency(domain: str) -> Optional[str]:
         return None
 
 
+def _select_shopify_variant(
+    variants: List[Any], product_name: str, product_title: str,
+    category: Optional[str], is_lux: bool,
+) -> Optional[Dict[str, Any]]:
+    """Bind the queried size to a specific Shopify variant instead of blindly pricing
+    variants[0] (usually the smallest/cheapest → a decant leak). Returns the chosen
+    variant, or None to PEND the product when the query STATES a size no variant offers,
+    or a size-unspecified query hits an unbindable price SPREAD on a non-fragrance.
+    Fragrances/luxury default to the flagship 100ml (else the LARGEST bottle) — never the
+    decant. Called only under variant_min_guard_enabled(); the caller keeps variants[0]
+    flag-OFF (byte-identical)."""
+    valid: List[Tuple[Dict[str, Any], Optional[int], float]] = []
+    for v in variants:
+        if not isinstance(v, dict):
+            continue
+        amt = parse_price_string(str(v.get("price", "")))
+        if amt is None or amt <= 0:
+            continue
+        # The variant's OWN title carries the authoritative per-variant size; fall back to the
+        # product-title context only when the variant title has no ml/oz token — so a product
+        # TITLE that lists a marketing size can't pollute a differently-sized variant's size
+        # (coverage review: extract_size_ml_any returns min(...), so a "…100ml" title would
+        # otherwise cap a "30ml" variant and could defeat the flagship pick).
+        vt = v.get("title") or ""
+        size = extract_size_ml_any(vt) or extract_size_ml_any(f"{product_title} {vt}")
+        valid.append((v, size, round(amt, 3)))
+    if not valid:
+        return None
+    q_size = extract_size_ml_any(product_name)
+    if q_size:
+        for v, size, _amt in valid:
+            if size == q_size:
+                return v
+        return None  # the stated size is not offered → pend, never serve a different size
+    # size-unspecified query
+    prices = {amt for _v, _s, amt in valid}
+    if len(prices) == 1:
+        return valid[0][0]  # all variants same price → unambiguous, no decant risk
+    cat = (category or "").lower()
+    if cat == "fragrances" or is_lux:
+        flagship = [v for v, size, _a in valid if size == 100]
+        if flagship:
+            return flagship[0]                                   # 100ml flagship convention
+        sized = [(size, v) for v, size, _a in valid if size]
+        if sized:
+            return max(sized, key=lambda t: t[0])[1]             # largest bottle, never the decant
+        return valid[0][0]                                       # no parseable sizes → no worse than today
+    return None  # non-fragrance size-unspecified spread → ambiguous → pend
+
+
 def _match_shopify_product(
     catalog: Optional[Dict[str, Any]],
     product_name: str,
@@ -9663,7 +9726,17 @@ def _match_shopify_product(
         variants = product.get("variants")
         if not isinstance(variants, list) or not variants:
             continue
-        variant = variants[0] if isinstance(variants[0], dict) else {}
+        # Variant-min decant guard (audit 2026-07-08): bind the queried size to a specific
+        # variant instead of blindly pricing variants[0] (usually the smallest = a decant
+        # served as the full bottle). Flag OFF → variants[0] (byte-identical).
+        if variant_min_guard_enabled():
+            variant = _select_shopify_variant(
+                variants, product_name, title, resolved_category, _is_lux,
+            )
+            if variant is None:
+                continue  # unbindable size/spread → pend this product (don't serve a decant)
+        else:
+            variant = variants[0] if isinstance(variants[0], dict) else {}
         amount = parse_price_string(str(variant.get("price", "")))
         if amount is None or amount <= 0:
             continue

--- a/app/services/woocommerce_service.py
+++ b/app/services/woocommerce_service.py
@@ -49,6 +49,7 @@ from app.services.price_service import (
     select_best,
     selection_primary_admits,
     strict_title_match,
+    variant_min_guard_enabled,
     variant_mismatch,
 )
 
@@ -116,6 +117,29 @@ def _amount_from_prices(prices: Dict[str, Any]) -> Optional[float]:
         return int(str(raw)) / (10 ** minor)
     except (TypeError, ValueError):
         return None
+
+
+def _woo_variable_spread(prices: Dict[str, Any]) -> bool:
+    """True iff this is a VARIABLE product priced from a price_range with a real
+    min != max spread (prices.price is null). Audit 2026-07-08: the Store API list
+    response carries NO per-variation sizes, so _amount_from_prices returns the
+    price_range MIN — a decant/cheapest variation that cannot be bound to the queried
+    size. Serving it leaks a decant as the full bottle. A min == max range (apparel
+    S/M/L all one price) or a simple product (single price) is NOT a spread."""
+    if not isinstance(prices, dict):
+        return False
+    if prices.get("price") not in (None, "", "null"):
+        return False  # simple product (single price) → never a spread
+    pr = prices.get("price_range")
+    if not isinstance(pr, dict):
+        return False
+    lo, hi = pr.get("min_amount"), pr.get("max_amount")
+    if lo in (None, "", "null") or hi in (None, "", "null"):
+        return False
+    try:
+        return int(str(lo)) != int(str(hi))
+    except (TypeError, ValueError):
+        return False
 
 
 def _match_woo_product(
@@ -203,6 +227,12 @@ def _match_woo_product(
         prices = prod.get("prices") or {}
         amount = _amount_from_prices(prices)
         if amount is None or amount <= 0:
+            continue
+        # Variant-min decant guard (audit 2026-07-08): a variable product whose price came
+        # from a price_range with min != max — the min is the cheapest variation (a decant),
+        # and the list response has no per-variation sizes to bind the queried size. PEND
+        # (skip) rather than leak the decant as the bottle. Flag OFF → served as today.
+        if variant_min_guard_enabled() and _woo_variable_spread(prices):
             continue
 
         currency_code = (prices.get("currency_code") or "").upper()

--- a/tests/test_variant_min_price_guard.py
+++ b/tests/test_variant_min_price_guard.py
@@ -1,0 +1,158 @@
+"""Variable-product MIN-variation DECANT LEAK guard (scraping audit 2026-07-08).
+
+woo/shopify variable products were served their CHEAPEST variation (a 30ml decant) as
+if it were the queried full bottle:
+  - woo `_amount_from_prices` falls back to price_range.min_amount for a variable product.
+  - shopify `_match_shopify_product` priced variants[0] (the store default/first, usually
+    the smallest).
+Fixed under ENABLE_VARIANT_MIN_PRICE_GUARD (default OFF; hard-requires ENABLE_EXACT_PRICE_GATE):
+  - woo: a min != max price_range spread with no per-variation sizes to bind -> PEND (skip).
+  - shopify: bind the queried size to a specific variant; size-unspecified fragrance ->
+    flagship/largest bottle (never the decant); non-fragrance unbindable spread -> PEND.
+Flag OFF -> exact current path (byte-identical). (magento deferred — its min-only GraphQL
+needs a query-byte change; tracked separately.)
+"""
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+
+from app.services import price_service as ps
+from app.services import woocommerce_service as woo
+from app.services.price_service import _match_shopify_product
+
+
+@pytest.fixture
+def guard_on(monkeypatch):
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "1")
+    monkeypatch.setenv("ENABLE_VARIANT_MIN_PRICE_GUARD", "1")
+    ps._extract_variant_descriptor_cached.cache_clear()
+    yield
+    ps._extract_variant_descriptor_cached.cache_clear()
+
+
+@pytest.fixture
+def guard_off(monkeypatch):
+    # exact gate stays ON (so matching behaves identically) — only the variant guard is OFF.
+    monkeypatch.setenv("ENABLE_EXACT_PRICE_GATE", "1")
+    monkeypatch.delenv("ENABLE_VARIANT_MIN_PRICE_GUARD", raising=False)
+    ps._extract_variant_descriptor_cached.cache_clear()
+    yield
+    ps._extract_variant_descriptor_cached.cache_clear()
+
+
+# --------------------------------------------------------------------------
+# WooCommerce — price_range spread pend
+# --------------------------------------------------------------------------
+def _woo_prod(name, price=None, price_range=None, currency="BHD", minor=3):
+    prices = {"currency_code": currency, "currency_minor_unit": minor}
+    if price is not None:
+        prices["price"] = price
+    if price_range is not None:
+        prices["price_range"] = price_range
+    return {"name": name, "prices": prices,
+            "permalink": "https://alibaksh.com/product/lattafa-khamrah", "is_in_stock": True}
+
+
+class TestWooSpread:
+    def test_variable_spread_pends_guard_on(self, guard_on):
+        # price null, range 12..45 BHD -> decant spread -> PEND (no candidate).
+        prods = [_woo_prod("Lattafa Khamrah Eau de Parfum",
+                           price_range={"min_amount": "12000", "max_amount": "45000"})]
+        assert woo._match_woo_product(prods, "Lattafa Khamrah", "BHD", "fragrances") is None
+
+    def test_variable_spread_returns_min_guard_off(self, guard_off):
+        prods = [_woo_prod("Lattafa Khamrah Eau de Parfum",
+                           price_range={"min_amount": "12000", "max_amount": "45000"})]
+        out = woo._match_woo_product(prods, "Lattafa Khamrah", "BHD", "fragrances")
+        assert out is not None and out["amount"] == 12.0   # byte-identical: min served
+
+    def test_variable_min_equals_max_not_pended(self, guard_on):
+        # apparel S/M/L all one price -> no spread -> still served.
+        prods = [_woo_prod("Lattafa Khamrah Eau de Parfum",
+                           price_range={"min_amount": "18000", "max_amount": "18000"})]
+        out = woo._match_woo_product(prods, "Lattafa Khamrah", "BHD", "fragrances")
+        assert out is not None and out["amount"] == 18.0
+
+    def test_simple_product_unchanged(self, guard_on):
+        prods = [_woo_prod("Lattafa Khamrah Eau de Parfum", price="20000")]
+        out = woo._match_woo_product(prods, "Lattafa Khamrah", "BHD", "fragrances")
+        assert out is not None and out["amount"] == 20.0
+
+    def test_spread_helper_unit(self):
+        assert woo._woo_variable_spread({"price_range": {"min_amount": "12000", "max_amount": "45000"}}) is True
+        assert woo._woo_variable_spread({"price_range": {"min_amount": "12000", "max_amount": "12000"}}) is False
+        assert woo._woo_variable_spread({"price": "20000"}) is False
+        assert woo._woo_variable_spread({}) is False
+
+
+# --------------------------------------------------------------------------
+# Shopify — positive size binding
+# --------------------------------------------------------------------------
+def _shopify_catalog(variants, title="Dior Sauvage Eau de Parfum", vendor="Dior"):
+    return {"_store_currency": "BHD", "products": [
+        {"title": title, "vendor": vendor, "handle": "sauvage", "variants": variants}]}
+
+
+def _v(size, price, available=True):
+    return {"title": size, "price": price, "available": available}
+
+
+class TestShopifyBinding:
+    def test_stated_size_binds_matching_variant(self, guard_on):
+        # Title carries 100ml (so a 100ml query matches upstream) but variants[0] is a 30ml
+        # decant — the leak. Guard binds the 100ml variant.
+        cat = _shopify_catalog([_v("30ml", "25.00"), _v("100ml", "55.00")],
+                               title="Dior Sauvage Eau de Parfum 100ml")
+        out = _match_shopify_product(cat, "Dior Sauvage EDP 100ml", "BHD", "d.bh", "fragrances")
+        assert out is not None and out["amount"] == 55.0 and out["size"] == "100ml"
+
+    def test_stated_size_variants0_decant_guard_off(self, guard_off):
+        cat = _shopify_catalog([_v("30ml", "25.00"), _v("100ml", "55.00")],
+                               title="Dior Sauvage Eau de Parfum 100ml")
+        out = _match_shopify_product(cat, "Dior Sauvage EDP 100ml", "BHD", "d.bh", "fragrances")
+        assert out is not None and out["amount"] == 25.0   # byte-identical: variants[0]=30ml decant leak
+
+    def test_size_unspecified_fragrance_prefers_flagship(self, guard_on):
+        cat = _shopify_catalog([_v("30ml", "25.00"), _v("100ml", "55.00")])
+        out = _match_shopify_product(cat, "Dior Sauvage", "BHD", "d.bh", "fragrances")
+        assert out is not None and out["amount"] == 55.0   # 100ml flagship, never the 30ml decant
+
+    def test_size_unspecified_variants0_decant_guard_off(self, guard_off):
+        cat = _shopify_catalog([_v("30ml", "25.00"), _v("100ml", "55.00")])
+        out = _match_shopify_product(cat, "Dior Sauvage", "BHD", "d.bh", "fragrances")
+        assert out is not None and out["amount"] == 25.0   # byte-identical: variants[0]=30ml decant leak
+
+    def test_size_unspecified_no_flagship_prefers_largest(self, guard_on):
+        cat = _shopify_catalog([_v("30ml", "25.00"), _v("50ml", "40.00")])
+        out = _match_shopify_product(cat, "Dior Sauvage", "BHD", "d.bh", "fragrances")
+        assert out is not None and out["amount"] == 40.0   # largest (50ml), never the 30ml decant
+
+    def test_stated_size_not_offered_pends(self, guard_on):
+        cat = _shopify_catalog([_v("30ml", "25.00"), _v("50ml", "40.00")])
+        out = _match_shopify_product(cat, "Dior Sauvage EDP 200ml", "BHD", "d.bh", "fragrances")
+        assert out is None   # 200ml not offered -> pend, never serve a different size
+
+    def test_all_same_price_unambiguous(self, guard_on):
+        cat = _shopify_catalog([_v("30ml", "25.00"), _v("100ml", "25.00")])
+        out = _match_shopify_product(cat, "Dior Sauvage", "BHD", "d.bh", "fragrances")
+        assert out is not None and out["amount"] == 25.0
+
+    def test_single_variant_unchanged(self, guard_on):
+        cat = _shopify_catalog([_v("100ml", "55.00")])
+        out = _match_shopify_product(cat, "Dior Sauvage", "BHD", "d.bh", "fragrances")
+        assert out is not None and out["amount"] == 55.0
+
+    def test_selector_unit_stated_size(self):
+        variants = [_v("30ml", "25.00"), _v("100ml", "55.00")]
+        chosen = ps._select_shopify_variant(variants, "Dior Sauvage 100ml",
+                                             "Dior Sauvage", "fragrances", True)
+        assert chosen is not None and chosen["title"] == "100ml"
+
+    def test_selector_unit_non_fragrance_spread_pends(self):
+        # supplements 60/120 count at different prices, size-unspecified -> ambiguous -> pend
+        variants = [_v("60 caps", "10.00"), _v("120 caps", "18.00")]
+        chosen = ps._select_shopify_variant(variants, "NOW Vitamin C",
+                                             "NOW Vitamin C", "supplements", False)
+        assert chosen is None


### PR DESCRIPTION
## Audit HIGH — variable-product min-variation DECANT LEAK (woo + shopify)

woo/shopify variable products were served their CHEAPEST variation (a 30ml decant) as the queried full bottle: woo `_amount_from_prices` falls back to `price_range.min_amount`; shopify `_match_shopify_product` priced `variants[0]` (usually the smallest).

New **`ENABLE_VARIANT_MIN_PRICE_GUARD` (default OFF; hard-requires `ENABLE_EXACT_PRICE_GATE`)** → ships **DORMANT**, byte-identical until canaried:
- **woo**: a `price_range` with min != max (a real spread) whose per-variation sizes the list response can't bind → PEND (skip) instead of leaking the min. min==max (apparel) and simple products untouched.
- **shopify**: bind the queried size to a specific variant (`_select_shopify_variant`, variant-title-first size derivation) instead of blindly pricing `variants[0]`. Stated size not offered → pend; size-unspecified fragrance/luxury → flagship 100ml else the LARGEST bottle (never the decant); non-fragrance unbindable spread → pend. Size stamped from the chosen variant.

**magento DEFERRED** (its min-only `priceRange` GraphQL needs a query-byte change with a tenant-rejection risk) → follow-up task.

### Gates
- TDD `tests/test_variant_min_price_guard.py` (15 cases, both directions + flag-OFF byte-identical leak proofs).
- **Coverage-driven adversarial review**: flag-OFF byte-identity PASS across all configs (incl. EXACT=0/GUARD=1 dormancy); no flag-ON regression; the reviewer-flagged title-pollution gap was hardened (variant-title-first). Documented deliberate coverage costs (woo pends category-blind on any spread; non-fragrance size-unspecified spread pends — correctness>coverage, fail-closed).
- **Comm gate** branch-only-NEW == [] modulo the documented `test_prices_endpoint_rate_limited` flake (real GET, passes isolated, fails on main too under load).

Recommend `/code-review ultra` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)