### PR TITLE
fix(llm): make the OPENAI_BASE_URL guard actually fail safe

### DIFF
--- a/app/services/llm_provider.py
+++ b/app/services/llm_provider.py
@@ -39,29 +39,49 @@ logger = logging.getLogger(__name__)
 
 _ENV = "OPENAI_BASE_URL"
 
+# Stock OpenAI, spelled out. This MUST be returned explicitly rather than None —
+# see the note on provider_base_url().
+STOCK_OPENAI_BASE_URL = "https://api.openai.com/v1"
 
-def provider_base_url() -> Optional[str]:
-    """The configured OpenAI-compatible base URL, or ``None`` for stock OpenAI.
 
-    Read FRESH per call (no module-level cache) so a Railway change takes effect
-    on the next client construction without a code deploy. Whitespace-only or
-    unset → ``None``, which the SDK treats exactly as "no base_url given".
+def provider_base_url() -> str:
+    """The OpenAI-compatible base URL to build clients with. NEVER ``None``.
+
+    🔒 WHY NEVER None (regression 2026-08-17): openai-python resolves the value
+    ITSELF when handed ``None`` — ``AsyncOpenAI.__init__`` does
+
+        if base_url is None: base_url = os.environ.get("OPENAI_BASE_URL")
+        if base_url is None: base_url = "https://api.openai.com/v1"
+
+    so returning ``None`` for a MALFORMED setting handed the SDK the very value
+    the guard had just rejected, and the client was built against it. Returning
+    an EXPLICIT url is what makes the validation real.
+
+    (The corollary: the SDK already supported ``OPENAI_BASE_URL`` natively. What
+    this module adds is validation + a diagnostic label, NOT the capability.)
+
+    Read FRESH per call (no module cache) so a Railway change applies on the next
+    client construction with no redeploy.
     """
     raw = (os.getenv(_ENV) or "").strip()
     if not raw:
-        return None
+        return STOCK_OPENAI_BASE_URL
     if not raw.startswith(("http://", "https://")):
-        # Fail SAFE: a malformed value must not silently point the app at a
-        # bogus host — fall back to stock OpenAI and say so loudly.
+        # Fail SAFE: a typo must not point the app at a bogus host.
         logger.warning(
             "[llm_provider] %s=%r is not an http(s) URL — ignoring, using stock OpenAI",
             _ENV, raw,
         )
-        return None
+        return STOCK_OPENAI_BASE_URL
     return raw
+
+
+def is_custom_provider() -> bool:
+    """True iff a VALID non-stock endpoint is configured."""
+    return provider_base_url() != STOCK_OPENAI_BASE_URL
 
 
 def describe_provider() -> str:
     """Short human label for logs/diagnostics. Never includes credentials."""
     base = provider_base_url()
-    return f"openai-compatible@{base}" if base else "openai"
+    return f"openai-compatible@{base}" if is_custom_provider() else "openai"

--- a/tests/test_llm_provider_base_url.py
+++ b/tests/test_llm_provider_base_url.py
@@ -8,21 +8,28 @@ import os
 
 import pytest
 
-from app.services.llm_provider import provider_base_url, describe_provider
+from app.services.llm_provider import (
+    provider_base_url,
+    describe_provider,
+    is_custom_provider,
+    STOCK_OPENAI_BASE_URL,
+)
 
 
 # ------------------------------------------------------------ default no-op
 
-def test_unset_is_none(monkeypatch):
+def test_unset_is_stock_openai(monkeypatch):
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    assert provider_base_url() is None
+    assert provider_base_url() == STOCK_OPENAI_BASE_URL
+    assert is_custom_provider() is False
     assert describe_provider() == "openai"
 
 
 @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
-def test_blank_is_none(monkeypatch, blank):
+def test_blank_is_stock_openai(monkeypatch, blank):
     monkeypatch.setenv("OPENAI_BASE_URL", blank)
-    assert provider_base_url() is None
+    assert provider_base_url() == STOCK_OPENAI_BASE_URL
+    assert is_custom_provider() is False
 
 
 # --------------------------------------------------------------- happy path
@@ -55,7 +62,8 @@ def test_surrounding_whitespace_is_stripped(monkeypatch):
 def test_malformed_falls_back_to_stock_openai(monkeypatch, bad, caplog):
     """A malformed value must NOT silently point the app at a bogus host."""
     monkeypatch.setenv("OPENAI_BASE_URL", bad)
-    assert provider_base_url() is None
+    assert provider_base_url() == STOCK_OPENAI_BASE_URL
+    assert is_custom_provider() is False
     assert describe_provider() == "openai"
 
 
@@ -63,7 +71,7 @@ def test_read_fresh_every_call(monkeypatch):
     """No module-level cache — a Railway change takes effect on the next client
     construction, with no redeploy."""
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    assert provider_base_url() is None
+    assert provider_base_url() == STOCK_OPENAI_BASE_URL
     monkeypatch.setenv("OPENAI_BASE_URL", "https://a.test/v1")
     assert provider_base_url() == "https://a.test/v1"
     monkeypatch.setenv("OPENAI_BASE_URL", "https://b.test/v1")
@@ -108,8 +116,9 @@ def test_all_client_factories_pass_base_url(monkeypatch):
     assert all(v == "https://spy.test/v1" for v in seen), seen
 
 
-def test_factories_pass_none_when_unset(monkeypatch):
-    """Default path — base_url=None is exactly what the SDK gets today."""
+def test_factories_pass_explicit_stock_url_when_unset(monkeypatch):
+    """Default path — an EXPLICIT stock url, so a later malformed env value
+    can never be re-read by the SDK behind our back."""
     import app.services.extraction_service as esvc
     seen = []
 
@@ -121,4 +130,43 @@ def test_factories_pass_none_when_unset(monkeypatch):
     monkeypatch.setattr(esvc, "AsyncOpenAI", _Spy)
     monkeypatch.setattr(esvc, "_client", None, raising=False)
     esvc.get_client()
-    assert seen == [None]
+    # explicit stock url, NOT None — None would let the SDK re-read the env var
+    assert seen == [STOCK_OPENAI_BASE_URL]
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION (2026-08-17): the fail-safe did not actually fail safe.
+#
+# openai-python resolves base_url itself when it is passed None:
+#     if base_url is None: base_url = os.environ.get("OPENAI_BASE_URL")
+#     if base_url is None: base_url = "https://api.openai.com/v1"
+#
+# So returning None for a MALFORMED value handed the SDK the same bad env var,
+# and the client was built against it — the exact outcome the guard existed to
+# prevent. The guard must therefore return an EXPLICIT stock URL, never None.
+# ---------------------------------------------------------------------------
+
+STOCK = "https://api.openai.com/v1"
+
+
+@pytest.mark.parametrize("bad", ["not-a-url", "ftp://x", "//protocol-relative", "junk value"])
+def test_malformed_value_cannot_reach_the_sdk(monkeypatch, bad):
+    """The SDK must end up on stock OpenAI, not on the malformed value."""
+    from openai import AsyncOpenAI
+    monkeypatch.setenv("OPENAI_BASE_URL", bad)
+    client = AsyncOpenAI(api_key="test", base_url=provider_base_url())
+    assert str(client.base_url).rstrip("/") == STOCK, str(client.base_url)
+
+
+def test_unset_resolves_to_stock_openai_through_the_sdk(monkeypatch):
+    from openai import AsyncOpenAI
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    client = AsyncOpenAI(api_key="test", base_url=provider_base_url())
+    assert str(client.base_url).rstrip("/") == STOCK
+
+
+def test_valid_value_reaches_the_sdk(monkeypatch):
+    from openai import AsyncOpenAI
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.test/v1")
+    client = AsyncOpenAI(api_key="test", base_url=provider_base_url())
+    assert str(client.base_url).rstrip("/") == "https://gateway.test/v1"


### PR DESCRIPTION
# Make the `OPENAI_BASE_URL` guard actually fail safe

PR #43 (merged, `c630436`) shipped a validation guard that **did not guard**.

## The bug

`openai-python` resolves `base_url` itself when handed `None`:

```python
if base_url is None: base_url = os.environ.get("OPENAI_BASE_URL")
if base_url is None: base_url = "https://api.openai.com/v1"
```

So returning `None` for a **malformed** value handed the SDK the very env var the guard had just
rejected, and the client was built against it:

```
OPENAI_BASE_URL=not-a-url   ->   SDK base_url = not-a-url/
```

…while the logs said `ignoring, using stock OpenAI`. A typo would have pointed every LLM call at a
bogus host, with the logs actively reassuring you it hadn't. That is worse than having no guard.

## The fix

`provider_base_url()` now returns an **explicit** URL and never `None`, so the SDK cannot re-resolve
behind it. Adds `is_custom_provider()` and exports `STOCK_OPENAI_BASE_URL`.

Verified against the real SDK, not just the helper:

| `OPENAI_BASE_URL` | SDK `base_url` | label |
|---|---|---|
| unset | `https://api.openai.com/v1/` | `openai` |
| `https://gateway.test/v1` | `https://gateway.test/v1/` | `openai-compatible@…` |
| `not-a-url` | `https://api.openai.com/v1/` | `openai` |

## It also corrects #43's premise

The SDK **already supported** `OPENAI_BASE_URL` natively. #43 did not add the capability — it adds
validation and a diagnostic label. The module docstring now says that plainly instead of implying
otherwise.

## Gates

- **TDD**: the 4 regression tests reproduce the bug against #43's merged code (RED), then pass
  (GREEN).
- The earlier tests had encoded the *buggy* contract (`assert provider_base_url() is None`) and are
  corrected — that assertion is precisely what let the bug through.
- **24/24** tests pass.
- **Comm zero-regression** vs main@`c630436`: **47 == 47**, `branch-only-NEW == []` *and*
  `baseline-only == []`.

## Prod impact today: none

`OPENAI_BASE_URL` is unset on both Railway services, so the stock path was always taken and the bug
was never reachable. It needed fixing before that variable is ever set — which is the exact scenario
#43 exists to enable.
