### PR TITLE
perf(cache): offload blocking Upstash GET off the event loop (PR1)

### DIFF
--- a/app/services/cache_service.py
+++ b/app/services/cache_service.py
@@ -536,6 +536,21 @@ def set_cached(key: str, value: Dict[str, Any], ttl: int = 86400) -> bool:
         return False
 
 
+def _redis_offload_enabled() -> bool:
+    """Scraping audit 2026-07-08 — gate offloading the SYNC Upstash REST round-trip off the
+    asyncio event loop. The module-level `redis_client` is a BLOCKING (httpx.Client) client,
+    so every get_cached from an async orchestrator method stalls the single worker loop for the
+    full Upstash RTT (~6-8 guaranteed per warm compare, ~12-20 cold). Read per-call (env flip,
+    no restart). Default OFF -> the caller's dispatch runs the sync call INLINE -> byte-identical.
+
+    Shared flag helper only; the offload DISPATCH lives in the calling module (scs._cache_get_async)
+    so a test that patches the CALLER's imported `get_cached` still intercepts both branches — a
+    wrapper here would call cache_service.get_cached directly and silently bypass those patches."""
+    return os.getenv("ENABLE_ASYNC_REDIS_OFFLOAD", "").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+
+
 def delete_cached(key: str) -> bool:
     """Delete a key from cache."""
     if not redis_client:

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -41,6 +41,7 @@ from app.services.database_service import get_user_demographics
 from app.services.serper_service import search_product_prices, search_price_organic, search_web
 from app.services.cache_service import (
     get_cached,
+    _redis_offload_enabled,
     set_cached,
     record_tier15_attempt,
     record_tier15_hit,
@@ -715,6 +716,23 @@ def _price_cache_bust_enabled() -> bool:
     (unset/false) in normal operation — this is evidence-gathering, not runtime.
     """
     return os.environ.get("PRICE_CACHE_BUST", "false").lower() == "true"
+
+
+async def _cache_get_async(key: str):
+    """Scraping audit 2026-07-08 (PR1) — offload the BLOCKING Upstash REST GET off the
+    single asyncio event loop when ENABLE_ASYNC_REDIS_OFFLOAD is on, so a warm compare's
+    ~6-8 guaranteed cache reads don't head-of-line-stall every other concurrent request.
+
+    Dispatch lives HERE (not in cache_service) and references the module-level `get_cached`
+    in BOTH branches, so a test that patches `structured_comparison_service.get_cached` still
+    intercepts it. Flag OFF -> `return get_cached(key)` runs synchronously to completion with
+    NO scheduler yield -> byte-identical to the pre-change direct call (same value, ordering,
+    fail-open). Flag ON -> asyncio.to_thread runs the identical sync command in the default
+    executor (the same idiom the scraper adapters already use); the sync `redis_client`
+    (pooled httpx.Client) is thread-safe and each Upstash command is a stateless POST."""
+    if _redis_offload_enabled():
+        return await asyncio.to_thread(get_cached, key)
+    return get_cached(key)
 
 
 # Wave-2 B1.1b (chokepoint R8b) — a module-level counter of cache-read identity
@@ -4179,8 +4197,8 @@ class StructuredComparisonService:
             if include_specs or include_reviews:
                 specs_key = get_specs_cache_key(brand, name, variant)
                 reviews_key = get_reviews_cache_key(brand, name, variant)
-                specs_hit = get_cached(specs_key) if not nocache else None
-                reviews_hit = get_cached(reviews_key) if not nocache else None
+                specs_hit = (await _cache_get_async(specs_key)) if not nocache else None
+                reviews_hit = (await _cache_get_async(reviews_key)) if not nocache else None
                 if (include_specs and not specs_hit) or (include_reviews and not reviews_hit):
                     t0 = time.perf_counter() if stage_timings is not None else None
                     unified_search = await search_web(
@@ -4658,7 +4676,7 @@ class StructuredComparisonService:
     ) -> Dict[str, Any]:
         """Get specs with caching (L1: Redis, L2: DB)."""
         cache_key = get_specs_cache_key(brand, name, variant)
-        cached = get_cached(cache_key) if not nocache else None
+        cached = (await _cache_get_async(cache_key)) if not nocache else None
         if cached:
             cached["_cached"] = True
             return cached
@@ -4875,7 +4893,7 @@ class StructuredComparisonService:
         # the routing escalation re-runs deterministically (specs/reviews stay
         # warm — they gate on `nocache` in _fetch_product_data, not this flag).
         price_nocache = nocache or _price_cache_bust_enabled()
-        cached = get_cached(cache_key) if not price_nocache else None
+        cached = (await _cache_get_async(cache_key)) if not price_nocache else None
         if cached and not _cache_price_identity_ok(cached, brand, name, category):
             logger.info("[PRICE] cache-read identity revalidation dropped a poisoned "
                         "entry for %s %s — re-resolving", brand, name)

--- a/tests/test_async_redis_offload.py
+++ b/tests/test_async_redis_offload.py
@@ -1,0 +1,132 @@
+"""Async Redis offload — scs._cache_get_async (scraping audit 2026-07-08, PR1).
+
+The module-level `redis_client` is a BLOCKING (httpx.Client) Upstash client, so every
+get_cached from an async orchestrator method stalls the single worker event loop for the
+full REST RTT (~6-8 guaranteed per warm compare). ENABLE_ASYNC_REDIS_OFFLOAD (default OFF)
+offloads the sync GET to a worker thread (asyncio.to_thread) so the loop is free during the RTT.
+
+The dispatch (`_cache_get_async`) lives in structured_comparison_service and references the
+module-level `get_cached` in BOTH branches, so a test that patches
+`structured_comparison_service.get_cached` still intercepts it (a cache_service-side wrapper
+would silently bypass those patches). Flag OFF -> inline sync call -> byte-identical.
+"""
+import asyncio
+import os
+import time
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy")
+
+import pytest
+
+from app.services import cache_service as cs
+from app.services import structured_comparison_service as scs
+
+
+@pytest.mark.asyncio
+class TestCacheGetAsync:
+    async def test_flag_off_runs_inline_no_offload(self, monkeypatch):
+        monkeypatch.delenv("ENABLE_ASYNC_REDIS_OFFLOAD", raising=False)
+        monkeypatch.setattr(scs, "get_cached", lambda k: {"k": k})
+        called = {"to_thread": False}
+        real = asyncio.to_thread
+
+        async def spy(fn, *a, **kw):
+            called["to_thread"] = True
+            return await real(fn, *a, **kw)
+
+        monkeypatch.setattr(scs.asyncio, "to_thread", spy)
+        out = await scs._cache_get_async("x")
+        assert out == {"k": "x"}
+        assert called["to_thread"] is False   # inline sync branch, no offload
+
+    async def test_patch_point_preserved(self, monkeypatch):
+        # THE reason dispatch lives in scs: patching scs.get_cached must intercept a HIT
+        # through _cache_get_async (both flag states), so existing cache-hit tests keep working.
+        monkeypatch.setattr(scs, "get_cached", lambda k: {"cached_hit": k})
+        monkeypatch.delenv("ENABLE_ASYNC_REDIS_OFFLOAD", raising=False)
+        assert await scs._cache_get_async("h") == {"cached_hit": "h"}
+        monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "1")
+        assert await scs._cache_get_async("h") == {"cached_hit": "h"}
+
+    async def test_flag_on_offloads_to_thread(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "1")
+        monkeypatch.setattr(scs, "get_cached", lambda k: {"k": k})
+        seen = {}
+        real = asyncio.to_thread
+
+        async def spy(fn, *a, **kw):
+            seen["fn"], seen["args"] = fn, a
+            return await real(fn, *a, **kw)
+
+        monkeypatch.setattr(scs.asyncio, "to_thread", spy)
+        out = await scs._cache_get_async("y")
+        assert out == {"k": "y"}
+        assert seen["fn"] is scs.get_cached and seen["args"] == ("y",)
+
+    async def test_value_equality_on_vs_off(self, monkeypatch):
+        monkeypatch.setattr(scs, "get_cached", lambda k: {"hit": k})
+        monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "0")
+        off = await scs._cache_get_async("p")
+        monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "1")
+        on = await scs._cache_get_async("p")
+        assert off == on == {"hit": "p"}
+
+    async def test_none_on_miss_both_ways(self, monkeypatch):
+        monkeypatch.setattr(scs, "get_cached", lambda k: None)
+        monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "0")
+        assert await scs._cache_get_async("m") is None
+        monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "1")
+        assert await scs._cache_get_async("m") is None
+
+    async def test_flag_on_does_not_block_loop(self, monkeypatch):
+        # A blocking get (0.2s) under the flag must run in a thread so a concurrent
+        # coroutine keeps ticking. If it blocked the loop inline, ticks would be ~0.
+        monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "1")
+        monkeypatch.setattr(scs, "get_cached", lambda k: (time.sleep(0.2), {"k": k})[1])
+        ticks = {"n": 0}
+
+        async def ticker():
+            while True:
+                await asyncio.sleep(0.005)
+                ticks["n"] += 1
+
+        tk = asyncio.create_task(ticker())
+        out = await scs._cache_get_async("z")
+        n_at_return = ticks["n"]
+        tk.cancel()
+        try:
+            await tk
+        except asyncio.CancelledError:
+            pass
+        assert out == {"k": "z"}
+        assert n_at_return >= 10   # loop serviced the ticker during the 0.2s offload
+
+    async def test_flag_off_blocks_loop_documents_fix(self, monkeypatch):
+        # Contrast: flag OFF runs the blocking get inline -> the loop stalls -> the
+        # concurrent ticker is starved during the 0.2s. Documents WHY the fix matters.
+        monkeypatch.delenv("ENABLE_ASYNC_REDIS_OFFLOAD", raising=False)
+        monkeypatch.setattr(scs, "get_cached", lambda k: (time.sleep(0.2), {"k": k})[1])
+        ticks = {"n": 0}
+
+        async def ticker():
+            while True:
+                await asyncio.sleep(0.005)
+                ticks["n"] += 1
+
+        tk = asyncio.create_task(ticker())
+        await asyncio.sleep(0)  # let the ticker start
+        await scs._cache_get_async("z")
+        n_at_return = ticks["n"]
+        tk.cancel()
+        try:
+            await tk
+        except asyncio.CancelledError:
+            pass
+        assert n_at_return <= 3   # loop was blocked inline (few/no ticks)
+
+
+def test_flag_helper_off_by_default(monkeypatch):
+    monkeypatch.delenv("ENABLE_ASYNC_REDIS_OFFLOAD", raising=False)
+    assert cs._redis_offload_enabled() is False
+    monkeypatch.setenv("ENABLE_ASYNC_REDIS_OFFLOAD", "true")
+    assert cs._redis_offload_enabled() is True


### PR DESCRIPTION
## Audit HIGH — sync Upstash Redis blocks the asyncio event loop (incremental PR1)

The module-level `redis_client` is a BLOCKING (httpx.Client) Upstash client, so every `get_cached` from an async orchestrator method stalls the single worker event loop for the full REST RTT — ~6-8 guaranteed reads per warm compare (12-20 cold), each a head-of-line stall for every other concurrent request/task.

**Incremental PR1** (smallest blast radius): a scs-local `_cache_get_async` offloads the sync GET via `asyncio.to_thread` (the same idiom the scraper adapters already use; the sync `redis_client`'s pooled httpx.Client is thread-safe, each Upstash command a stateless POST) behind **`ENABLE_ASYNC_REDIS_OFFLOAD` (default OFF)**. Wired at the 4 guaranteed-every-compare GET sites (`_fetch_product_data` specs+reviews, `_get_specs`, `_get_price`). Writes / budget-gate GETs / metrics deferred to follow-up PRs.

**Dispatch lives in scs (not cache_service)** and references the module-level `get_cached` in BOTH branches, so a test patching `structured_comparison_service.get_cached` still intercepts it (a cache_service-side wrapper would silently bypass the cache-hit tests). **Flag OFF → `return get_cached(key)` runs synchronously with no scheduler yield → byte-identical** (same value, ordering, fail-open).

### Gates
- TDD `tests/test_async_redis_offload.py` (8 cases incl. the non-blocking proof — a concurrent coroutine advances ≥10 ticks during a 0.2s offloaded get — the flag-OFF blocking contrast, and patch-point preservation).
- **Coverage-driven adversarial review**: CLEAN — flag-OFF byte-identical (no scheduler yield), patch-point preserved (the 4 at-risk cache-hit test files pass), scope exactly 4 sites/3 files, offload correct + fail-open + ContextVar-safe. (Dead `import asyncio` flagged by the review was removed.)
- **Comm gate** branch-only-NEW == [] modulo the documented `test_prices_endpoint_rate_limited` flake.

Recommend `/code-review ultra` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)