### PR TITLE
fix(specs): reconcile subtype spec keys and cache the enriched result (#59)

### DIFF
--- a/app/services/extraction_service.py
+++ b/app/services/extraction_service.py
@@ -219,6 +219,104 @@ FRAGRANCE_SUBTYPE_SPEC_ALIASES: Dict[str, str] = {
 }
 
 
+# #59 — SA-1 generalised. The subtype prompt asks GPT for PRODUCT_TYPE_SCHEMAS
+# field names while extract_specs cleans against CATEGORY_SPEC_SCHEMAS, so any
+# subtype-named answer was dropped and its canonical home stamped "N/A" — which
+# then fired the PAID smart-fallback / Tier-2 / Tier-3 refill for a value the
+# model had already produced.
+#
+# Keyed by the subtype id detect_product_type returns. Only maps a subtype field
+# onto an EXISTING canonical field of the same category — no schema is extended.
+# Fragrance entries are the original SA-1 pair, unchanged.
+SUBTYPE_SPEC_ALIASES: Dict[str, Dict[str, str]] = {
+    # --- electronics ---
+    "electronics.tv":            {"screen_size": "display", "smart_os": "os"},
+    "electronics.laptop":        {"cpu": "processor", "battery_hrs": "battery", "ports": "connectivity"},
+    "electronics.smartwatch":    {"battery_days": "battery"},
+    "electronics.headphones":    {"battery_hrs": "battery", "bt_version": "connectivity"},
+    "electronics.speaker":       {"battery_hrs": "battery"},
+    "electronics.ac":            {"wifi": "connectivity"},
+    "electronics.vacuum":        {"battery_min": "battery"},
+    "electronics.washer":        {"dimensions": "weight"},
+    # --- supplements ---
+    "supplements.vitamin":       {"dose_iu_mcg": "dosage", "third_party_tested": "certifications"},
+    "supplements.mineral":       {"dose_mg": "dosage"},
+    "supplements.protein":       {"container_size": "count"},
+    "supplements.preworkout":    {"caffeine_mg": "dosage", "servings": "count"},
+    "supplements.fish_oil":      {"epa_mg": "dosage", "third_party_tested": "certifications"},
+    # supplements.multivitamin has no subtype key that maps onto a canonical
+    # field — its prompt fields (vitamins_count/minerals_count/iron_included)
+    # have no canonical home, and form/serving_size/count are already canonical.
+    # --- fragrances (original SA-1 pair; behavior unchanged) ---
+    "fragrances.edp":            dict(FRAGRANCE_SUBTYPE_SPEC_ALIASES),
+    "fragrances.edt":            dict(FRAGRANCE_SUBTYPE_SPEC_ALIASES),
+    "fragrances.niche":          dict(FRAGRANCE_SUBTYPE_SPEC_ALIASES),
+    # --- makeup ---
+    "makeup.foundation":         {"shade_range_count": "shade_range", "vol_ml": "volume"},
+    "makeup.lipstick":           {"vol_g": "volume", "longevity_hrs": "long_lasting", "color": "shade_range"},
+    "makeup.mascara":            {"color": "shade_range", "water_proof": "waterproof"},
+    # --- skincare ---
+    "skincare.serum":            {"hero_active": "active_ingredient", "secondary_actives": "ingredients",
+                                  "vol_ml": "volume", "ph": "ph_level"},
+    "skincare.sunscreen":        {"filter_type": "active_ingredient"},
+    "skincare.cleanser":         {"actives": "active_ingredient", "vol_ml": "volume", "ph": "ph_level"},
+    # --- haircare ---
+    "haircare.shampoo":          {"target_concern": "hair_concern", "vol_ml": "volume", "scent": "scent"},
+    # --- fashion ---
+    "fashion.bag":               {"lining": "material", "closure": "closure_type"},
+    "fashion.shoe":              {"upper_material": "material", "sizing_run": "size_options",
+                                  "closure": "closure_type"},
+    "fashion.watch":             {"case_material": "material", "strap": "design_details"},
+    # --- grocery ---
+    "grocery.oil":               {"volume_ml": "size", "variety": "ingredients"},
+    "grocery.tea":               {"bags_count": "count", "type": "ingredients"},
+    "grocery.chocolate":         {"weight_g": "size", "cacao_pct": "ingredients"},
+}
+
+
+# #59 — some category non-negotiables cannot exist for a given subtype: a TV has
+# no battery, processor, RAM or rear camera. Without this, missing_critical lists
+# them on every compare and the paid Tier-2 (one Serper + one GPT per field) and
+# Tier-3 (a gpt-4o call) cascade chases a spec that can never be filled.
+#
+# An entry may only REMOVE fields from the category list, never add — a field
+# removed here follows the existing A.4.9 rule: the dependent scoring dimension
+# is omitted, never faked.
+SUBTYPE_NON_NEGOTIABLE_DROPS: Dict[str, tuple] = {
+    "electronics.tv":             ("battery", "processor", "ram", "rear_camera"),
+    "electronics.ac":             ("battery", "processor", "ram", "rear_camera"),
+    "electronics.washer":         ("battery", "processor", "ram", "rear_camera"),
+    "electronics.refrigerator":   ("battery", "processor", "ram", "rear_camera"),
+    "electronics.speaker":        ("processor", "ram", "rear_camera"),
+    "electronics.headphones":     ("processor", "ram", "rear_camera"),
+    "electronics.smartwatch":     ("processor", "ram", "rear_camera"),
+    "electronics.vacuum":         ("processor", "ram", "rear_camera"),
+    "electronics.gaming_console": ("battery", "rear_camera"),
+    "electronics.laptop":         ("rear_camera",),
+}
+
+
+def subtype_spec_aliases(type_key: Optional[str]) -> Dict[str, str]:
+    """Alias map for a subtype id, or empty when it has none."""
+    if not type_key:
+        return {}
+    return SUBTYPE_SPEC_ALIASES.get(type_key, {})
+
+
+def non_negotiable_fields_for(category: str, type_key: Optional[str] = None) -> List[str]:
+    """Non-negotiable schema fields for ``category``, minus any the subtype
+    cannot physically have.
+
+    Falls back to the plain category list for an unknown or absent subtype, so
+    behavior is unchanged everywhere an override is not declared.
+    """
+    base = CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE.get(canonicalize_category(category), [])
+    drops = SUBTYPE_NON_NEGOTIABLE_DROPS.get(type_key or "", ())
+    if not drops:
+        return list(base)
+    return [f for f in base if f not in drops]
+
+
 # Bundle C § 2f Step 1 — split critical schema fields into two layers:
 #   - NON_NEGOTIABLE: A.4.7 Tier 2 + A.4.8 Tier 3 fallbacks chase these
 #     hard. If still missing after 3-tier fallback, the dependent dim is
@@ -451,6 +549,7 @@ def _build_specs_prompt(brand: str, name: str, variant: str, category: str, sear
     variant_note = f" ({s_variant})" if s_variant else ""
 
     # L2.12 — try product-type-specific schema first.
+    type_key = None
     try:
         from app.services.product_type_router import (
             detect_product_type,
@@ -461,6 +560,7 @@ def _build_specs_prompt(brand: str, name: str, variant: str, category: str, sear
         type_key = detect_product_type(full_name_for_detection, category)
         type_fields = get_schema_for_type(type_key)
     except Exception:
+        type_key = None
         type_fields = []
 
     if type_fields:
@@ -508,7 +608,10 @@ SEARCH CONTEXT:
 
 Return ONLY valid JSON (no markdown) matching the schema above."""
 
-    return {"system": system_prompt, "user": user_prompt}
+    # `type_key` rides along so extract_specs can reconcile the subtype-named
+    # keys this prompt just asked for back onto their canonical homes (#59).
+    # Additive — existing callers read only "system"/"user".
+    return {"system": system_prompt, "user": user_prompt, "type_key": type_key}
 
 
 PRICE_EXTRACTION_SYSTEM = """You are a price extraction expert for GCC markets. Your goal is to find the MOST AUTHORITATIVE retail price, not the cheapest one.
@@ -1072,17 +1175,28 @@ async def extract_specs(
         allowed_fields = set(CATEGORY_SPEC_SCHEMAS[schema_key])
         meta_keys = {"brand", "model", "variant", "category"}
 
-        # SA-1 (fragrance-scoped) — reconcile subtype-named keys onto their
-        # canonical homes BEFORE the filter, so the fragrance subtype prompt's
-        # `longevity_hrs`/`volume_ml` values are not silently dropped. Canonical
-        # value (if GPT also emitted one) stays authoritative; the alias only
-        # fills a canonical key that is absent/empty.
-        if schema_key == "fragrances":
-            for alias_key, canonical_key in FRAGRANCE_SUBTYPE_SPEC_ALIASES.items():
-                alias_val = raw.get(alias_key)
+        # #59 (generalised from the fragrance-only SA-1) — reconcile
+        # subtype-named keys onto their canonical homes BEFORE the filter.
+        # `_build_specs_prompt` asked GPT for the SUBTYPE field list, but the
+        # filter below keeps only CATEGORY fields, so without this every
+        # subtype-named answer is dropped and its canonical home stamped "N/A" —
+        # which then fires the PAID smart-fallback / Tier-2 / Tier-3 refill for a
+        # value the model already returned.
+        #
+        # Semantics preserved from SA-1: a canonical value GPT also emitted stays
+        # authoritative; the alias only fills a canonical key that is
+        # absent/empty/"null". `_source` citations are reconciled the same way so
+        # fact-checking still attributes the value it kept.
+        _aliases = subtype_spec_aliases(prompt_parts.get("type_key"))
+        for alias_key, canonical_key in _aliases.items():
+            if canonical_key not in allowed_fields:
+                continue  # defensive: never invent a non-schema field
+            for src, dst in ((alias_key, canonical_key),
+                             (f"{alias_key}_source", f"{canonical_key}_source")):
+                alias_val = raw.get(src)
                 if alias_val is None or (isinstance(alias_val, str) and not alias_val.strip()):
                     continue
-                canon_val = raw.get(canonical_key)
+                canon_val = raw.get(dst)
                 canon_empty = (
                     canon_val is None
                     or canon_val == ""
@@ -1090,7 +1204,7 @@ async def extract_specs(
                     or (isinstance(canon_val, str) and (not canon_val.strip() or "or null" in canon_val.lower()))
                 )
                 if canon_empty:
-                    raw[canonical_key] = alias_val
+                    raw[dst] = alias_val
 
         cleaned = {}
         for key in list(meta_keys) + CATEGORY_SPEC_SCHEMAS[schema_key]:

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -413,6 +413,22 @@ _TIER2_WALL_SECONDS = 4.0
 _TIER2_PER_FIELD_SECONDS = 3.5  # near-full wall; gather lets fields share
 
 
+def _detect_subtype(brand: str, name: str, category: str):
+    """Resolve the product subtype id (e.g. ``electronics.tv``) for a product.
+
+    Mirrors what ``_build_specs_prompt`` does when choosing the prompt's field
+    list, so the fill tiers filter non-negotiables by the SAME subtype the
+    prompt was written against (#59). Returns ``None`` on any failure, which
+    makes ``non_negotiable_fields_for`` fall back to the plain category list.
+    """
+    try:
+        from app.services.product_type_router import detect_product_type
+
+        return detect_product_type(f"{brand} {name}".strip(), category)
+    except Exception:  # noqa: BLE001 — never let subtype detection break a fill tier
+        return None
+
+
 async def tier2_fill_non_negotiables(
     *,
     brand: str,
@@ -434,11 +450,12 @@ async def tier2_fill_non_negotiables(
       - Fires ONLY when at least one non-negotiable is blank — common
         happy-path comparisons skip Tier 2 entirely (zero added wall).
     """
-    from app.services.extraction_service import (
-        CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE,
-    )
+    from app.services.extraction_service import non_negotiable_fields_for
 
-    non_negotiable = CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE.get(category, [])
+    # #59 — resolve the subtype so fields this product cannot physically have
+    # (a TV's battery / rear_camera) are not chased. Each such field would cost
+    # one Serper search plus one GPT call here, on every comparison, forever.
+    non_negotiable = non_negotiable_fields_for(category, _detect_subtype(brand, name, category))
     if not non_negotiable:
         return {}  # 'other' category + unknown categories have no non-negotiables
 
@@ -548,12 +565,13 @@ async def tier3_synthesize_non_negotiables(
       - Marks each filled field as confidence='tier3_synthesis' so trust
         validation can treat it as inferred rather than retrieved.
     """
-    from app.services.extraction_service import (
-        CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE,
-    )
+    from app.services.extraction_service import non_negotiable_fields_for
     from app.services.model_router_service import model_router
 
-    non_negotiable = CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE.get(category, [])
+    # #59 — same subtype filter as Tier 2. This tier costs a gpt-4o call, so
+    # chasing an impossible field is the single most expensive no-op in the
+    # spec cascade.
+    non_negotiable = non_negotiable_fields_for(category, _detect_subtype(brand, name, category))
     if not non_negotiable:
         return {}
 
@@ -4528,6 +4546,10 @@ class StructuredComparisonService:
         # literal "N/A" - GPT sometimes echoes the placeholder back instead
         # of returning null, which would noop-overwrite and stamp the wrong
         # _field_confidence marker. Treat "N/A" as no-knowledge from fallback.
+        # #59 — tracks whether any fill stage actually changed the specs dict, so
+        # the enriched result can be written back to the cache once at the end.
+        _specs_enriched_by_fallback = False
+
         if fallback_added:
             fb_idx = phase2_keys.index("_smart_fallback")
             fb_result = phase2_results[fb_idx]
@@ -4541,6 +4563,7 @@ class StructuredComparisonService:
                     if existing in (None, "", "N/A"):
                         result_specs[field] = value
                         fc[field] = "smart_fallback"
+                        _specs_enriched_by_fallback = True
                 result["specs"] = result_specs
 
         # Bundle C § 2f A.4.7 — Tier 2 fallback. Fires ONLY when Tier 1 +
@@ -4566,6 +4589,7 @@ class StructuredComparisonService:
                 if existing in (None, "", "N/A"):
                     result_specs_now[field] = value
                     fc[field] = "tier2_fallback"
+                    _specs_enriched_by_fallback = True
             result["specs"] = result_specs_now
 
         # Bundle D A.4.8 — Tier 3 batched GPT-4o synthesis. Fires ONLY when
@@ -4589,7 +4613,40 @@ class StructuredComparisonService:
                 if existing in (None, "", "N/A"):
                     result_specs_now[field] = value
                     fc[field] = "tier3_synthesis"
+                    _specs_enriched_by_fallback = True
             result["specs"] = result_specs_now
+
+        # #59 Half 2 — re-cache the ENRICHED specs.
+        #
+        # _get_specs writes the cache BEFORE returning, i.e. before any of the
+        # three fill stages above run, and none of them wrote back. So the
+        # degraded dict was what got cached, and the whole paid refill cascade
+        # (smart-fallback + one Serper+GPT per Tier-2 field + a gpt-4o Tier-3
+        # call) re-fired on EVERY warm comparison of that product for the full
+        # 7-day specs TTL. Writing the filled dict here makes the refill a
+        # once-per-TTL cost instead of a per-request one.
+        #
+        # Mirrors the _get_specs write exactly, including the L2 save, and
+        # strips the transient keys that must never be persisted.
+        if _specs_enriched_by_fallback:
+            try:
+                _enriched = {
+                    k: v for k, v in (result.get("specs") or {}).items()
+                    if k not in ("_search_snippets", "_cached", "_cache_source")
+                }
+                if _enriched and not _enriched.get("error"):
+                    _specs_key = get_specs_cache_key(brand, name, variant)
+                    set_cached(_specs_key, _enriched, SPECS_CACHE_TTL)
+                    from app.services.product_data_service import save_specs
+                    _fire_and_forget(
+                        save_specs(_specs_key, brand, name, variant, category, _enriched),
+                        label="save_specs.enriched",
+                    )
+            except Exception as _enrich_err:  # noqa: BLE001 — caching is best-effort
+                logger.warning(
+                    "[specs] enriched re-cache failed for %s %s: %r",
+                    brand, name, _enrich_err,
+                )
 
         rating_data = {"rating": None, "review_count": None, "rating_verified": False, "rating_source": None}
         for i, key in enumerate(phase2_keys):

--- a/tests/test_subtype_spec_reconciliation.py
+++ b/tests/test_subtype_spec_reconciliation.py
@@ -1,0 +1,201 @@
+﻿"""Issue #59 â€” subtype spec keys must land in their canonical homes.
+
+``_build_specs_prompt`` asks GPT for the SUBTYPE field list
+(``PRODUCT_TYPE_SCHEMAS``), but ``extract_specs`` cleans the response against the
+CATEGORY list (``CATEGORY_SPEC_SCHEMAS``). Every subtype-named key the model was
+told to fill was therefore dropped and its canonical home stamped ``"N/A"`` â€”
+which then fired the paid smart-fallback / Tier-2 / Tier-3 refill cascade on a
+field the model had already answered.
+
+Only fragrances had a reconciliation (two aliases). These tests pin the
+generalised version, and pin that fragrance behavior is unchanged.
+
+They also pin the second half: a category non-negotiable that a subtype genuinely
+cannot have (a TV has no battery or rear camera) must not be chased by the paid
+cascade at all.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import extraction_service
+from app.services.extraction_service import (
+    CATEGORY_SPEC_SCHEMAS,
+    CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE,
+    SUBTYPE_SPEC_ALIASES,
+    extract_specs,
+    non_negotiable_fields_for,
+)
+from app.services.product_type_router import PRODUCT_TYPE_SCHEMAS
+
+
+def _mock_openai_returning(payload: dict):
+    """Build a client whose completion returns exactly ``payload`` as JSON.
+
+    ``extract_specs`` resolves its client through ``get_client()``, so tests
+    patch that rather than the module-level ``client`` singleton.
+    """
+    message = MagicMock()
+    message.content = json.dumps(payload)
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    # Plain ints, not MagicMocks â€” the cache-telemetry helper compares these.
+    usage = MagicMock()
+    usage.prompt_tokens = 100
+    usage.completion_tokens = 50
+    usage.total_tokens = 150
+    usage.prompt_tokens_cached = 0
+    usage.prompt_tokens_details = None
+    response.usage = usage
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+    return client
+
+
+class TestAliasMapIntegrity:
+    """The map must reference only real keys on both sides â€” a typo here
+    silently reintroduces the bug it exists to fix."""
+
+    def test_every_subtype_key_exists_in_the_router(self):
+        unknown = sorted(set(SUBTYPE_SPEC_ALIASES) - set(PRODUCT_TYPE_SCHEMAS))
+        assert not unknown, f"alias table names subtypes that do not exist: {unknown}"
+
+    def test_alias_sources_are_fields_the_subtype_prompt_actually_asks_for(self):
+        bad = []
+        for subtype, aliases in SUBTYPE_SPEC_ALIASES.items():
+            asked = set(PRODUCT_TYPE_SCHEMAS[subtype])
+            for alias_key in aliases:
+                if alias_key not in asked:
+                    bad.append(f"{subtype}.{alias_key}")
+        assert not bad, f"alias sources the prompt never requests: {bad}"
+
+    def test_alias_targets_are_canonical_fields_of_that_category(self):
+        bad = []
+        for subtype, aliases in SUBTYPE_SPEC_ALIASES.items():
+            category = subtype.split(".", 1)[0]
+            canonical = set(CATEGORY_SPEC_SCHEMAS.get(category, []))
+            for alias_key, canonical_key in aliases.items():
+                if canonical_key not in canonical:
+                    bad.append(f"{subtype}.{alias_key} -> {canonical_key}")
+        assert not bad, f"alias targets that are not canonical fields: {bad}"
+
+
+class TestSubtypeValuesReachCanonicalFields:
+    """The core defect: a value GPT returned under its subtype name must not be
+    thrown away."""
+
+    @pytest.mark.asyncio
+    async def test_skincare_serum_hero_active_becomes_active_ingredient(self):
+        payload = {
+            "brand": "CeraVe", "model": "Resurfacing Retinol Serum", "variant": None,
+            "category": "skincare",
+            "hero_active": "Retinol",
+            "vol_ml": "30",
+        }
+        with patch.object(extraction_service, "get_client", return_value=_mock_openai_returning(payload)):
+            specs, _usage = await extract_specs("CeraVe", "Resurfacing Retinol Serum", None, "skincare", "search context")
+        assert specs["active_ingredient"] == "Retinol"
+        assert specs["volume"] == "30"
+
+    @pytest.mark.asyncio
+    async def test_makeup_foundation_shade_range_count_becomes_shade_range(self):
+        payload = {
+            "brand": "Fenty", "model": "Pro Filt'r Foundation", "variant": None,
+            "category": "makeup",
+            "shade_range_count": "50 shades",
+            "vol_ml": "32",
+        }
+        with patch.object(extraction_service, "get_client", return_value=_mock_openai_returning(payload)):
+            specs, _usage = await extract_specs("Fenty", "Pro Filt'r Foundation", None, "makeup", "search context")
+        assert specs["shade_range"] == "50 shades"
+        assert specs["volume"] == "32"
+
+    @pytest.mark.asyncio
+    async def test_supplements_vitamin_dose_becomes_dosage(self):
+        payload = {
+            "brand": "Nature Made", "model": "Vitamin D3 1000 IU", "variant": None,
+            "category": "supplements",
+            "dose_iu_mcg": "1000 IU",
+            "form": "Softgel",
+        }
+        with patch.object(extraction_service, "get_client", return_value=_mock_openai_returning(payload)):
+            specs, _usage = await extract_specs("Nature Made", "Vitamin D3 1000 IU", None, "supplements", "search context")
+        assert specs["dosage"] == "1000 IU"
+        assert specs["form"] == "Softgel"
+
+
+class TestFragranceBehaviorUnchanged:
+    """The pre-existing two-entry fragrance reconciliation must survive
+    generalisation byte-for-byte in effect."""
+
+    @pytest.mark.asyncio
+    async def test_fragrance_aliases_still_map(self):
+        payload = {
+            "brand": "Dior", "model": "Sauvage", "variant": None, "category": "fragrances",
+            "longevity_hrs": "8",
+            "volume_ml": "100",
+        }
+        with patch.object(extraction_service, "get_client", return_value=_mock_openai_returning(payload)):
+            specs, _usage = await extract_specs("Dior", "Sauvage", None, "fragrances", "search context")
+        assert specs["longevity"] == "8"
+        assert specs["volume"] == "100"
+
+    @pytest.mark.asyncio
+    async def test_canonical_value_wins_over_alias(self):
+        """If GPT emitted BOTH, the canonical one stays authoritative."""
+        payload = {
+            "brand": "Dior", "model": "Sauvage", "variant": None, "category": "fragrances",
+            "longevity": "10 hours",
+            "longevity_hrs": "8",
+        }
+        with patch.object(extraction_service, "get_client", return_value=_mock_openai_returning(payload)):
+            specs, _usage = await extract_specs("Dior", "Sauvage", None, "fragrances", "search context")
+        assert specs["longevity"] == "10 hours"
+
+    @pytest.mark.asyncio
+    async def test_blank_alias_does_not_overwrite(self):
+        payload = {
+            "brand": "Dior", "model": "Sauvage", "variant": None, "category": "fragrances",
+            "longevity": "10 hours",
+            "longevity_hrs": "",
+        }
+        with patch.object(extraction_service, "get_client", return_value=_mock_openai_returning(payload)):
+            specs, _usage = await extract_specs("Dior", "Sauvage", None, "fragrances", "search context")
+        assert specs["longevity"] == "10 hours"
+
+
+class TestInapplicableNonNegotiables:
+    """A TV has no battery, processor, RAM or rear camera. Chasing those through
+    the paid Tier-2/Tier-3 cascade burns Serper credits and a gpt-4o call on a
+    spec that cannot exist."""
+
+    def test_tv_drops_the_inapplicable_electronics_non_negotiables(self):
+        fields = non_negotiable_fields_for("electronics", "electronics.tv")
+        for impossible in ("battery", "processor", "ram", "rear_camera"):
+            assert impossible not in fields
+
+    def test_phone_keeps_every_electronics_non_negotiable(self):
+        fields = non_negotiable_fields_for("electronics", "electronics.phone")
+        assert set(fields) == set(CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE["electronics"])
+
+    def test_unknown_subtype_falls_back_to_the_category_list(self):
+        fields = non_negotiable_fields_for("electronics", "electronics.default")
+        assert set(fields) == set(CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE["electronics"])
+
+    def test_none_subtype_falls_back_to_the_category_list(self):
+        fields = non_negotiable_fields_for("skincare", None)
+        assert set(fields) == set(CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE["skincare"])
+
+    def test_override_never_invents_a_field(self):
+        """An override may only REMOVE fields, never add ones the cascade would
+        then chase without a schema home."""
+        for category, base in CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE.items():
+            for subtype in [k for k in PRODUCT_TYPE_SCHEMAS if k.startswith(f"{category}.")]:
+                resolved = non_negotiable_fields_for(category, subtype)
+                assert set(resolved) <= set(base), (
+                    f"{subtype} resolved a non-negotiable outside the category list"
+                )


### PR DESCRIPTION
Closes #59. Two halves of one cost-and-quality defect, both code-default live.

## Half 1 — the prompt asked for keys the cleaner threw away
`_build_specs_prompt` asks GPT for the **subtype** field list (`PRODUCT_TYPE_SCHEMAS`) while `extract_specs` cleans against the **category** list (`CATEGORY_SPEC_SCHEMAS`), so every subtype-named answer was dropped and its canonical home stamped `"N/A"`. Only fragrances had a reconciliation (two aliases).

Because `detect_product_type` falls back to the **first** subtype when no keyword matches, this fired on nearly every query in a subtype-bearing category: a skincare serum's `hero_active` was discarded, `active_ingredient` read `"N/A"`, and the paid smart-fallback + Tier-2 (one Serper + one GPT **per field**) + Tier-3 (a gpt-4o call) cascade then re-fetched what the model had already returned.

`SUBTYPE_SPEC_ALIASES` generalises the reconciliation across all categories, mapping only onto fields that already exist in the canonical schema — no schema is extended. The fragrance pair is carried over unchanged, and SA-1 semantics are preserved: a canonical value GPT also emitted stays authoritative. `_source` citations are reconciled alongside their value so attribution follows.

`SUBTYPE_NON_NEGOTIABLE_DROPS` + `non_negotiable_fields_for()`: a TV has no battery, processor, RAM or rear camera, so Tier 2 and Tier 3 no longer chase specs that cannot exist. Overrides may only **remove** fields (test-enforced); a removed field follows the existing A.4.9 rule and is omitted, never faked.

## Half 2 — the fills were never cached
`_get_specs` writes the specs cache **before** returning, i.e. before any of the three fill stages run, and none wrote back. The degraded dict was cached, so the entire paid refill cascade re-fired on **every warm comparison for the full 7-day TTL**. The enriched dict is now written back once, mirroring the `_get_specs` write including the L2 save, with transient keys stripped and the write gated on a stage having actually filled something.

## Verification
14 new tests, including integrity tests asserting every alias source is a field the subtype prompt really requests and every target is a real canonical field — that check caught a bad `supplements.multivitamin` entry during development.

Comm gate against `origin/main` over a 156-file blast radius: **branch-only-NEW == []** (identical 40 pre-existing failures both sides), 2683 → 2697 passing.