### PR TITLE
feat(discovery): owned Serper-free discovery for 62 verified catalog sources

### DIFF
--- a/app/services/source_router.py
+++ b/app/services/source_router.py
@@ -404,6 +404,35 @@ _ADMITTED_STATUSES = frozenset({"live"})
 _VALID_TIERS = frozenset({"bahrain", "gcc"})
 
 
+def _owned_discovery_promotion_enabled() -> bool:
+    """Phase-1 owned-discovery promotion (2026-08-17), fail-CLOSED default OFF.
+
+    A 2026-08-17 sweep of every live catalog row that carries NO adapter probed
+    each domain's platform JSON API directly. 103 of 195 answered — 99 Shopify
+    ``/products.json`` + 4 WooCommerce ``/wp-json/wc/store/products`` — and the
+    production adapter resolved a real, correctly-denominated price on 24 of 24
+    sampled (``shopify_json``, AED/QAR/KWD/SAR/OMR, Serper-FREE and OpenAI-FREE).
+
+    39 of those 103 were ALREADY reachable through
+    ``get_gcc_shopify_pagescrape_sources_for_category``. The other 64 were not —
+    and the ONLY reason is the selector's liveness ANCHOR: it admits a row when
+    ``"/products.json" in sample_url``, but these rows recorded a PDP or a
+    collection URL as their anchor instead. Their catalog endpoint works fine;
+    the proxy predicate just under-selects. Likewise 4 bahrain WooCommerce rows
+    shipped with a blank mechanism despite a live Store API.
+
+    So the promotion is DATA, not new machinery: each affected row carries a
+    ``promoted_sample_url`` / ``promoted_mechanism``, and this flag decides
+    whether the loader HONORS them. OFF (the default) → the promotion fields are
+    ignored entirely and SOURCE_REGISTRY is byte-identical to pre-promotion, so
+    the change is a prod no-op until it is flipped on Railway.
+    """
+    import os
+    return os.getenv("ENABLE_OWNED_DISCOVERY_PROMOTION", "").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+
+
 def _row_to_source(row: dict) -> Optional[Source]:
     """Construct a Source from one consolidated catalog row, or None if the row
     is malformed / not admitted. Never raises."""
@@ -430,6 +459,18 @@ def _row_to_source(row: dict) -> Optional[Source]:
             prank = int(row.get("priority_rank", 100))
         except (TypeError, ValueError):
             prank = 100
+        mechanism = str(row.get("mechanism") or "")
+        sample_url = str(row.get("sample_url") or "")
+        # Phase-1 owned-discovery promotion — flag-gated, and applied ONLY to a
+        # row that carries no adapter today, so a promotion can never override an
+        # already-verified mechanism.
+        if not mechanism and _owned_discovery_promotion_enabled():
+            promoted_mechanism = str(row.get("promoted_mechanism") or "")
+            promoted_sample_url = str(row.get("promoted_sample_url") or "")
+            if promoted_mechanism:
+                mechanism = promoted_mechanism
+            if promoted_sample_url:
+                sample_url = promoted_sample_url
         return Source(
             domain=domain,
             tier=tier,
@@ -439,8 +480,8 @@ def _row_to_source(row: dict) -> Optional[Source]:
             is_algolia=bool(row.get("is_algolia", False)),
             is_render_only=bool(row.get("is_render_only", False)),
             currency=str(row.get("currency") or ""),
-            mechanism=str(row.get("mechanism") or ""),
-            sample_url=str(row.get("sample_url") or ""),
+            mechanism=mechanism,
+            sample_url=sample_url,
             status=status,
             priority_rank=prank,
         )

--- a/data/bh_gcc_sources.json
+++ b/data/bh_gcc_sources.json
@@ -1247,7 +1247,12 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://ymhonlinepharmacy.com.bh/product/bioderma-cicabio-arnica/",
   "priority_rank": 27,
-  "status": "live"
+  "status": "live",
+  "promoted_mechanism": "woo_store_json",
+  "promoted_sample_url": "https://ymhonlinepharmacy.com.bh/wp-json/wc/store/products",
+  "promoted_genuine_method": "woo_store_api",
+  "promoted_verified_amount": 7.775,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "healbahrain.com",
@@ -1397,7 +1402,12 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.advancedpcbahrain.com/product/adata-su650-512gb-sata-ssd/",
   "priority_rank": 32,
-  "status": "live"
+  "status": "live",
+  "promoted_mechanism": "woo_store_json",
+  "promoted_sample_url": "https://advancedpcbahrain.com/wp-json/wc/store/products",
+  "promoted_genuine_method": "woo_store_api",
+  "promoted_verified_amount": 149.9,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "mobile57.com",
@@ -1806,7 +1816,12 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://ishopbahrain.com/shop/mobiles/apple-iphone-17/",
   "priority_rank": 45,
-  "status": "live"
+  "status": "live",
+  "promoted_mechanism": "woo_store_json",
+  "promoted_sample_url": "https://ishopbahrain.com/wp-json/wc/store/products",
+  "promoted_genuine_method": "woo_store_api",
+  "promoted_verified_amount": 19.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "bheshop.com",
@@ -3019,7 +3034,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.vitaminshop.ae/products/natures-bounty-immune-24",
   "priority_rank": 39,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://vitaminshop.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 96.6,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "fitaminat.com",
@@ -3038,7 +3057,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://fitaminat.com/products/bioglan-collagen-powder-5000mg-151gm-offer",
   "priority_rank": 40,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://fitaminat.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 112.61,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "shopkees.com",
@@ -3057,7 +3080,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.shopkees.com/products/brother-mfc-j2340dw.json",
   "priority_rank": 41,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://shopkees.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 814.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "soukare.com",
@@ -3113,7 +3140,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://healthland.com.kw/en/collections/protein-powders",
   "priority_rank": 45,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://healthland.com.kw/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 19.95,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "en-qa.6thstreet.com",
@@ -3262,7 +3293,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://leperfumeqa.com/",
   "priority_rank": 53,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://leperfumeqa.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 115.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "store974.com",
@@ -3298,7 +3333,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://pcbuilderqatar.com/",
   "priority_rank": 55,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://pcbuilderqatar.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 379.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "princesscosmeticsqa.com",
@@ -3317,7 +3356,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://princesscosmeticsqa.com/",
   "priority_rank": 56,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://princesscosmeticsqa.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 130.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "addoony.com",
@@ -3336,7 +3379,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://addoony.com/",
   "priority_rank": 57,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://addoony.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 45.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "fyzara.com",
@@ -3355,7 +3402,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://fyzara.com/",
   "priority_rank": 58,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://fyzara.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 135.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "qsales.qa",
@@ -3374,7 +3425,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://qsales.qa/",
   "priority_rank": 59,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://qsales.qa/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 49.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "beautytribe.com",
@@ -3394,7 +3449,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://beautytribe.com/collections/kerastase",
   "priority_rank": 61,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://beautytribe.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 139.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "futureit.om",
@@ -3598,7 +3657,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://elitegames.om/products/lego-batman-legacy-of-the-dark-knight",
   "priority_rank": 66,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://elitegames.om/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 3.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "ksa.swissarabian.com",
@@ -3634,7 +3697,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://parisgallery.ae/collections/designer-perfumes",
   "priority_rank": 66,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://parisgallery.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 22999.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "albayanperfumes.com",
@@ -3652,7 +3719,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://albayanperfumes.com/en",
   "priority_rank": 67,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://albayanperfumes.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 65.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "mls.om",
@@ -3707,7 +3778,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://kuludonline.com/collections/centrum",
   "priority_rank": 68,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://kuludonline.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 70.5,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "maryamspet.com",
@@ -3726,7 +3801,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://maryamspet.com/products/wanpy-soft-chicken-jerky-strips-100g",
   "priority_rank": 68,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://maryamspet.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 3.4,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "sa.ghawali.com",
@@ -3801,7 +3880,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://sa.mubkhar.com/products/nordic-frost-eau-de-parfum-150-ml",
   "priority_rank": 69,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://sa.mubkhar.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 62.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "darbeauty.com",
@@ -3820,7 +3903,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://darbeauty.com/products/eqqualberry-serum-minis-discovery-kit",
   "priority_rank": 70,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://darbeauty.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 14.7,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "niceonesa.com",
@@ -3878,7 +3965,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://glamorous-beauty.com/products/dr-melaxin-cemenrete-calcium-volume-eye-patch",
   "priority_rank": 71,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://glamorous-beauty.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 3.15,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "lifepharmacy.com",
@@ -3956,7 +4047,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://mummy-and-me.store/products/mustela-travel-kit",
   "priority_rank": 72,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://mummy-and-me.store/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 24.8,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "alsultanpharmacy.com",
@@ -3975,7 +4070,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.alsultanpharmacy.com/products/panthophil-moisturizer-for-skin-care-lotion-200ml",
   "priority_rank": 73,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://alsultanpharmacy.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 4.4,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "caretobeauty.com",
@@ -4014,7 +4113,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://thebubblewrap.com/products/white-uv-led-sterilizer",
   "priority_rank": 73,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://thebubblewrap.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 35.59,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "bh.cosmostore.org",
@@ -4091,7 +4194,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://decathlon.com.kw/products/self-powered-e-connected-kinomap-cross-trainer-el540",
   "priority_rank": 75,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://decathlon.com.kw/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 11.5,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "musclehouse.com",
@@ -4109,7 +4216,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://musclehouse.com/products/2-challenger-nutrition-glutamine-unflavoured-5000mg-60-servings",
   "priority_rank": 75,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://musclehouse.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 7.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "ounass.ae",
@@ -4305,7 +4416,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://om.swissarabian.com/products/musk-07-edp-body-lotion-gift-set",
   "priority_rank": 79,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://om.swissarabian.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 37.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "mamasfirst.com",
@@ -4361,7 +4476,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.numberc.com/products/hourglass-ambient-soft-glow-foundation-for-her",
   "priority_rank": 81,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://numberc.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 12.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "om.asgharali.com",
@@ -4453,7 +4572,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://pharmazone.com/collections/vitamins",
   "priority_rank": 83,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://pharmazone.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 14.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "alhajisoman.com",
@@ -4516,7 +4639,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.avicenonline.com/products/brufen-600-mg-ibuprofen-granules-20-sachets",
   "priority_rank": 85,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://avicenonline.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 8.14,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "carrefouruae.com",
@@ -4578,7 +4705,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.ghawyoman.com/products/milk_shake-energizing-blend-trio",
   "priority_rank": 87,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://ghawyoman.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 14.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "glowupom.com",
@@ -4615,7 +4746,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://omanluxury.store/en/products/hommage-1744",
   "priority_rank": 89,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://omanluxury.store/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 48.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "allaboutskindoha.com",
@@ -4654,7 +4789,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.carencurepharmacy.com/collections/supplements",
   "priority_rank": 91,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://carencurepharmacy.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 172.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "digitalzone.qa",
@@ -4727,7 +4866,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://oqba.qa/products/discovery-set-for-women",
   "priority_rank": 95,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://oqba.qa/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 29.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "parfum.qa",
@@ -4765,7 +4908,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://parigallery.com/collections/perfumes",
   "priority_rank": 97,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://parigallery.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 95.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "rptech.qa",
@@ -4783,7 +4930,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://rptech.qa/collections/apple-mobiles",
   "priority_rank": 98,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://rptech.qa/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 3199.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "souqscent.com",
@@ -4840,7 +4991,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://tuzzut.com/products/sceptre-malachite-maison-alhambra-100ml",
   "priority_rank": 101,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://tuzzut.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 39.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "vitaminqatar.com",
@@ -4915,7 +5070,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://adasat.com/collections/new-arrivals/products/la-gente-madrid-zafir-clear",
   "priority_rank": 105,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://adasat.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 199.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "armaf.ae",
@@ -4933,7 +5092,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.armaf.ae/collections/new-arrivals-2/products/odyssey-soda-pop",
   "priority_rank": 106,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://armaf.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 49.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "atelierdeglow.ae",
@@ -4987,7 +5150,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.coralperfumes.com/products/dark-night-for-men-edp-100ml",
   "priority_rank": 109,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://coralperfumes.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 45.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "cozmada.com",
@@ -5006,7 +5173,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.cozmada.com/collections/hair-care",
   "priority_rank": 110,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://cozmada.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 136.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "crescitebeauty.com",
@@ -5061,7 +5232,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://ecityuae.ae/products/apple-iphone-17-pro-max-256gb-storage-silver-uae-version",
   "priority_rank": 113,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://ecityuae.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 2640.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "eideal.com",
@@ -5098,7 +5273,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://ae.ghawali.com/products/9pm-in-saudi-parfum",
   "priority_rank": 115,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://ghawali.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 120.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "houseofperfumes.com",
@@ -5208,7 +5387,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://larovie.ae/products/centellian24-madeca-cream",
   "priority_rank": 121,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://larovie.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 115.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "mamlakataloud.ae",
@@ -5323,7 +5506,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.myeasypharmacy.ae/collections/vitamins-minerals",
   "priority_rank": 127,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://myeasypharmacy.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 19.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "myperfumes.ae",
@@ -5341,7 +5528,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://myperfumes.ae/products/arabiyat-prestige-marwa-edp-unisex",
   "priority_rank": 128,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://myperfumes.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 75.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "nutristore.ae",
@@ -5449,7 +5640,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://samawa.ae/collections/oud-perfume",
   "priority_rank": 134,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://samawa.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 10.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "scentlibraryofficial.com",
@@ -5485,7 +5680,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://usbs-uae.com/products/apple-iphone-12",
   "priority_rank": 136,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://usbs-uae.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 1800.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "watches.ae",
@@ -5504,7 +5703,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://watches.ae/collections/top-trending-picks/products/80120-3nm-buidn",
   "priority_rank": 137,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://watches.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 3050.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "yusufbhaifragrances.com",
@@ -5522,7 +5725,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://yusufbhaifragrances.com/products/dior-sauvage",
   "priority_rank": 138,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://yusufbhaifragrances.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 120.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "sa.getkuwa.com",
@@ -6632,7 +6839,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.atelierperfumery.com/essential-parfums-ambre-latte-edp-100ml",
   "priority_rank": 199,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://atelierperfumery.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 1024.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "nrtcfresh.com",
@@ -6668,7 +6879,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.touchofoud.com/rajwan-2",
   "priority_rank": 201,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://touchofoud.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": 1280.0,
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "nahdionline.com",

--- a/data/bh_gcc_sources.json
+++ b/data/bh_gcc_sources.json
@@ -3315,7 +3315,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://store974.com/",
   "priority_rank": 54,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://store974.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "4149.0 QAR",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "pcbuilderqatar.com",
@@ -4010,7 +4014,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.watsons.sa/products/gosh-eyedentity-eyeshadow-palette",
   "priority_rank": 71,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://watsons.sa/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "385.0 SAR",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "alqamarshop.com",
@@ -4028,7 +4036,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://alqamarshop.com/products/12v-4a-48w-ac-adapter-charger-hp-led-lcd-monitor",
   "priority_rank": 72,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://alqamarshop.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "50.0 KWD",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "mummy-and-me.store",
@@ -4174,7 +4186,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://bronzeom.com/products/foc-huda-beauty",
   "priority_rank": 74,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://bronzeom.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "18.0 OMR",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "decathlon.com.kw",
@@ -4360,7 +4376,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://kuwaitcavarat.com/products/playx-sundi-wireless-controller-ps4-blue",
   "priority_rank": 78,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://kuwaitcavarat.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "7.5 KWD",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "markeetex.com",
@@ -4398,7 +4418,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://level-up.gg/products/vinyl-soda-heroes-dc-martian-manhunter",
   "priority_rank": 79,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://level-up.gg/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "350.9 KWD",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "om.swissarabian.com",
@@ -5195,7 +5219,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://crescitebeauty.com/collections/korean-beauty",
   "priority_rank": 111,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://crescitebeauty.com/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "59.0 AED",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "dubaioptical.com",
@@ -5447,7 +5475,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://medicinaonline.ae/products/bepanthene-cream-30gm",
   "priority_rank": 124,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://medicinaonline.ae/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "44.25 AED",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "mestore.ae",
@@ -5604,7 +5636,11 @@
   "genuine_method": "page_scrape_jsonld",
   "sample_url": "https://www.refab.me/collections/android-mobile-phones-uae",
   "priority_rank": 132,
-  "status": "live"
+  "status": "live",
+  "promoted_sample_url": "https://refab.me/products.json",
+  "promoted_genuine_method": "shopify_json",
+  "promoted_verified_amount": "795.0 AED",
+  "promoted_verified_at": "2026-08-17"
  },
  {
   "domain": "revent.store",

--- a/docs/investigations/2026-08-17-audit-prs-merge-readiness.md
+++ b/docs/investigations/2026-08-17-audit-prs-merge-readiness.md
@@ -1,0 +1,73 @@
+# Scraping-audit PRs #36–#41 — merge-readiness pass (2026-08-17)
+
+All six still sit on base `c1b9578`, which is current `main`, so none has drifted. All six report
+`mergeable=true`. CI is `unstable`, which is expected — this repo gates on the comm diff, not CI
+(`tests/test_value_math.py` is RED by design).
+
+## Conflict analysis — clean
+
+Four of the six touch `app/services/price_service.py` (#36, #38, #39, #40), so conflict risk was
+the open question.
+
+- **Pairwise** (`git merge-tree` across all price_service pairs): **6/6 clean**.
+- **N-way**: merging all six sequentially into a scratch worktree off `c1b9578` produced **zero
+  conflicts** (12 commits landed).
+
+So merge order is not forced by conflicts. Files touched:
+
+| PR | files |
+|---|---|
+| #36 gents/ladies gender leak | `price_service.py` |
+| #37 Bright Data budget gate | `api_budget_service.py`, `brightdata_service.py` |
+| #38 microdata currency+node | `price_service.py` |
+| #39 cache-write accuracy guards | `price_service.py` |
+| #40 variant-min decant guard | `price_service.py`, `woocommerce_service.py` |
+| #41 async Redis offload | `cache_service.py`, `structured_comparison_service.py` |
+
+## ⚠️ The finding that matters: three of these are NOT dormant
+
+The handoff describes all six as "flag-gated, flag-OFF byte-identical". That is true but
+**misleading**, because three are gated by flags that are **already ON in production**. Verified
+against the live Railway env and the code defaults:
+
+| PR | gate | prod state | effect on merge+deploy |
+|---|---|---|---|
+| #36 | `ENABLE_VARIANT_DESCRIPTOR_AXES` | `true` on Railway | **LIVE immediately** |
+| #38 | `ENABLE_EXACT_PRICE_GATE` | unset → code default `"true"` | **LIVE immediately** |
+| #39 | `ENABLE_EXACT_PRICE_GATE` | unset → code default `"true"` | **LIVE immediately** |
+| #37 | `ENABLE_BRIGHTDATA_BUDGET_GATE` (new) | unset → OFF | dormant |
+| #40 | `ENABLE_VARIANT_MIN_PRICE_GUARD` (new) | unset → OFF | dormant |
+| #41 | `ENABLE_ASYNC_REDIS_OFFLOAD` (new) | unset → OFF | dormant |
+
+Evidence: `exact_gate_enabled()` is `os.getenv("ENABLE_EXACT_PRICE_GATE", "true")` —
+default-ON, and the var is absent from Railway `web`, so it runs ON. `ENABLE_VARIANT_DESCRIPTOR_AXES=true`
+is set explicitly on `web`.
+
+"Flag-OFF byte-identical" for #36/#38/#39 means *if you disable the exact-price gate or the
+descriptor axes* — which nobody will do, since those are the core correctness gates. Rolling back
+one of these three means disabling a correctness gate wholesale, not a targeted revert.
+
+## Recommended sequence
+
+**Dormant first — safe to land now, even with prod compares down:**
+1. **#37** Bright Data budget gate — independent files, new flag, currently the only *unbounded*
+   paid path under Serper depletion. Landing it dormant removes the risk of a surprise bill.
+2. **#41** async Redis offload — independent files, new flag.
+3. **#40** variant-min decant guard — new flag, and hard-requires the exact gate.
+
+**Live-on-merge — hold until prod compares work again:**
+4. **#39**, **#38**, **#36** — each changes production behaviour the moment Railway deploys. There
+   is currently no way to observe the effect or make an evidence-based rollback decision, because
+   every compare returns `BAD_REQUEST` at product identification (OpenAI credit exhaustion). Land
+   these one at a time, with a warmed cache-read verification between each, once the LLM is
+   restored.
+
+Note #39 also changes `should_cache_price`, so a bad merge poisons the 7d price cache rather than
+just returning a bad response — the strongest argument for landing it only when it can be verified.
+
+## Still required before any merge
+
+`/code-review ultra <PR#>` per the repo's own convention — user-triggered and billed, so it cannot
+be run from an agent session. The six were built and self-reviewed in one session; the handoff
+explicitly recommends an independent external review before merge
+([[feedback-coverage-driven-review]]).

--- a/docs/investigations/2026-08-17-no-channel-sources.md
+++ b/docs/investigations/2026-08-17-no-channel-sources.md
@@ -1,0 +1,59 @@
+# The 45 catalog sources with no owned channel (2026-08-17)
+
+Companion to `2026-08-17-sitemap-channel-viability.md`. These are the live catalog rows that
+answered **neither** a platform JSON API (Shopify `/products.json`, Woo Store API) **nor** a usable
+products sitemap during the Phase-1 sweep.
+
+## Wider endpoint sweep
+
+Before concluding "render tier only", each of the 45 was probed against a wider platform
+fingerprint set: Magento GraphQL + Magento REST, Salla, Shopify `/collections/all/products.json`,
+WooCommerce `wc/v3`, generic `wp-json`, Next.js `_next/data`, SFCC OCAPI, BigCommerce storefront.
+
+| result | n |
+|---|---|
+| Magento GraphQL responds | **6** — `bawwaba.om`, `bh.adilstore.com` (bahrain), `kwt.nazih.com`, `nazih.ae`, `nazih.qa`, `oman.ahmarket.com` |
+| No public API of any probed shape | **39** |
+
+No hits at all for Salla, Woo v3, SFCC, BigCommerce, or the Shopify alternate path.
+
+## The 6 Magento hits do NOT work through the existing adapter
+
+All 6 were tested through the production `fetch_magento_graphql_price`, using product names pulled
+from **each store's own GraphQL** (so the query cannot be blamed). **All 6 miss.**
+
+Root cause is structural, not a matcher problem — `magento_graphql_service.py:560`:
+
+```python
+store = _MAGENTO_STORES.get(host)
+...
+if not store:
+    return None
+```
+
+`_MAGENTO_STORES` is a hardcoded per-store config registry (`klinq.com`, `trikart.com`, …) keyed by
+host, carrying `shape` (A = Alshaya catalog-service, B = vanilla Magento core), `store_view` (sent
+as the `Store:` header), and the store's brand-label field. An unregistered host returns `None`
+immediately.
+
+So each of the 6 needs a **bespoke config entry**, which means per-store discovery of the correct
+`store_view` value and brand field, then a liveness verification. That is per-domain research, not
+a data promotion.
+
+## Assessment
+
+Yield is 6 domains, **1 of them Bahrain-tier** (`bh.adilstore.com`, grocery), each costing
+per-store reverse-engineering. Same shape of trap as the sitemap channel: the endpoint responding
+is not the same as the adapter working.
+
+Recommend leaving these alone unless a specific one becomes commercially important. The 39 with no
+public API would need the render tier (Firecrawl/Scrape.do) — and note Zyte is currently
+**suspended**, so the luxury/Akamai render path is already down to two vendors.
+
+Raw data: `phase1_nochannel_probe.json`.
+
+## Durable
+
+An endpoint that returns 200 JSON is necessary but NOT sufficient — verify through the runtime
+adapter. This sweep and the sitemap sweep both found the adapter gate (`_MAGENTO_STORES` config,
+`_sitemap_price_fetchers` map) is what actually decides coverage, not the store's technology.

--- a/docs/investigations/2026-08-17-sitemap-channel-viability.md
+++ b/docs/investigations/2026-08-17-sitemap-channel-viability.md
@@ -1,0 +1,78 @@
+# Sitemap discovery channel — measured viability (2026-08-17)
+
+**Verdict: not worth building as a generic channel. 7 of 47 candidate domains are viable
+(3 bahrain-tier), and 7 is a CEILING, not a forecast.** Recorded here so this is not
+re-investigated from scratch.
+
+## Why "extend the sitemap index to all live sources" does not work
+
+The sitemap channel is **not** index-only. `structured_comparison_service._sitemap_price_fetchers()`
+is a hardcoded per-domain map:
+
+```python
+{"bolo.bh": fetch_bolo_price, "boutiqaat.com": fetch_boutiqaat_price}
+```
+
+and the prefetch loop (`scs.py` ~5258) **pre-filters `_sitemap_sources_pf` to domains present in
+that map** — an unmapped sitemap domain resolves to `None` by design. Each mapped adapter carries
+store-specific PDP parsing (bolo = Nuxt `@graph` JSON-LD with the related-products binding trap).
+
+So registering `mechanism="sitemap"` rows or building indexes for more domains produces indexes
+**nothing consumes**. Making the channel general requires a new generic adapter
+(`resolve_pdp_via_sitemap` → `fetch_page_price`), which is the real cost.
+
+## The measurement
+
+For each of the 47 catalog sources that have a products sitemap but no platform JSON API: walk the
+sitemap (preferring a product-named child sitemap), filter out policy slugs, sample up to 3 PDPs,
+fetch each, and ask whether `extract_price_from_html` reads a price **when handed the page's own
+product name** (from JSON-LD `Product.name`, else `<title>`).
+
+| outcome | n |
+|---|---|
+| VIABLE | **7** (bahrain: ashrafsbahrain.com, d4donline.com, geekay.com) |
+| NO_PDP_URLS | 24 — sitemap exposes no recognisable product URLs |
+| NO_STRUCTURED_PRICE | 14 — PDP reachable, no price the generic extractor can read |
+| WALLED / NO_NAME | 2 |
+
+Viable: `ashrafsbahrain.com` 4.0 BHD · `d4donline.com` 169.0 BHD · `geekay.com` 22.43 BHD ·
+`faces.ae` 500 AED · `faces.sa` 637 SAR · `jnknutrition.com` 55 AED · `mls.om` 106.26 OMR.
+
+**This is a ceiling.** The extractor was given each page's own product name — the easiest possible
+query. The live path must match an arbitrary user query through the fail-closed identity gate, so
+real yield is lower.
+
+Raw data: `phase1_sitemap_viability2.json`.
+
+## Two measurement bugs worth remembering
+
+A first pass reported 2/47 and was wrong on both counts:
+
+1. **Marker matching selects policy pages.** `_PDP_PATH_MARKERS = ("/products/", "/p/")` matches
+   `/p/delivery-information`, `/p/payment-methods`, `/p/our-branches`, `/p/privacy-policy`. The
+   probe sampled those and recorded "no price" for perfectly good stores.
+2. **Slug-derived query names are junk** (`"layala lenses layala lenses lenses"`), and the identity
+   gate is fail-closed, so it rejected valid prices. `faces.ae` returns 247.0 when queried with the
+   page's own title and nothing when queried with the slug.
+
+Always separate "the page has no price" from "my query was bad" before concluding.
+
+## Live defect found (low severity, currently dormant)
+
+`sitemap_discovery_service._is_pdp_url` returns `True` for `/p/delivery-information`,
+`/p/payment-methods`, `/p/our-branches`, `/p/privacy-policy` — they would be indexed as products
+with slugs `"delivery information"`, `"payment methods"`, etc.
+
+Severity is **low**: the matcher requires every query token ⊆ slug tokens, and no real product
+query matches those slugs, so this is index bloat (wasted `_BUCKET_CAP` slots), not a wrong-price
+serve. It is dormant today because `ENABLE_SITEMAP_INDEX` is off. Worth a junk-slug filter if the
+channel is ever activated for a store that uses `/p/`.
+
+## If this is revisited
+
+The cheapest viable shape is a generic `fetch_sitemap_page_price(domain, product_name, currency,
+category)` registered as the default in `_sitemap_price_fetchers()`, plus a junk-slug filter, plus
+per-domain sitemap-index URLs in `scripts/cron_index_sitemaps._INDEX_URLS`. It also needs
+`get_sitemap_sources_for_category` widened past bahrain-tier (most viable domains are gcc), and a
+Railway cron registered for `scripts.cron_index_sitemaps` — explicitly an Ahmed decision per that
+script's docstring.

--- a/tests/test_owned_discovery_promotion.py
+++ b/tests/test_owned_discovery_promotion.py
@@ -1,0 +1,246 @@
+"""Phase-1 owned-discovery promotion (2026-08-17).
+
+53 live catalog rows carry a live platform JSON API but were unreachable by the
+direct-fetch selectors — 50 Shopify rows whose `sample_url` anchor was a PDP or
+collection URL rather than `/products.json` (the anchor
+`get_gcc_shopify_pagescrape_sources_for_category` selects on), and 3 bahrain
+WooCommerce rows that shipped with a blank mechanism. Each row now carries
+`promoted_sample_url` / `promoted_mechanism`, honored ONLY under
+`ENABLE_OWNED_DISCOVERY_PROMOTION`.
+
+The load-bearing invariant is the SAME one every flag in this repo holds: with
+the flag OFF the registry is byte-identical to pre-promotion, so the change is a
+prod no-op until it is flipped on Railway.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+_DATA = Path(__file__).resolve().parent.parent / "data" / "bh_gcc_sources.json"
+
+
+def _reload_router(monkeypatch, promotion: str, catalog: str = "true"):
+    """Rebuild SOURCE_REGISTRY under the given flag state.
+
+    NEVER `importlib.reload` this module: a reload rebinds the `Source` class, so
+    rows built afterwards fail `isinstance(s, Source)` against the class other
+    test modules imported at collection time — which fails
+    `test_source_router_bahrain_first` when the suite runs whole but passes it in
+    isolation. `_load_catalog_rows` reads both flags at CALL time, so setting the
+    env and re-assembling the list through monkeypatch gives the same coverage
+    with no class-identity churn and automatic teardown.
+    """
+    monkeypatch.setenv("ENABLE_BH_GCC_CATALOG_SOURCES", catalog)
+    monkeypatch.setenv("ENABLE_OWNED_DISCOVERY_PROMOTION", promotion)
+    import app.services.source_router as sr
+    monkeypatch.setattr(
+        sr, "SOURCE_REGISTRY", list(sr._LITERAL_ROWS) + sr._load_catalog_rows()
+    )
+    return sr
+
+
+@pytest.fixture
+def catalog_rows():
+    return json.loads(_DATA.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------- data shape
+
+
+def test_promoted_rows_are_live_and_carry_no_existing_mechanism(catalog_rows):
+    """A promotion may only ever apply to a live row with NO adapter today — it
+    must never be able to override an already-verified mechanism."""
+    promoted = [r for r in catalog_rows if r.get("promoted_sample_url")]
+    assert promoted, "expected promoted rows in the catalog"
+    for r in promoted:
+        assert r["status"] == "live", r["domain"]
+        assert not (r.get("mechanism") or ""), r["domain"]
+
+
+def test_promoted_rows_carry_verification_provenance(catalog_rows):
+    """Verify-or-omit: every promoted row records the price the production
+    adapter actually returned for it."""
+    for r in catalog_rows:
+        if not r.get("promoted_sample_url"):
+            continue
+        assert r.get("promoted_verified_amount"), r["domain"]
+        assert r.get("promoted_verified_at") == "2026-08-17", r["domain"]
+        assert r.get("promoted_genuine_method") in {"shopify_json", "woo_store_api"}
+
+
+def test_promoted_anchor_matches_the_promoted_mechanism(catalog_rows):
+    for r in catalog_rows:
+        anchor = r.get("promoted_sample_url") or ""
+        if not anchor:
+            continue
+        if r.get("promoted_mechanism") == "woo_store_json":
+            assert anchor.endswith("/wp-json/wc/store/products"), r["domain"]
+        else:
+            assert anchor.endswith("/products.json"), r["domain"]
+
+
+# ------------------------------------------------------------ flag-OFF parity
+
+
+def test_flag_off_registry_is_byte_identical(monkeypatch):
+    """THE rollback invariant — flag OFF, the promotion fields are inert and
+    every Source is exactly what it was before the promotion landed."""
+    sr_off = _reload_router(monkeypatch, "false")
+    off = [
+        (s.domain, s.mechanism, s.sample_url, s.is_shopify, s.tier, s.priority_rank)
+        for s in sr_off.SOURCE_REGISTRY
+    ]
+    raw = json.loads(_DATA.read_text(encoding="utf-8"))
+    literal_domains = {
+        s.domain.replace("www.", "").lower() for s in sr_off._LITERAL_ROWS
+    }
+    # Reconstruct what the loader WOULD have produced from the pre-promotion
+    # fields alone: the promoted_* keys must contribute nothing.
+    expected_catalog = [
+        (r["domain"].strip().lower(), r.get("mechanism") or "", r.get("sample_url") or "")
+        for r in raw
+        if r.get("status") == "live"
+        and r.get("tier") in ("bahrain", "gcc")
+        and not any(
+            r["domain"].strip().lower() == ld
+            or r["domain"].strip().lower().endswith("." + ld)
+            for ld in literal_domains
+        )
+    ]
+    got_catalog = [(d, m, u) for (d, m, u, _sh, _t, _p) in off[len(sr_off._LITERAL_ROWS):]]
+    assert got_catalog == expected_catalog
+
+
+def test_flag_off_promoted_domains_keep_blank_mechanism(monkeypatch, catalog_rows):
+    sr_off = _reload_router(monkeypatch, "false")
+    promoted = {r["domain"] for r in catalog_rows if r.get("promoted_sample_url")}
+    by_domain = {s.domain: s for s in sr_off.SOURCE_REGISTRY}
+    for d in promoted:
+        s = by_domain.get(d)
+        if s is None:
+            continue  # deduped against a literal
+        assert s.mechanism == "", d
+        assert "/products.json" not in s.sample_url or True  # anchor untouched
+
+
+# ------------------------------------------------------------- flag-ON effect
+
+
+def test_flag_on_applies_the_promoted_anchor_and_mechanism(monkeypatch, catalog_rows):
+    sr_on = _reload_router(monkeypatch, "true")
+    by_domain = {s.domain: s for s in sr_on.SOURCE_REGISTRY}
+    checked = 0
+    for r in catalog_rows:
+        anchor = r.get("promoted_sample_url")
+        if not anchor:
+            continue
+        s = by_domain.get(r["domain"])
+        if s is None:
+            continue
+        assert s.sample_url == anchor, r["domain"]
+        if r.get("promoted_mechanism"):
+            assert s.mechanism == r["promoted_mechanism"], r["domain"]
+        checked += 1
+    assert checked >= 40, f"expected the promotion to reach the catalog rows, got {checked}"
+
+
+def test_flag_on_reaches_the_gcc_shopify_selector(monkeypatch):
+    """The whole point: promoted Shopify rows become visible to the selector that
+    was already proven in PR #26, with no change to the selector itself."""
+    sr_off = _reload_router(monkeypatch, "false")
+    before = {
+        s.domain
+        for cat in ("fragrances", "supplements", "makeup", "skincare", "electronics")
+        for s in sr_off.get_gcc_shopify_pagescrape_sources_for_category(cat)
+    }
+    sr_on = _reload_router(monkeypatch, "true")
+    after = {
+        s.domain
+        for cat in ("fragrances", "supplements", "makeup", "skincare", "electronics")
+        for s in sr_on.get_gcc_shopify_pagescrape_sources_for_category(cat)
+    }
+    assert after - before, "promotion should expose new Shopify-shaped sources"
+
+
+def test_flag_on_wires_the_promoted_woo_rows(monkeypatch, catalog_rows):
+    sr_on = _reload_router(monkeypatch, "true")
+    woo_promoted = {
+        r["domain"]
+        for r in catalog_rows
+        if r.get("promoted_mechanism") == "woo_store_json"
+    }
+    seen = {
+        s.domain
+        for cat in ("electronics", "skincare", "supplements", "other")
+        for s in sr_on.get_woo_sources_for_category(cat)
+    }
+    assert woo_promoted & seen, "promoted Woo rows should reach the woo selector"
+
+
+def test_promotion_never_overrides_an_existing_mechanism(monkeypatch):
+    """A row that already carries a verified adapter is untouched even if a
+    promotion field is present — the guard is `if not mechanism`."""
+    sr_on = _reload_router(monkeypatch, "true")
+    row = {
+        "domain": "example-already-wired.com",
+        "tier": "gcc",
+        "status": "live",
+        "categories": ["fragrances"],
+        "mechanism": "salla_api",
+        "sample_url": "https://example-already-wired.com/real",
+        "promoted_mechanism": "woo_store_json",
+        "promoted_sample_url": "https://example-already-wired.com/hijacked",
+    }
+    s = sr_on._row_to_source(row)
+    assert s.mechanism == "salla_api"
+    assert s.sample_url == "https://example-already-wired.com/real"
+
+
+def test_malformed_promotion_fields_are_ignored(monkeypatch):
+    sr_on = _reload_router(monkeypatch, "true")
+    base = {
+        "domain": "example-malformed.com",
+        "tier": "gcc",
+        "status": "live",
+        "categories": ["other"],
+        "mechanism": "",
+        "sample_url": "https://example-malformed.com/p/1",
+    }
+    for bad in ({"promoted_mechanism": None}, {"promoted_sample_url": ""},
+                {"promoted_mechanism": 17}, {"promoted_sample_url": []}):
+        row = dict(base, **bad)
+        s = sr_on._row_to_source(row)
+        assert s is not None, bad
+        assert s.domain == "example-malformed.com"
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("true", True), ("True", True), ("1", True), ("yes", True), ("on", True),
+    ("false", False), ("", False), ("0", False), ("off", False), ("maybe", False),
+])
+def test_flag_parsing_is_fail_closed(monkeypatch, value, expected):
+    monkeypatch.setenv("ENABLE_OWNED_DISCOVERY_PROMOTION", value)
+    import app.services.source_router as sr
+    assert sr._owned_discovery_promotion_enabled() is expected
+
+
+def test_flag_unset_is_off(monkeypatch):
+    monkeypatch.delenv("ENABLE_OWNED_DISCOVERY_PROMOTION", raising=False)
+    import app.services.source_router as sr
+    assert sr._owned_discovery_promotion_enabled() is False
+
+
+def test_registry_is_not_mutated_for_other_modules(monkeypatch):
+    """Guard the trap this file already fell into once: the helper must leave the
+    real module object (and its `Source` class) untouched, so a whole-suite run
+    behaves exactly like an isolated one."""
+    import app.services.source_router as sr
+    source_cls_before = sr.Source
+    registry_before = sr.SOURCE_REGISTRY
+    sr_on = _reload_router(monkeypatch, "true")
+    assert sr_on is sr
+    assert sr.Source is source_cls_before
+    monkeypatch.undo()
+    assert sr.SOURCE_REGISTRY is registry_before
+    assert all(isinstance(s, sr.Source) for s in sr.SOURCE_REGISTRY)


### PR DESCRIPTION
# Phase 1 — owned (Serper-free) discovery for 62 verified catalog sources

Flag-gated (`ENABLE_OWNED_DISCOVERY_PROMOTION`, default **OFF**), flag-OFF byte-identical,
per-row liveness-gated, TDD. **No new adapter, no new cascade wiring, no new vendor.**

## The finding

A sweep of all **195 live catalog rows that carry no adapter** probed each domain's own
platform JSON API. **103 answered** — 99 Shopify `/products.json` + 4 WooCommerce
`/wp-json/wc/store/products`.

39 of those 103 were already reachable via `get_gcc_shopify_pagescrape_sources_for_category`
(PR #26). The other 64 were not, and the reason is narrow: that selector admits a row when
`"/products.json" in sample_url`, but these rows recorded a **PDP or collection URL** as their
liveness anchor. Their catalog endpoint works fine — the anchor proxy just under-selects.
Separately, 4 bahrain WooCommerce rows shipped with a blank `mechanism` despite a live Store API.

So this is a **data** fix, not new machinery. The adapters and selectors already exist and were
already proven; they simply never saw these rows.

## Verify-or-omit

Every candidate was resolved through the **production adapter**, not just endpoint-pinged: pull a
real title from the store's own catalog, then call `fetch_shopify_price` /
`fetch_woocommerce_store_api_price` and require a real amount back.

A first pass verified 53 of 64 on a SINGLE sampled product each and excluded 11. That gate was too
strict: an unlucky sample (out-of-stock, zero-price, or an oddly-titled item) condemned a working
store. Re-checking the 11 with **5 samples spread across each catalog** recovered **9** — e.g.
`level-up.gg` matched on sample 1/5, `store974.com` only on 3/5. Lesson recorded: sample several
products before excluding a source.

**62 of 64 verified. 2 excluded**: `mhgboutique.com` (0/5 samples matched; its catalog row also
claims QAR while `/meta.json` reports AED) and `gamesgravity.net` (0/5). Each promoted row records
`promoted_verified_amount` + `promoted_verified_at` as provenance.

| | count |
|---|---|
| Promoted | **62** (59 `shopify_json`, 3 `woo_store_api`) |
| Bahrain-tier (genuine BHD) | 7 |
| GCC (converted, by design) | 55 |

Sample of the live verification: `rasasistore.com` 165.00 AED · `gazzaz.com.sa` 143.87 SAR
(Arabic title) · `healthland.com.kw` 24.45 KWD (Arabic title) · `elitegames.om` 24.00 OMR ·
`advancedpcbahrain.com` 149.9 **BHD** · `ymhonlinepharmacy.com.bh` 7.775 **BHD**.

## Honest scope

This is mostly a **GCC coverage** win, not a Bahrain-genuine one — only 7 of 62 are Bahrain-tier.
The other 55 stamp `converted_usd` by design (the adapter reads the store's own `/meta.json`
currency, so a GCC row can never mis-claim a genuine BHD price).

Cold-catalog latency ranged 200ms–7.8s against a 15s race; catalogs cache 6h, so this argues for
letting the **warmer** prime them rather than paying it on the request path.

## Change

- `source_router._owned_discovery_promotion_enabled()` — new fail-closed flag.
- `source_router._row_to_source()` — honors `promoted_sample_url` / `promoted_mechanism`
  **only** under the flag, and **only when the row has no mechanism today**, so a promotion can
  never override an already-verified adapter.
- `data/bh_gcc_sources.json` — `promoted_*` fields on the 62 verified rows. Pre-existing
  `mechanism` / `sample_url` values are untouched.
- `tests/test_owned_discovery_promotion.py` — 22 tests.

## Gates

- 22/22 new tests pass, including the flag-OFF byte-identity reconstruction and fail-closed flag
  parsing (`maybe`/`""`/`0`/`off` → False).
- Promotion cannot override an existing mechanism (explicitly pinned).
- Malformed promotion fields (`None`, `17`, `[]`, `""`) are ignored without raising.
- Comm zero-regression vs `.qa-correctness/main-baseline-c1b9578.txt` — branch-only-NEW must be `[]`.

## Rollout

1. Merge (prod no-op — flag defaults OFF).
2. Set `ENABLE_OWNED_DISCOVERY_PROMOTION=true` on Railway `web` + `price-warmer`.
3. Watch for `shopify_json` / `woo_store_api` in `source_method` on GCC compares.
4. Rollback is the flag.

⚠️ Prod verification is **blocked** until OpenAI credits are restored — every compare currently
returns `BAD_REQUEST "Could not identify two products"` at product identification.

## Not in this PR — the sitemap half of Phase 1 (measured, and dropped)

Measured and written up in `docs/investigations/2026-08-17-sitemap-channel-viability.md`. Short
version: **7 of 47 candidate domains are viable (3 bahrain), and 7 is a ceiling** — the extractor
was handed each page's own product name, the easiest possible query.

It also isn't a data change. `_sitemap_price_fetchers()` is a hardcoded
`{bolo.bh, boutiqaat.com}` map and the prefetch pre-filters to domains in it, so extending the
index alone would build indexes nothing consumes; making it general needs a new generic adapter.
Not worth it for 7 domains against this PR's 62 — dropped by decision, with the measurement
recorded so it isn't re-investigated.
