### PR TITLE
docs: audit handoff — issues #46-#81, first three fixes, and three repo traps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,18 @@ ToS/Privacy fact base, code-side blockers (delete cascade, expo-notifications pl
 
 **Canary phasing:** With <10 testers pre-launch, set new-feature canary % to 100 — lower % statistically hash-buckets a small tester set out of the feature being tested. Drop to 10 only at App Store soft-launch, then ramp 10→50→100 per `docs/runbooks/qaren-canary-onboarding.md`.
 
+## Active runtime (full-repo audit + first three fixes, 2026-08-24)
+
+A full audit of `main c630436` produced **GitHub issues #46–#81** (12 P1, 23 P2, 1 P3), each self-contained with verified `file:line`. Three are implemented and pushed, **no PRs opened, nothing merged, nothing deployed**: `fix/46-dependency-lock` (`d6c52ab`), `fix/58-model-config` (`b9e962e`), `fix/59-subtype-specs` (`48daac6`). Each passed the repo comm gate against `origin/main` with **branch-only-NEW == []**.
+
+**Three findings that change how you work in this repo — full detail in `docs/investigations/2026-08-24-audit-implementation-handoff.md`:**
+
+1. **CI has been RED on main since at least 2026-07-07** (176 failed / 9,359 passed on `c630436`). Causes: a missing `pillow` dev dependency (fixed on `fix/46`) and the RED-by-design `tests/test_value_math.py` stubs that CI never excluded (still open — **#49**). "Tests green" has not been a real merge gate; do not treat a green local run as proof until #49 lands.
+2. **`pytest tests/` hangs — the default suite makes LIVE network calls.** `magento_graphql_service.py:275` and `noon_service.py:170` fetch real retailer sites in executor threads that the pytest timeout cannot kill (this is **#70** reproducing in-suite), and with `.env` present Serper 403s and OpenAI 429s stall the retries (**#48**). Run targeted file sets, excluding adapter/network-heavy files.
+3. **`app/config.py` is a trap, not merely dead.** It declares seven REQUIRED pydantic fields and instantiates `Settings()` at import (`:55`), so importing it raises `ValidationError` wherever those env vars are absent. Never put new config there — `app/services/model_config.py` is the pattern to copy (env reads, safe defaults, zero required credentials). Related: `openai_service.py:20` builds `AsyncOpenAI` at module import, and every current openai release rejects keyless construction, so `import app.main` fails without `OPENAI_API_KEY` (verified across 2.54.0/3.2.0/3.3.1 — pre-existing, not a pinning artifact).
+
+**Model ids are now config, not code** (#58): `OPENAI_MODEL_{VERDICT,STANDARD,VISION,CRITIC,MODERATION}`, resolved per call, logged once at startup as `[models] …`. Defaults are unchanged (`gpt-4o` / `gpt-4o-mini`). **Do NOT flip to a GPT-5 id without a live smoke test** — GPT-5 rejects `temperature=0` outright (the verdict's determinism A/B depends on it), requires `max_completion_tokens`, and counts invisible reasoning tokens against that same budget so a straight `1000` carry-over can return empty content. The shims (`sampling_kwargs`, `token_limit_kwargs`) prevent the 400s; they cannot restore determinism.
+
 ## Known Remaining Bugs (deferred)
 - **✅ KEYS ROTATED 2026-06-27 (prod un-degraded):** `SERPER_API_KEY` PAID `7de9c750…`, `SCRAPEDO_API_TOKEN` `963772…`, new Zyte acct `e3374b…` — all set on Railway + local `.env`, prod verified live. (Was: all 3 dead 2026-06-26.) Full keys ONLY in gitignored `.env`. See the 2026-06-27 Active-runtime entry.
 - **Scrape.do timing out** on GCC luxury retailers (Ounass, Bloomingdales). Firecrawl is primary; Scrape.do is Tier 1.5d fallback only. Investigation `docs/investigations/2026-05-16-scrapedo-timeout-analysis.md` — recommendation: **accept current behavior** (graceful Tier 2 fallback).

--- a/docs/investigations/2026-08-24-audit-implementation-handoff.md
+++ b/docs/investigations/2026-08-24-audit-implementation-handoff.md
@@ -1,0 +1,135 @@
+# Audit implementation — session handoff (2026-08-24)
+
+Continues the full-repo audit of `origin/main @ c630436`. Issues **#46–#81** were
+filed from that audit; **#46, #58, #59** are implemented, pushed, and awaiting PR.
+This file is the pick-up point.
+
+## Branches pushed (no PRs opened yet, nothing merged, nothing deployed)
+
+| Branch | Commit | Issue |
+|---|---|---|
+| `fix/46-dependency-lock` | `d6c52ab` | #46 — compiled universal dependency lock + CI drift gate |
+| `fix/58-model-config` | `b9e962e` | #58 — OpenAI model ids in one env-overridable module |
+| `fix/59-subtype-specs` | `48daac6` | #59 — subtype spec reconciliation + enriched-specs caching |
+
+All three branch off `c630436` and are independent. `#58` and `#59` both touch
+`extraction_service.py` in **disjoint regions** (model kwargs vs the alias table
+and cleaning loop), so they merge in either order.
+
+Work was done in the linked worktree `../smartcompare-fixes` so the main
+checkout's dirty tree was never touched.
+
+## Verification method used (repeat this for the remaining issues)
+
+The repo's own comm gate, run per branch: the same test-file set on the branch and
+on pristine `origin/main` (via `git stash`), diff the sorted FAILED sets, and
+require **branch-only-NEW == []**.
+
+| Branch | Files | main fails | branch fails | New | Passing |
+|---|---|---|---|---|---|
+| #58 | 87 | 40 | 40 | **0** | 1749 → 1802 |
+| #59 | 156 | 40 | 40 | **0** | 2683 → 2697 |
+
+`#46` changed zero `.py` files, and a floating install was proven byte-identical
+to the lock for all 67 Windows-resolvable packages, so its outcome is unchanged
+by construction.
+
+---
+
+## 🔴 Findings that are NOT yet filed as issues — read before planning tomorrow
+
+### 1. CI has been RED on `main` for at least two months
+
+Every run back to **2026-07-07** failed, including the live production commit
+`c630436` (`gh run list --branch main`). The latest: **176 failed / 9,359 passed**.
+So "tests green" has not been a functioning merge gate for the entire period the
+audit covers. Two root causes, both now understood:
+
+* `ModuleNotFoundError: No module named 'PIL'` — `tests/test_security_regression.py`
+  imports PIL, which was declared only in the non-deployed `backend/pyproject.toml`.
+  **Fixed on `fix/46-dependency-lock`** (pillow added to `requirements-dev.in`).
+* `ImportError: cannot import name 'build_value_delta_text' / '_classify_value_match'`
+  — the RED-by-design TDD stubs in `tests/test_value_math.py` (35 failures) that
+  CLAUDE.md documents but CI never excluded. **Still unfixed** — belongs to #49.
+
+Until #49 lands, expect ~40 pre-existing failures locally and a red CI.
+
+### 2. The default test suite makes live network calls
+
+A full free-unit run hangs. The stack shows `magento_graphql_service.py:275` and
+`noon_service.py:170` performing **real `curl_cffi` requests to live retailer
+sites** inside `concurrent.futures` workers, stuck in `curl.perform()` — which the
+pytest timeout **cannot kill**, because a `wait_for` cannot cancel an executor
+thread. That is issue **#70** reproducing inside the test suite.
+
+With credentials present it is worse: Serper answered **403 Unauthorized** and
+OpenAI **429 Too Many Requests**, and the retry loops blew the timeout. This is
+issue **#48** (conftest loads the real `.env` with `override=True`) in action.
+
+**Practical consequence:** run targeted file sets, not `pytest tests/`. The
+exclusion pattern used here (adapter/network-heavy files) is recorded in the
+commands above.
+
+### 3. Production is running an unpinned dependency set that has already moved
+
+The 2026-08-18 CI run installed **openai 3.2.0**; the floors resolve to **3.3.1**
+today. `#46` freezes today's resolve, which is what the next Railway rebuild would
+have installed anyway — it does not change what deploys, it makes it reproducible.
+
+**Landmine found while verifying:** `app/services/openai_service.py:20` constructs
+`AsyncOpenAI` at **module import**, and every current openai release raises
+`OpenAIError: Missing credentials` when no key is in the environment. So
+`import app.main` fails anywhere `OPENAI_API_KEY` is unset. Verified against
+2.54.0, 3.2.0 and 3.3.1 — this is **version-independent and pre-existing**, not
+caused by the lock. Making that client lazy is worth its own issue.
+
+### 4. `app/config.py` is a trap, not just dead code
+
+It declares **seven required pydantic fields** and instantiates `Settings()` at
+module import (`:55`), so importing it raises `ValidationError` wherever those env
+vars are absent. Issue #58's proposed implementation said to put the new model
+config there; doing so would have broken every service import in CI. The model
+config lives in `app/services/model_config.py` instead, which reads env with safe
+defaults and requires no credentials. **Any future issue that says "add it to
+app/config.py" needs the same correction.**
+
+---
+
+## What #58 deliberately did NOT do
+
+Step 1 (indirection) only. The defaults are still `gpt-4o` / `gpt-4o-mini`, so
+behavior is unchanged and flipping a model is now an env change with instant
+rollback.
+
+Step 2 (flip to `gpt-5-mini` / `gpt-5-nano`) is **not safe to do blindly.**
+Researched against developers.openai.com on 2026-08-24:
+
+* GPT-5 models are reasoning models and accept **only the default temperature**;
+  `temperature=0` is a hard 400. The verdict call depends on `temperature=0` — an
+  A/B in `docs/plans/2026-06-12-s2-shadow-results.md` attributes the whole
+  winner-variance bucket to it. `sampling_kwargs()` drops the parameter for GPT-5
+  ids, so the call will not 400 — but the determinism guarantee goes with it.
+* `max_tokens` is rejected; `max_completion_tokens` is required.
+  `token_limit_kwargs()` handles this.
+* `max_completion_tokens` **counts invisible reasoning tokens against the same
+  budget**. Carrying `1000` straight over can return empty content with
+  `finish_reason="length"`. Raise the caps and/or pass `reasoning_effort="minimal"`.
+* `gpt-5-pro` is Responses-API only and will fail on chat completions.
+
+**Before flipping: smoke-test the target id against a real key.** The economics
+are worth it (verdict ≈ $0.0224 → $0.0030; vision ≈ 30× cheaper on gpt-5-nano),
+but this needs a live call, and OpenAI credits were exhausted at the time of writing.
+
+## Suggested order for tomorrow
+
+1. Open PRs for the three pushed branches (`gh pr create`), review, merge `#46` first.
+2. **#49** — CI gates. Excluding the RED-by-design stubs is what finally turns CI
+   green, which every later merge depends on.
+3. **#48** — neutralize credentials in conftest; this is what makes the suite
+   runnable end to end and stops tests touching the production cache.
+4. **#60** — Serper budget gate (cheapest removal of a recurring outage).
+5. Then the price-truth cluster: **#50 → #51**, **#53**.
+
+Costed decision context for the scraper build-vs-buy question is unchanged: keep
+the hybrid, and point owned-scraper investment at discovery (**#75**, the sitemap
+channel that is already written and inert), not at rendering.


### PR DESCRIPTION
Session handoff for the full-repo audit of `main c630436` that produced issues #46–#81, plus the implementation of #46 / #58 / #59 (PRs #82, #83, #84).

Records three findings that change how work is done in this repo:

1. **CI has been red on `main` since at least 2026-07-07**, including the live production commit — 176 failed / 9,359 passed. Causes: a missing `pillow` dev dependency (fixed in #82) and the RED-by-design `test_value_math.py` stubs CI never excluded (#49). "Tests green" has not been a functioning merge gate.
2. **`pytest tests/` hangs — the default suite makes live network calls** to real retailer sites in executor threads the pytest timeout cannot kill (#70 reproducing in-suite), compounded by conftest loading the real `.env` (#48).
3. **`app/config.py` raises `ValidationError` on import** wherever its seven required env vars are absent, so it is a trap for anything that says "add config there".

Also records why #58 stopped at indirection rather than flipping to GPT-5.

Docs only — no code paths touched.