### PR TITLE
feat(llm): OPENAI_BASE_URL support so the provider is config, not code

### DIFF
--- a/app/services/extraction_service.py
+++ b/app/services/extraction_service.py
@@ -14,6 +14,8 @@ from typing import Optional, List, Dict, Any
 from datetime import datetime
 import httpx
 from openai import AsyncOpenAI
+
+from app.services.llm_provider import provider_base_url
 from app.utils.prompt_sanitizer import sanitize_prompt_input, check_injection_patterns
 
 logger = logging.getLogger(__name__)
@@ -40,7 +42,11 @@ def get_client() -> AsyncOpenAI:
     if _client is None:
         api_key = os.getenv("OPENAI_API_KEY")
         logger.info(f"Initializing OpenAI client with key ending in: ...{api_key[-10:] if api_key else 'NONE'}")
-        _client = AsyncOpenAI(api_key=api_key, timeout=httpx.Timeout(120.0, connect=30.0))
+        _client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=provider_base_url(),
+            timeout=httpx.Timeout(120.0, connect=30.0),
+        )
     return _client
 
 # GCC Region mappings

--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -1,0 +1,67 @@
+"""OpenAI-compatible provider indirection (2026-08-17).
+
+Every LLM call in this codebase goes through ``openai.AsyncOpenAI``. That SDK
+talks to any OpenAI-COMPATIBLE endpoint when given a ``base_url``, so a single
+env var is enough to move the whole app off api.openai.com without touching a
+call site.
+
+WHY THIS EXISTS: on 2026-08-17 both OpenAI keys returned 429
+``credit_balance_exhausted`` and every ``/text/compare`` failed at product
+identification. The free-trial grant is a one-time expiring credit, not a daily
+allowance, so it does not come back on its own. This module makes the
+provider a CONFIG decision instead of a code change.
+
+DEFAULT IS A NO-OP: ``OPENAI_BASE_URL`` unset → ``None`` → the SDK uses its own
+default (https://api.openai.com/v1) and behaviour is byte-identical to before
+this module existed.
+
+SCOPE — read before relying on it:
+  * This covers providers that accept the SAME MODEL NAMES this codebase sends
+    (``gpt-4o-mini``, ``gpt-4o``, ``omni-moderation-latest``). That means Azure
+    OpenAI, and any gateway that maps model names server-side (LiteLLM proxy,
+    Cloudflare AI Gateway, an OpenRouter-style alias layer).
+  * A provider with its OWN model names (Groq's ``llama-3.3-70b``, DeepSeek's
+    ``deepseek-chat``) ALSO needs model-name mapping — the model strings are
+    still hardcoded at ~12 call sites. Point such a provider at a mapping
+    gateway, or add model indirection as a follow-up.
+  * ``client.moderations.create`` (content_safety L3) is OpenAI-specific. Most
+    compatible providers do not implement it. That path already FAILS OPEN on
+    exception, so a swap degrades to "no L3 moderation" rather than breaking —
+    a real safety reduction to weigh, not a crash.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV = "OPENAI_BASE_URL"
+
+
+def provider_base_url() -> Optional[str]:
+    """The configured OpenAI-compatible base URL, or ``None`` for stock OpenAI.
+
+    Read FRESH per call (no module-level cache) so a Railway change takes effect
+    on the next client construction without a code deploy. Whitespace-only or
+    unset → ``None``, which the SDK treats exactly as "no base_url given".
+    """
+    raw = (os.getenv(_ENV) or "").strip()
+    if not raw:
+        return None
+    if not raw.startswith(("http://", "https://")):
+        # Fail SAFE: a malformed value must not silently point the app at a
+        # bogus host — fall back to stock OpenAI and say so loudly.
+        logger.warning(
+            "[llm_provider] %s=%r is not an http(s) URL — ignoring, using stock OpenAI",
+            _ENV, raw,
+        )
+        return None
+    return raw
+
+
+def describe_provider() -> str:
+    """Short human label for logs/diagnostics. Never includes credentials."""
+    base = provider_base_url()
+    return f"openai-compatible@{base}" if base else "openai"

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -10,12 +10,14 @@ from typing import Any, Dict, List, Optional
 import httpx
 from openai import AsyncOpenAI
 
+from app.services.llm_provider import provider_base_url
+
 logger = logging.getLogger(__name__)
 
 # Initialize async client (reads OPENAI_API_KEY from env at request time).
 # Explicit timeout: 30s connect (Railway networking can be slow), 120s total.
 # This module-level singleton is kept for back-compat with existing call sites.
-client = AsyncOpenAI(timeout=httpx.Timeout(120.0, connect=30.0))
+client = AsyncOpenAI(base_url=provider_base_url(), timeout=httpx.Timeout(120.0, connect=30.0))
 
 # Memoised per-project clients for the dual-project routing in
 # select_client_for_user. Filled lazily by get_client(); resolved against
@@ -40,13 +42,16 @@ def get_client(use_shared_project: bool = True) -> AsyncOpenAI:
 
     if use_shared_project:
         # Shared (default). Existing OPENAI_API_KEY env handles this.
-        new_client = AsyncOpenAI(timeout=httpx.Timeout(120.0, connect=30.0))
+        new_client = AsyncOpenAI(
+            base_url=provider_base_url(), timeout=httpx.Timeout(120.0, connect=30.0)
+        )
     else:
         # Private. Fall back to default key if a separate one isn't set —
         # acceptable on day 1; the routing API stays correct.
         private_key = os.getenv("OPENAI_API_KEY_PRIVATE") or os.getenv("OPENAI_API_KEY")
         new_client = AsyncOpenAI(
             api_key=private_key,
+            base_url=provider_base_url(),
             timeout=httpx.Timeout(120.0, connect=30.0),
         )
     _client_cache[use_shared_project] = new_client

--- a/app/services/url_extraction_service.py
+++ b/app/services/url_extraction_service.py
@@ -15,6 +15,8 @@ from urllib.parse import urlparse, parse_qs
 from bs4 import BeautifulSoup
 from openai import AsyncOpenAI
 
+from app.services.llm_provider import provider_base_url
+
 from app.services.extraction_service import canonicalize_category
 
 logger = logging.getLogger(__name__)
@@ -25,7 +27,11 @@ _client = None
 def get_client() -> AsyncOpenAI:
     global _client
     if _client is None:
-        _client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"), timeout=httpx.Timeout(120.0, connect=30.0))
+        _client = AsyncOpenAI(
+            api_key=os.getenv("OPENAI_API_KEY"),
+            base_url=provider_base_url(),
+            timeout=httpx.Timeout(120.0, connect=30.0),
+        )
     return _client
 
 

--- a/tests/test_llm_provider_base_url.py
+++ b/tests/test_llm_provider_base_url.py
@@ -1,0 +1,124 @@
+"""OpenAI-compatible provider indirection (2026-08-17).
+
+The load-bearing invariant: with OPENAI_BASE_URL unset, every client is
+constructed exactly as before, so this is a prod no-op until it is configured.
+"""
+import importlib
+import os
+
+import pytest
+
+from app.services.llm_provider import provider_base_url, describe_provider
+
+
+# ------------------------------------------------------------ default no-op
+
+def test_unset_is_none(monkeypatch):
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    assert provider_base_url() is None
+    assert describe_provider() == "openai"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+def test_blank_is_none(monkeypatch, blank):
+    monkeypatch.setenv("OPENAI_BASE_URL", blank)
+    assert provider_base_url() is None
+
+
+# --------------------------------------------------------------- happy path
+
+@pytest.mark.parametrize("url", [
+    "https://api.groq.com/openai/v1",
+    "http://localhost:4000",
+    "https://gateway.ai.cloudflare.com/v1/acct/app/openai",
+])
+def test_valid_url_passes_through(monkeypatch, url):
+    monkeypatch.setenv("OPENAI_BASE_URL", url)
+    assert provider_base_url() == url
+    assert describe_provider() == f"openai-compatible@{url}"
+
+
+def test_surrounding_whitespace_is_stripped(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "  https://example.test/v1  ")
+    assert provider_base_url() == "https://example.test/v1"
+
+
+# ------------------------------------------------------------- fail-safe
+
+@pytest.mark.parametrize("bad", [
+    "api.groq.com/openai/v1",   # no scheme
+    "ftp://example.test",
+    "gopher://x",
+    "not a url at all",
+    "//protocol-relative",
+])
+def test_malformed_falls_back_to_stock_openai(monkeypatch, bad, caplog):
+    """A malformed value must NOT silently point the app at a bogus host."""
+    monkeypatch.setenv("OPENAI_BASE_URL", bad)
+    assert provider_base_url() is None
+    assert describe_provider() == "openai"
+
+
+def test_read_fresh_every_call(monkeypatch):
+    """No module-level cache — a Railway change takes effect on the next client
+    construction, with no redeploy."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    assert provider_base_url() is None
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://a.test/v1")
+    assert provider_base_url() == "https://a.test/v1"
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://b.test/v1")
+    assert provider_base_url() == "https://b.test/v1"
+
+
+def test_never_leaks_credentials_in_label(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gw.test/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value-do-not-log")
+    assert "sk-secret" not in describe_provider()
+
+
+# ------------------------------------------- the factories actually use it
+
+def test_all_client_factories_pass_base_url(monkeypatch):
+    """Every AsyncOpenAI construction in the app must honour the setting —
+    a factory that forgets it would silently stay on stock OpenAI."""
+    import app.services.openai_service as osvc
+    import app.services.extraction_service as esvc
+    import app.services.url_extraction_service as usvc
+
+    seen = []
+
+    class _Spy:
+        def __init__(self, *a, **kw):
+            seen.append(kw.get("base_url", "MISSING"))
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://spy.test/v1")
+    for mod in (osvc, esvc, usvc):
+        monkeypatch.setattr(mod, "AsyncOpenAI", _Spy)
+    monkeypatch.setattr(osvc, "_client_cache", {}, raising=False)
+    monkeypatch.setattr(esvc, "_client", None, raising=False)
+    monkeypatch.setattr(usvc, "_client", None, raising=False)
+
+    osvc.get_client(use_shared_project=True)
+    monkeypatch.setattr(osvc, "_client_cache", {}, raising=False)
+    osvc.get_client(use_shared_project=False)
+    esvc.get_client()
+    usvc.get_client()
+
+    assert len(seen) == 4, seen
+    assert all(v == "https://spy.test/v1" for v in seen), seen
+
+
+def test_factories_pass_none_when_unset(monkeypatch):
+    """Default path — base_url=None is exactly what the SDK gets today."""
+    import app.services.extraction_service as esvc
+    seen = []
+
+    class _Spy:
+        def __init__(self, *a, **kw):
+            seen.append(kw.get("base_url", "MISSING"))
+
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setattr(esvc, "AsyncOpenAI", _Spy)
+    monkeypatch.setattr(esvc, "_client", None, raising=False)
+    esvc.get_client()
+    assert seen == [None]


### PR DESCRIPTION
# `OPENAI_BASE_URL` — make the LLM provider a config decision, not a code change

Default is a **no-op**. Unset → `base_url=None` → the SDK uses its own default and behaviour is
byte-identical to today.

## Why

Both OpenAI keys return `429 credit_balance_exhausted`, so every `/text/compare` fails at product
identification with `BAD_REQUEST "Could not identify two products"`. Verified across the three
cheapest models on the **prod** key:

```
gpt-4o-mini:   429 credit_balance_exhausted
gpt-3.5-turbo: 429 credit_balance_exhausted
gpt-4.1-nano:  429 credit_balance_exhausted
```

The free-trial grant is a one-time expiring credit, not a daily allowance — it does not return on
its own. And there is nothing to fail over to today: local `.env` and both Railway services hold
exactly one LLM credential, and `openai` is the only LLM SDK in `requirements.txt`.

Every LLM call in this codebase goes through `openai.AsyncOpenAI`, which talks to any
OpenAI-compatible endpoint given a `base_url`. Threading that one setting through the four client
constructions means the provider can change without touching any of the ~15 call sites.

## Scope — narrow on purpose

- **Covered:** providers that accept the model names this codebase sends (`gpt-4o-mini`, `gpt-4o`,
  `omni-moderation-latest`) — Azure OpenAI, or a gateway that maps names server-side (LiteLLM
  proxy, Cloudflare AI Gateway).
- **Not covered:** a provider with its own model names (Groq `llama-3.3-70b`, DeepSeek
  `deepseek-chat`) *also* needs model-name mapping — those strings are still hardcoded at ~12 call
  sites. Point such a provider at a mapping gateway, or add model indirection as a follow-up.
- **Moderation:** `client.moderations.create` (content-safety L3) is OpenAI-specific and most
  compatible providers omit it. That path **already fails open**, so a swap degrades to *no L3
  moderation* rather than crashing. That is a real safety reduction to weigh, not a blocker.

## Fail-safe

A malformed value (no scheme, `ftp://`, junk) is **ignored with a WARNING** and falls back to stock
OpenAI — a typo cannot silently point the app at a bogus host. The value is read fresh per call, so
a Railway change applies on the next client construction with no redeploy.

## Change

| file | change |
|---|---|
| `app/services/llm_provider.py` | new — `provider_base_url()` + `describe_provider()` |
| `app/services/openai_service.py` | 3 `AsyncOpenAI(...)` constructions |
| `app/services/extraction_service.py` | 1 construction |
| `app/services/url_extraction_service.py` | 1 construction |

21 lines of production code across the three service files.

## Gates

- **18/18** tests in `tests/test_llm_provider_base_url.py`, including a spy proving **all four**
  factories pass the value through (a factory that forgot it would silently stay on stock OpenAI),
  and that unset yields exactly `base_url=None`.
- **Comm zero-regression** vs a fresh `origin/main` baseline at `efed37f`: **47 == 47**, with
  `branch-only-NEW == []` *and* `baseline-only == []` — identical failure sets, both directions.

## Rollout

Nothing to do to merge — it is inert. To use it: set `OPENAI_BASE_URL` (and a matching
`OPENAI_API_KEY`) on Railway `web` + `price-warmer`. Rollback is unsetting the variable.

Adding OpenAI credits remains the cheapest path at the documented ~$0.01/comparison. This exists so
that is a choice rather than the only option.
