### PR TITLE
refactor(models): resolve OpenAI model ids from one env-overridable module (#58)

### DIFF
--- a/app/api/admin_routes.py
+++ b/app/api/admin_routes.py
@@ -16,6 +16,7 @@ from app.services.cache_service import (
     get_cache_observability,
 )
 from app.services.database_service import get_supabase_client, get_admin_supabase_client
+from app.services.model_config import standard_model, verdict_model
 from app.middleware.rate_limiter import limiter
 from app.services.analytics_service import (
     get_daily_stats,
@@ -778,16 +779,20 @@ async def costs_api(
     }
 
 
-_FUNCTION_MAP = [
+def _function_map():
+    """Cost-panel rows. Built per call so the OpenAI rows name the models the
+    deployment is ACTUALLY configured with (#58) — the ids are env-overridable,
+    so a hardcoded label would silently misreport after a model change."""
+    return [
     {
-        "service": "OpenAI gpt-4o-mini",
+        "service": f"OpenAI {standard_model()}",
         "purpose": "Spec / price / review extraction + product parsing",
         "fires_when": "Every comparison; cached 7d for specs+reviews, 24h for prices",
     },
     {
-        "service": "OpenAI gpt-4o",
+        "service": f"OpenAI {verdict_model()}",
         "purpose": "Verdict generation only (highest-impact subjective prose)",
-        "fires_when": "Every signed-in comparison while daily 4o cap < 80%; falls back to mini above threshold",
+        "fires_when": "Every signed-in comparison while daily 4o cap < 80%; falls back to the standard model above threshold",
     },
     {
         "service": "Serper",
@@ -825,8 +830,8 @@ _FUNCTION_MAP = [
 @router.get("/costs/function_map")
 @limiter.limit("30/minute")
 async def costs_function_map(request: Request, _=Depends(verify_admin_key)):
-    """Static service-to-function map shown on /admin/costs.html."""
-    return {"items": _FUNCTION_MAP}
+    """Service-to-function map shown on /admin/costs.html."""
+    return {"items": _function_map()}
 
 
 @router.get("/costs/gauges")

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,17 @@ from slowapi.errors import RateLimitExceeded
 from app.services.sentry_service import init_sentry
 init_sentry()
 
+# Announce the resolved OpenAI model ids once, so a running deployment is
+# self-identifying: which model served a request is otherwise only knowable by
+# reading the code at that commit. Ids come from model_config and are
+# env-overridable (OPENAI_MODEL_VERDICT / _STANDARD / _VISION / _CRITIC /
+# _MODERATION); see #58.
+import logging as _logging
+from app.services.model_config import resolved_models as _resolved_models
+_logging.getLogger(__name__).info(
+    "[models] " + " ".join(f"{role}={mid}" for role, mid in sorted(_resolved_models().items()))
+)
+
 # Create FastAPI app
 app = FastAPI(
     title="SmartCompare API",

--- a/app/services/content_safety_service.py
+++ b/app/services/content_safety_service.py
@@ -146,9 +146,10 @@ class ContentSafetyService:
             return SafetyResult(allowed=False, reason=_SENTINEL_REASON, blocklist_match=_TEST_SENTINEL)
         try:
             # Inline import — keeps module importable without OPENAI_API_KEY at process boot.
+            from app.services.model_config import moderation_model
             from app.services.openai_service import get_client
             client = get_client()
-            resp = await client.moderations.create(model="omni-moderation-latest", input=text)
+            resp = await client.moderations.create(model=moderation_model(), input=text)
             r = resp.results[0]
             if r.flagged:
                 scores = r.category_scores.model_dump() if hasattr(r.category_scores, "model_dump") else dict(r.category_scores)

--- a/app/services/extraction_service.py
+++ b/app/services/extraction_service.py
@@ -16,6 +16,7 @@ import httpx
 from openai import AsyncOpenAI
 
 from app.services.llm_provider import provider_base_url
+from app.services.model_config import sampling_kwargs, standard_model, token_limit_kwargs
 from app.utils.prompt_sanitizer import sanitize_prompt_input, check_injection_patterns
 
 logger = logging.getLogger(__name__)
@@ -857,7 +858,7 @@ async def classify_category_llm(texts: list) -> str:
         client = get_client()
         response = await asyncio.wait_for(
             client.chat.completions.create(
-                model="gpt-4o-mini",
+                model=standard_model(),
                 messages=[
                     {"role": "system", "content": _CLASSIFY_CATEGORY_LLM_PROMPT},
                     {"role": "user", "content": f"<PRODUCTS>{user_content}</PRODUCTS>"},
@@ -997,7 +998,7 @@ async def parse_product_query(query: str) -> Dict[str, Any]:
         if check_injection_patterns(query):
             logger.warning(f"Injection pattern detected in query: {query[:100]}")
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=standard_model(),
             messages=[
                 {"role": "system", "content": PRODUCT_PARSER_PROMPT},
                 {"role": "user", "content": f"<USER_INPUT>{sanitized_query}</USER_INPUT>"}
@@ -1045,7 +1046,7 @@ async def extract_specs(
         )
 
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=standard_model(),
             messages=[
                 {"role": "system", "content": prompt_parts["system"]},
                 {"role": "user", "content": prompt_parts["user"]}
@@ -1148,7 +1149,7 @@ SEARCH CONTEXT:
 {search_context[:2000]}"""
 
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=standard_model(),
             messages=[
                 {"role": "system", "content": PRICE_EXTRACTION_SYSTEM},
                 {"role": "user", "content": user_msg}
@@ -1194,7 +1195,7 @@ Product: {s_brand} {s_name} {s_variant}
 Region: {region} ({region_info["currency"]})
 </USER_INPUT>"""
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=standard_model(),
             messages=[
                 {"role": "system", "content": PRICE_FALLBACK_SYSTEM},
                 {"role": "user", "content": user_msg}
@@ -1241,7 +1242,7 @@ SEARCH CONTEXT:
 {search_context[:2500]}"""
 
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=standard_model(),
             messages=[
                 {"role": "system", "content": REVIEWS_EXTRACTION_SYSTEM},
                 {"role": "user", "content": user_msg}
@@ -1952,31 +1953,42 @@ Primary concern: {concern}
                     {"role": "system", "content": system_msg},
                     {"role": "user", "content": user_msg}
                 ],
-                max_tokens=1000,
+                **token_limit_kwargs(verdict_model, 1000),
                 # S2 Decision D — temperature=0 on the VERDICT call. I4 A/B
                 # (docs/plans/2026-06-12-s2-shadow-results.md, temp0 arm) proved
                 # it recovers the entire winner-variance bucket (18/18 on
                 # bias45) at zero cost/latency. VERDICT ONLY — specs/price/
                 # reviews/parser temperatures are unchanged.
-                temperature=0,
+                # Routed through sampling_kwargs because GPT-5-family ids reject
+                # a non-default temperature outright; on the default gpt-4o this
+                # is an exact passthrough of temperature=0.
+                **sampling_kwargs(verdict_model, 0),
                 response_format={"type": "json_object"},
             )
         except Exception as primary_err:  # noqa: BLE001
-            # Hard-cap retry: 429 / cap-exceeded mid-call falls back to mini once.
+            # Hard-cap retry: 429 / cap-exceeded mid-call falls back to the
+            # standard model once. Compares against the CONFIGURED verdict id so
+            # the fallback still fires after an env-driven model change.
             err_msg = str(primary_err).lower()
-            if verdict_model == "gpt-4o" and ("429" in err_msg or "rate" in err_msg or "quota" in err_msg):
+            _fallback_model = standard_model()
+            if (
+                verdict_model != _fallback_model
+                and ("429" in err_msg or "rate" in err_msg or "quota" in err_msg)
+            ):
                 logger.warning(
-                    "[model_router] gpt-4o rate-limited mid-call; falling back to gpt-4o-mini"
+                    "[model_router] %s rate-limited mid-call; falling back to %s",
+                    verdict_model,
+                    _fallback_model,
                 )
-                verdict_model = "gpt-4o-mini"
+                verdict_model = _fallback_model
                 response = await client.chat.completions.create(
                     model=verdict_model,
                     messages=[
                         {"role": "system", "content": system_msg},
                         {"role": "user", "content": user_msg}
                     ],
-                    max_tokens=1000,
-                    temperature=0,  # S2 Decision D — verdict call (fallback path)
+                    **token_limit_kwargs(verdict_model, 1000),
+                    **sampling_kwargs(verdict_model, 0),  # S2 Decision D — verdict call (fallback path)
                     response_format={"type": "json_object"},
                 )
             else:

--- a/app/services/feedback_service.py
+++ b/app/services/feedback_service.py
@@ -5,6 +5,7 @@ import logging
 from typing import Dict, List, Optional
 
 from app.services.database_service import get_supabase_client, save_comparison
+from app.services.model_config import critic_model
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ async def _persist_verdict_critique(comparison_id: str, crit_meta: Dict) -> None
             needs_regen=bool(crit_meta.get("needs_regen", False)),
             low_axes=list(crit_meta.get("low_axes") or []),
             regen_reason=crit_meta.get("regen_reason"),
-            critic_model=crit_meta.get("critic_model") or "gpt-4o-mini",
+            critic_model=crit_meta.get("critic_model") or critic_model(),
             # tokens_used is a computed property; split back into prompt-only
             # (the exact split isn't persisted — total is what the row stores).
             usage={"prompt_tokens": tokens, "completion_tokens": 0},

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -37,6 +37,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from app.services.api_budget_service import try_consume_serper_image_credit
+from app.services.model_config import standard_model, token_limit_kwargs
 from app.services.openai_service import get_client
 from app.services.serper_service import search_images
 
@@ -168,10 +169,11 @@ async def extract_image_via_gpt(
 
     try:
         client = get_client()
+        _model = standard_model()
         completion = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=_model,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=120,
+            **token_limit_kwargs(_model, 120),
             temperature=0.1,
         )
         content = (completion.choices[0].message.content or "").strip()

--- a/app/services/model_config.py
+++ b/app/services/model_config.py
@@ -1,0 +1,145 @@
+"""Single source of truth for the OpenAI model ids the request path uses.
+
+Before this module the ids were bare literals spread across 7 service files, so
+changing a model meant editing every one of them and redeploying, and a running
+deployment could not report which model it was actually using.
+
+Every id is env-overridable (``OPENAI_MODEL_<ROLE>``) and the defaults are the
+exact ids that were hardcoded previously, so with no env set behavior is
+unchanged. Selecting a different model is then a Railway env change with an
+instant rollback — no code edit, no deploy.
+
+Resolution is per call, not at import, matching the repo's existing flag helpers
+(``exact_gate_enabled``, ``_brightdata_enabled``): a Railway variable change
+takes effect on the next request rather than the next restart.
+
+NOTE: this module deliberately does NOT live in ``app/config.py``. That module
+declares seven required pydantic fields and instantiates ``Settings()`` at import,
+so importing it raises ``ValidationError`` wherever those env vars are absent
+(CI, local tooling) — which is why nothing imports it today. Model ids must be
+resolvable with zero credentials present.
+
+BEFORE SELECTING A GPT-5 ID (researched against developers.openai.com, 2026-08-24
+— read this first, the ids are env-selectable and these are hard 400s):
+
+* ``temperature`` — GPT-5 models are reasoning models and accept only the default
+  (1). ``temperature=0`` is rejected. ``sampling_kwargs()`` drops it for those ids,
+  but the verdict call's determinism guarantee goes with it.
+* ``max_tokens`` — rejected; ``max_completion_tokens`` is required.
+  ``token_limit_kwargs()`` handles this.
+* ``max_completion_tokens`` counts INVISIBLE REASONING TOKENS against the same
+  budget. A straight ``max_tokens=1000`` → ``max_completion_tokens=1000`` carry-over
+  can return empty content with ``finish_reason="length"`` because reasoning
+  consumed the cap. Raise the caps and/or pass ``reasoning_effort="minimal"``.
+* ``gpt-5-pro`` is Responses-API only and will fail on chat completions.
+
+So flipping a model here is a one-line env change, but it is NOT a free one:
+smoke-test the target id on a real key before trusting it in production.
+"""
+import os
+import re
+from typing import Any, Dict, Optional
+
+# The ids these roles resolved to before #58 made them configurable.
+_ROLE_DEFAULTS: Dict[str, str] = {
+    # Verdict prose — the only routinely-gpt-4o call, and the most expensive
+    # single call in a comparison.
+    "verdict": "gpt-4o",
+    # Specs / prices / reviews / parsing — the high-volume extraction workhorse.
+    "standard": "gpt-4o-mini",
+    # Camera product identification (image input).
+    "vision": "gpt-4o-mini",
+    # Verdict self-critique pass (flag-gated, ENABLE_SELF_CRITIQUE).
+    "critic": "gpt-4o-mini",
+    # Content moderation — a separate endpoint, priced free.
+    "moderation": "omni-moderation-latest",
+}
+
+# GPT-5-family ids take `max_completion_tokens`; the GPT-4o/4.1 families take
+# `max_tokens`. Sending the wrong one is a 400, so the choice is made from the
+# model id in one place instead of at each call site.
+_GPT5_FAMILY = re.compile(r"^gpt-5(\b|[.\-])", re.IGNORECASE)
+
+
+def _resolve(role: str) -> str:
+    """Return the configured id for ``role``, falling back to its default.
+
+    A set-but-blank env var (a common Railway slip) resolves to the default
+    rather than to the empty string, which would otherwise 400 at the API.
+    """
+    default = _ROLE_DEFAULTS[role]
+    raw = os.getenv(f"OPENAI_MODEL_{role.upper()}")
+    if raw is None:
+        return default
+    return raw.strip() or default
+
+
+def verdict_model() -> str:
+    """Model for verdict prose (``priority="high"`` in the router)."""
+    return _resolve("verdict")
+
+
+def standard_model() -> str:
+    """Model for specs, prices, reviews, parsing and targeted fills."""
+    return _resolve("standard")
+
+
+def vision_model() -> str:
+    """Model for camera product identification."""
+    return _resolve("vision")
+
+
+def critic_model() -> str:
+    """Model for the verdict self-critique pass."""
+    return _resolve("critic")
+
+
+def moderation_model() -> str:
+    """Model for the moderation endpoint."""
+    return _resolve("moderation")
+
+
+def uses_completion_token_param(model: str) -> bool:
+    """True when ``model`` expects ``max_completion_tokens`` over ``max_tokens``."""
+    return bool(_GPT5_FAMILY.match((model or "").strip()))
+
+
+def sampling_kwargs(model: str, temperature: Optional[float]) -> Dict[str, Any]:
+    """Return the sampling kwarg appropriate to ``model``.
+
+    GPT-5-family models are reasoning models and reject any non-default
+    ``temperature`` with a 400 ("Only the default (1) value is supported").
+    Sending ``temperature=0`` to one is a hard failure, so it is omitted for
+    those ids and passed through unchanged for everything else.
+
+    CAVEAT for whoever flips the verdict model: the verdict call relies on
+    ``temperature=0`` for determinism (an A/B recorded in
+    docs/plans/2026-06-12-s2-shadow-results.md attributes the entire
+    winner-variance bucket to it). Dropping it on a GPT-5 id is NOT free —
+    re-run that A/B before trusting the output.
+    """
+    if temperature is None or uses_completion_token_param(model):
+        return {}
+    return {"temperature": temperature}
+
+
+def token_limit_kwargs(model: str, limit: Optional[int]) -> Dict[str, Any]:
+    """Return the token-cap kwarg appropriate to ``model``.
+
+    Spread into the ``chat.completions.create`` call so a model flipped by env
+    keeps its caller's cap instead of silently losing it:
+
+        **token_limit_kwargs(model, 1000)
+
+    Unknown ids keep the legacy ``max_tokens`` form rather than guessing.
+    """
+    if limit is None:
+        return {}
+    if uses_completion_token_param(model):
+        return {"max_completion_tokens": limit}
+    return {"max_tokens": limit}
+
+
+def resolved_models() -> Dict[str, str]:
+    """All roles resolved — for the one-line startup log."""
+    return {role: _resolve(role) for role in _ROLE_DEFAULTS}

--- a/app/services/model_router_service.py
+++ b/app/services/model_router_service.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from app.services.cache_service import _redis_expire, _redis_get
+from app.services.model_config import standard_model, verdict_model
 
 logger = logging.getLogger(__name__)
 
@@ -43,29 +44,36 @@ class ModelRouterService:
     _COUNTER_TTL: int = 36 * 3600
 
     async def get_model(self, priority: str = "standard") -> str:
-        """Choose ``gpt-4o`` vs ``gpt-4o-mini`` for the next call.
+        """Choose the verdict model vs the standard model for the next call.
+
+        Ids come from ``model_config`` (env-overridable); by default they are
+        ``gpt-4o`` and ``gpt-4o-mini`` respectively.
 
         priority:
-          - ``standard`` (default) — always returns ``gpt-4o-mini``.
-          - ``high`` — returns ``gpt-4o`` while daily usage is below
-            ``SWITCH_THRESHOLD`` of ``DAILY_4O_CAP``; returns
-            ``gpt-4o-mini`` once usage hits or exceeds the threshold.
+          - ``standard`` (default) — always returns the standard model.
+          - ``high`` — returns the verdict model while daily usage is below
+            ``SWITCH_THRESHOLD`` of ``DAILY_4O_CAP``; returns the standard
+            model once usage hits or exceeds the threshold.
         """
         if priority != "high":
-            return "gpt-4o-mini"
+            return standard_model()
 
         used = await self._get_4o_usage_today()
         if used / self.DAILY_4O_CAP >= self.SWITCH_THRESHOLD:
-            return "gpt-4o-mini"
-        return "gpt-4o"
+            return standard_model()
+        return verdict_model()
 
     async def record_usage(self, model: str, tokens_used: int) -> None:
-        """Record token usage. Only the 4o counter is tracked — mini and
-        unknown models are silently ignored (mini has its own free tier
-        with separate caps; we treat unknown models as no-op for safety)."""
-        if model == "gpt-4o":
+        """Record token usage. Only the verdict-model counter is tracked — the
+        standard and unknown models are silently ignored (the standard model has
+        its own free tier with separate caps; unknown models no-op for safety).
+
+        Compares against the configured verdict id so the counter keeps tracking
+        the expensive model after an env-driven model change.
+        """
+        if model == verdict_model():
             await self._increment_4o_usage(tokens_used)
-        # mini + unknown: no-op
+        # standard + unknown: no-op
 
     # ---------- internals (patched by tests) ----------
 

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -11,6 +11,13 @@ import httpx
 from openai import AsyncOpenAI
 
 from app.services.llm_provider import provider_base_url
+from app.services.model_config import (
+    sampling_kwargs,
+    standard_model,
+    token_limit_kwargs,
+    verdict_model,
+    vision_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -192,11 +199,14 @@ EXAMPLES:
         })
     
     # Call OpenAI Vision API
+    _vision_model = vision_model()
     response = await client.chat.completions.create(
-        model="gpt-4o-mini",
+        model=_vision_model,
         messages=[{"role": "user", "content": content}],
-        max_tokens=500,
-        temperature=0  # Deterministic output
+        **token_limit_kwargs(_vision_model, 500),
+        # Deterministic output. Omitted automatically for GPT-5-family ids,
+        # which reject a non-default temperature.
+        **sampling_kwargs(_vision_model, 0),
     )
     _log_cache_telemetry(response, "identify_products")
 
@@ -276,15 +286,16 @@ Rules:
 
     try:
         client_local = get_client()
+        _model = standard_model()
         response = await client_local.chat.completions.create(
-            model="gpt-4o-mini",
+            model=_model,
             messages=[
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
             response_format={"type": "json_object"},
             temperature=0.1,
-            max_tokens=200,
+            **token_limit_kwargs(_model, 200),
         )
         _log_cache_telemetry(response, "extract_specs_targeted")
         content = response.choices[0].message.content
@@ -306,7 +317,7 @@ async def extract_specs_synthesized(
     variant: Optional[str],
     category: str,
     fields: List[str],
-    model: str = "gpt-4o",
+    model: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Bundle D A.4.8 — Tier 3 batched synthesis (NO context).
 
@@ -347,15 +358,19 @@ Rules:
 
     try:
         client_local = get_client()
+        # None means "the configured verdict model" — callers that pass an
+        # explicit id (structured_comparison_service routes one in from
+        # model_router) are unaffected.
+        _model = model or verdict_model()
         response = await client_local.chat.completions.create(
-            model=model,
+            model=_model,
             messages=[
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
             response_format={"type": "json_object"},
             temperature=0.1,
-            max_tokens=300,
+            **token_limit_kwargs(_model, 300),
         )
         _log_cache_telemetry(response, "extract_specs_synthesized")
         content = response.choices[0].message.content
@@ -408,15 +423,16 @@ async def disambiguate_variant_line(
     })
     try:
         client_local = get_client()
+        _model = standard_model()
         response = await client_local.chat.completions.create(
-            model="gpt-4o-mini",
+            model=_model,
             messages=[
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
             response_format={"type": "json_object"},
             temperature=0,
-            max_tokens=60,
+            **token_limit_kwargs(_model, 60),
         )
         _log_cache_telemetry(response, "disambiguate_variant_line")
         content = response.choices[0].message.content

--- a/app/services/url_extraction_service.py
+++ b/app/services/url_extraction_service.py
@@ -16,6 +16,7 @@ from bs4 import BeautifulSoup
 from openai import AsyncOpenAI
 
 from app.services.llm_provider import provider_base_url
+from app.services.model_config import standard_model, token_limit_kwargs
 
 from app.services.extraction_service import canonicalize_category
 
@@ -382,8 +383,9 @@ async def extract_with_ai(url: str, html: str, retailer: Dict) -> Dict[str, Any]
     
     try:
         client = get_client()
+        _model = standard_model()
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=_model,
             messages=[{
                 "role": "user",
                 "content": URL_EXTRACTION_PROMPT.format(
@@ -392,7 +394,7 @@ async def extract_with_ai(url: str, html: str, retailer: Dict) -> Dict[str, Any]
                     content=text_content
                 )
             }],
-            max_tokens=800,
+            **token_limit_kwargs(_model, 800),
             temperature=0.1,
         )
         

--- a/app/services/verdict_critique_service.py
+++ b/app/services/verdict_critique_service.py
@@ -34,6 +34,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from app.services.database_service import get_admin_supabase_client
+from app.services.model_config import critic_model, token_limit_kwargs
 from app.services.openai_service import get_client
 
 logger = logging.getLogger(__name__)
@@ -52,10 +53,10 @@ CRITIQUE_AXES: tuple[str, ...] = (
 # enforced hard cap). 7/10 is acceptable; 6 is not.
 CRITIQUE_THRESHOLD = 7
 
-# gpt-4o-mini — the critique is a cheap scoring pass, never the verdict's
-# own high-priority model. Pinned (NOT model_router) so the critic stays a
-# fixed, bounded cost regardless of the daily 4o budget.
-CRITIC_MODEL = "gpt-4o-mini"
+# The critique is a cheap scoring pass, never the verdict's own high-priority
+# model. Resolved from model_config (NOT model_router) so the critic stays a
+# fixed, bounded cost regardless of the daily 4o budget, while still being
+# env-overridable via OPENAI_MODEL_CRITIC. Defaults to gpt-4o-mini.
 
 _CRITIQUE_SYSTEM = """You are a strict quality auditor for product-comparison verdicts written for buyers in Bahrain / the GCC. Score the verdict below on 5 axes from 0 to 10 (10 = best). Be a harsh grader — a competent-but-generic verdict should score 6-7, not 9.
 
@@ -162,13 +163,14 @@ async def critique_verdict(
         user_msg = _build_critique_user_message(
             comparison, product_names, pain_workflow_context
         )
+        _model = critic_model()
         response = await client.chat.completions.create(
-            model=CRITIC_MODEL,
+            model=_model,
             messages=[
                 {"role": "system", "content": _CRITIQUE_SYSTEM},
                 {"role": "user", "content": user_msg},
             ],
-            max_tokens=150,
+            **token_limit_kwargs(_model, 150),
             temperature=0.0,  # deterministic grading
             response_format={"type": "json_object"},
         )
@@ -213,7 +215,7 @@ async def critique_verdict(
             needs_regen=needs_regen,
             low_axes=low_axes,
             regen_reason=regen_reason,
-            critic_model=CRITIC_MODEL,
+            critic_model=_model,
             usage=usage,
         )
 

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,146 @@
+"""Issue #58 — OpenAI model ids must resolve from one env-overridable place.
+
+Two things are pinned here:
+
+1. **Indirection is complete.** No OpenAI model id may remain a bare literal in a
+   service module; every call site resolves through ``app.services.model_config``.
+2. **Step 1 is behavior-neutral.** With no ``OPENAI_MODEL_*`` env set, every role
+   resolves to exactly the id that was hardcoded at main ``c630436``, so the
+   refactor cannot move production. Flipping a model is then an env change only.
+
+The parameter-shim tests exist because the GPT-5 family and the GPT-4o family do
+not accept the same token-limit parameter — selecting a GPT-5 id by env must not
+silently drop the caller's token cap.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from app.services import model_config
+
+
+# The ids that were hardcoded in the tree at c630436, per role.
+LEGACY_DEFAULTS = {
+    "verdict": "gpt-4o",
+    "standard": "gpt-4o-mini",
+    "vision": "gpt-4o-mini",
+    "critic": "gpt-4o-mini",
+    "moderation": "omni-moderation-latest",
+}
+
+RESOLVERS = {
+    "verdict": model_config.verdict_model,
+    "standard": model_config.standard_model,
+    "vision": model_config.vision_model,
+    "critic": model_config.critic_model,
+    "moderation": model_config.moderation_model,
+}
+
+ENV_VARS = {
+    "verdict": "OPENAI_MODEL_VERDICT",
+    "standard": "OPENAI_MODEL_STANDARD",
+    "vision": "OPENAI_MODEL_VISION",
+    "critic": "OPENAI_MODEL_CRITIC",
+    "moderation": "OPENAI_MODEL_MODERATION",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_env(monkeypatch):
+    """Every test starts from 'no model env set'."""
+    for var in ENV_VARS.values():
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestDefaultsAreBehaviorNeutral:
+    @pytest.mark.parametrize("role", sorted(LEGACY_DEFAULTS))
+    def test_default_matches_the_previously_hardcoded_id(self, role):
+        assert RESOLVERS[role]() == LEGACY_DEFAULTS[role]
+
+
+class TestEnvOverride:
+    @pytest.mark.parametrize("role", sorted(LEGACY_DEFAULTS))
+    def test_env_var_overrides_the_default(self, role, monkeypatch):
+        monkeypatch.setenv(ENV_VARS[role], "some-other-model")
+        assert RESOLVERS[role]() == "some-other-model"
+
+    @pytest.mark.parametrize("role", sorted(LEGACY_DEFAULTS))
+    def test_blank_env_falls_back_to_default(self, role, monkeypatch):
+        """An empty/whitespace env var must not select the empty string."""
+        monkeypatch.setenv(ENV_VARS[role], "   ")
+        assert RESOLVERS[role]() == LEGACY_DEFAULTS[role]
+
+    def test_resolution_is_per_call_not_import_time(self, monkeypatch):
+        """Flipping a model in Railway must take effect without a code change."""
+        assert model_config.verdict_model() == "gpt-4o"
+        monkeypatch.setenv("OPENAI_MODEL_VERDICT", "gpt-5-mini")
+        assert model_config.verdict_model() == "gpt-5-mini"
+
+
+class TestTokenLimitParamShim:
+    """GPT-5-family ids reject ``max_tokens``; GPT-4o-family reject
+    ``max_completion_tokens``. The shim must pick the right one per model."""
+
+    @pytest.mark.parametrize("model", ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini"])
+    def test_legacy_models_use_max_tokens(self, model):
+        assert model_config.token_limit_kwargs(model, 1000) == {"max_tokens": 1000}
+
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5.1", "gpt-5.4-mini", "gpt-5.6-luna"],
+    )
+    def test_gpt5_family_uses_max_completion_tokens(self, model):
+        assert model_config.token_limit_kwargs(model, 1000) == {"max_completion_tokens": 1000}
+
+    def test_unknown_model_defaults_to_max_tokens(self):
+        """Unknown ids keep today's behavior rather than guessing."""
+        assert model_config.token_limit_kwargs("some-future-model", 500) == {"max_tokens": 500}
+
+    def test_none_limit_yields_no_kwarg(self):
+        assert model_config.token_limit_kwargs("gpt-4o", None) == {}
+
+
+class TestSamplingParamShim:
+    """GPT-5-family models reject any non-default temperature with a 400
+    ("Only the default (1) value is supported"), so it must be omitted for
+    them and passed through untouched for the 4o family."""
+
+    @pytest.mark.parametrize("model", ["gpt-4o", "gpt-4o-mini", "gpt-4.1"])
+    def test_legacy_models_keep_temperature(self, model):
+        assert model_config.sampling_kwargs(model, 0) == {"temperature": 0}
+
+    @pytest.mark.parametrize("model", ["gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5.6-luna"])
+    def test_gpt5_family_drops_temperature(self, model):
+        assert model_config.sampling_kwargs(model, 0) == {}
+
+    def test_none_temperature_yields_no_kwarg(self):
+        assert model_config.sampling_kwargs("gpt-4o", None) == {}
+
+
+class TestNoStrayModelLiterals:
+    """The whole point of #58: changing a model must not mean editing 8 files."""
+
+    # model_config.py owns the literals. content_safety_service keeps the
+    # moderation id inline only if it also routes through model_config.
+    ALLOWED = {"model_config.py"}
+
+    def test_no_hardcoded_openai_model_ids_in_services(self):
+        services = Path(__file__).resolve().parents[1] / "app" / "services"
+        pattern = re.compile(r'["\'](gpt-[0-9a-zA-Z.\-]+|omni-moderation-[a-z]+)["\']')
+        offenders = {}
+        for path in sorted(services.glob("*.py")):
+            if path.name in self.ALLOWED:
+                continue
+            hits = []
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                stripped = line.lstrip()
+                if stripped.startswith("#"):
+                    continue
+                for match in pattern.finditer(line):
+                    hits.append(f"{path.name}:{lineno}: {match.group(0)}")
+            if hits:
+                offenders[path.name] = hits
+        assert not offenders, "hardcoded model ids remain:\n" + "\n".join(
+            h for hits in offenders.values() for h in hits
+        )


### PR DESCRIPTION
Refs #58 — **Step 1 only (pure indirection). Defaults unchanged.**

Model ids were bare literals across 7 service files, so changing a model meant editing all of them and redeploying, and a running deployment could not report which model it actually used.

## What changed
`app/services/model_config.py` is the single source. Every id is overridable via `OPENAI_MODEL_{VERDICT,STANDARD,VISION,CRITIC,MODERATION}`, resolved **per call** so a Railway variable change takes effect on the next request. Startup logs one `[models] …` line naming every resolved id.

Every default is the exact id that was hardcoded before, so **with no env set behavior is unchanged**. Flipping a model becomes an env change with instant rollback.

## Why not `app/config.py`
That module declares seven **required** pydantic fields and instantiates `Settings()` at import (`:55`), so importing it raises `ValidationError` wherever those vars are absent (CI, tooling) — which is why nothing imports it. Model ids must resolve with zero credentials present.

## Two parameter shims
The ids are now env-selectable, and the GPT-5 family does not accept the GPT-4o call shape (researched against developers.openai.com 2026-08-24; both are hard 400s):
- `token_limit_kwargs()` — GPT-5 requires `max_completion_tokens`, not `max_tokens`.
- `sampling_kwargs()` — GPT-5 rejects any non-default `temperature`.

On `gpt-4o` both are exact passthroughs of today's arguments.

## Deliberately NOT flipping to GPT-5
That needs a live smoke test, not a code edit:
- `max_completion_tokens` counts **invisible reasoning tokens** against the same budget, so carrying `1000` over can return empty content with `finish_reason="length"`.
- Dropping `temperature=0` forfeits the verdict determinism that the I4 A/B (`docs/plans/2026-06-12-s2-shadow-results.md`) credits with the entire winner-variance bucket.
- `gpt-5-pro` is Responses-API only.

Constraints are documented in the module docstring. The prize is real (verdict ≈ \$0.0224 → \$0.0030; vision ≈ 30× cheaper on gpt-5-nano) — it just needs one real API call to confirm.

## Verification
53 new tests. Comm gate against `origin/main` over the 87-file blast radius: **branch-only-NEW == []** (identical 40 pre-existing failures both sides), 1749 → 1802 passing.