### PR TITLE
test(conftest): stop the default suite carrying production credentials (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,17 +382,23 @@ Railway MCP server is configured at project root (`.mcp.json`, stdio via `railwa
 python -m pytest tests/ -v -m "not (live_unit or live_db or integration)" --ignore=tests/test_integration.py
 
 # Live unit tests (iHerb, Serper, GPT — ~$0.03)
-python -m pytest tests/ -v -m "not (live_db or integration)"
+LIVE=1 python -m pytest tests/ -v -m "not (live_db or integration)"
 
 # Integration tests (live Railway — ~$0.06)
-python -m pytest tests/test_integration.py -v -m integration
+LIVE=1 python -m pytest tests/test_integration.py -v -m integration
 
 # Full suite
-python -m pytest tests/ -v --timeout=180
+LIVE=1 python -m pytest tests/ -v --timeout=180
 ```
 
 - `python -m py_compile <file>` for syntax checks; `npx tsc --noEmit` for frontend types.
-- `conftest.py` auto-loads `.env` via python-dotenv.
+- `conftest.py` auto-loads `.env` via python-dotenv, then STRIPS the
+  credential-bearing names from it (issue #48) so the default tier runs
+  credential-free, same as CI. **`LIVE=1` is what restores them** — the
+  `live_unit` / `live_db` / `integration` markers no longer opt in on their
+  own, so `-m live_db` without `LIVE=1` skips every selected test instead of
+  running it. PowerShell: `$env:LIVE=1; python -m pytest ...`. See
+  `tests/_env_safety.py`.
 - ~100 test files (`test_<feature>.py`, one per service). 80%+ coverage target for new features.
 - No regressions: all existing tests must pass before merging.
 - **Eval gate (Bundle B B.6):** pre-merge `python -m scripts.eval_runner --subset smoke20 --mode regression --baseline-run-id 4aee8e88-da97-41b3-974b-3e75c2c9c10e` (S1 baseline = 21.0%). Measurement runs ALWAYS `--concurrency 1` (walls are load-sensitive); full-200 needs `--allow-full` + dispatcher GO (~600-1,000 Serper credits). Runbooks: `docs/runbooks/qaren-eval.md` + `qaren-gold-set.md`.

--- a/docs/CONTEXT_REFERENCE.md
+++ b/docs/CONTEXT_REFERENCE.md
@@ -143,19 +143,26 @@ LOG_LEVEL=INFO                            # Structured logging level (DEBUG/INFO
 python -m pytest tests/ -v -m "not (live_unit or live_db or integration)" --ignore=tests/test_integration.py
 
 # Include live unit tests (iHerb scraping, Serper, GPT vision) — adds ~$0.03
-python -m pytest tests/ -v -m "not (live_db or integration)"
+LIVE=1 python -m pytest tests/ -v -m "not (live_db or integration)"
 
 # Live database tests (needs Supabase credentials in .env)
-python -m pytest tests/test_drug_database_service.py -v -m live_db
+LIVE=1 python -m pytest tests/test_drug_database_service.py -v -m live_db
 
 # Integration tests — hits live Railway, costs ~$0.06, takes ~4 min
-python -m pytest tests/test_integration.py -v -m integration
+LIVE=1 python -m pytest tests/test_integration.py -v -m integration
 
 # All tests
-python -m pytest tests/ -v --timeout=180
+LIVE=1 python -m pytest tests/ -v --timeout=180
 ```
 
-**Note:** `tests/conftest.py` auto-loads `.env` via `python-dotenv`, so Supabase credentials are available for all tests.
+**Note:** `tests/conftest.py` auto-loads `.env` via `python-dotenv` and then
+NEUTRALISES every credential-bearing name in it (issue #48), so the default
+tier runs with the same credential-free environment CI does. `LIVE=1` is the
+only thing that restores the real values — **without it the marker alone is a
+no-op**: a `pytest -m live_db` run reports the live tests as `skipped`, not as
+passed. Omit `LIVE=1` and Supabase credentials are NOT available to a test.
+The `LIVE=1 ...` prefix above is bash; in PowerShell use
+`$env:LIVE=1; python -m pytest ...` (and `Remove-Item Env:LIVE` afterwards).
 
 ### Test Files
 | File | Tests | Type | Notes |
@@ -193,11 +200,18 @@ python -m pytest tests/ -v --timeout=180
 | **Total** | **809** | | **793 free unit + 14 live_unit + 6 live_db + 10 integration** |
 
 ### Pytest Markers
+Selecting a marker is **not** an opt-in on its own. Since issue #48 the
+`pytest_collection_modifyitems` hook in `tests/conftest.py` skips every
+`live_unit` / `live_db` / `integration` item unless `LIVE=1` is set, because
+the default tier no longer holds the credentials those tests need. Run them
+with the `LIVE=1` prefix in the last column or they silently report `skipped`.
+
 | Marker | Purpose | Run command |
 |--------|---------|-------------|
-| `live_unit` | Tests calling live external services (iHerb, Serper, OpenAI) | `-m live_unit` |
-| `live_db` | Tests requiring live Supabase `bahrain_approved_drugs` table | `-m live_db` |
-| `integration` | End-to-end tests against live Railway production | `-m integration` |
+| `live_unit` | Tests calling live external services (iHerb, Serper, OpenAI) | `LIVE=1 pytest -m live_unit` |
+| `live_db` | Tests requiring live Supabase `bahrain_approved_drugs` table | `LIVE=1 pytest -m live_db` |
+| `integration` | End-to-end tests against live Railway production | `LIVE=1 pytest -m integration` |
+| `bench` | Latency/throughput benchmarks against live Railway | `BENCH=1 pytest -m bench` (own gate, not `LIVE`) |
 
 ## Local Backend Testing
 

--- a/tests/_env_safety.py
+++ b/tests/_env_safety.py
@@ -1,0 +1,244 @@
+"""Credential neutralisation for the default (non-LIVE) test tier — issue #48.
+
+WHY THIS EXISTS
+---------------
+`tests/conftest.py` loads the developer's real `.env` over the top of the
+process environment (`load_dotenv(override=True)`), so a local
+`pytest tests/` ran the DEFAULT suite with production credentials. Two
+reach-through vectors fire at IMPORT time, before any fixture can intervene:
+
+  * `app/main.py:42` calls `init_sentry()` at module scope and
+    `app/services/sentry_service.py:199-202` initialises the real SDK for any
+    non-empty `SENTRY_DSN` — test exceptions report into production Sentry.
+  * `app/services/cache_service.py:15-28` builds the Upstash client at module
+    scope — any unmocked cache call READS AND WRITES the shared production
+    cache that the warmer and live users read.
+
+`load_dotenv` is left in place (feature flags and tuning knobs are still
+expected to come from `.env`); only the credential-bearing and
+production-endpoint names are neutralised, and only when the caller has not
+opted in with `LIVE=1`.
+
+WHY A GUARD ON `load_dotenv` TOO
+-------------------------------
+Sanitising once in `conftest.py` is necessary but not sufficient:
+`app/main.py:11`, `app/services/extraction_service.py:5` and
+`app/services/url_extraction_service.py:6` each call
+`load_dotenv(override=True)` themselves at import. Importing any of them
+re-injects the real `.env` on top of the sanitized environment — and if that
+happens before `cache_service` is imported, the module-level Upstash client
+points at production again. `install_dotenv_guard()` wraps the real
+`load_dotenv` so the non-credential half of `.env` keeps flowing while the
+credentials are re-cleared on every reload.
+
+POP OR SENTINEL — THE RULE
+--------------------------
+A var is CLEARED when absence is the state its consumer already documents as
+"disabled": `cache_service` falls to `redis_client = None`, `init_sentry()`
+returns early, the vendor clients all check `if not KEY`. Absence there
+reproduces exactly the credential-free environment CI runs, so nothing new is
+invented and an unmocked call cannot go anywhere.
+
+A var gets an unusable SENTINEL when absence would break a legitimately
+OFFLINE test instead of disabling anything — `openai_service.py:20` builds
+`AsyncOpenAI(...)` at import, `create_client()` is a pure constructor that
+dozens of fully-mocked tests reach through a service `__init__`, and
+`youtube_service.py:47` caches its key in a module-level global whose value
+depends on import order. Each sentinel reuses the exact literal the test suite
+already `os.environ.setdefault(...)`s for itself, and every sentinel host sits
+under RFC 2606's reserved `.invalid` TLD, so a call that slips past its mock
+fails locally and instantly rather than reaching production.
+
+Measured: popping the `SUPABASE_*` trio instead fails ~80 offline tests, and
+popping `YOUTUBE_API_KEY` fails 9 more in-suite-only. Both were passing on
+main by talking to the real production project.
+
+WHAT PROTECTS THE LIVE TIERS
+----------------------------
+`test_demographics_rls.py`, `test_migration_023.py`,
+`test_migration_028_pain_workflow_events.py` and
+`test_migration_032_b1_pre_hardening.py` gate on `os.getenv("SUPABASE_URL")`
+and `pytest.skip(...)` when it is missing — a guard the sentinel would defeat
+on its own. They are protected instead by :data:`LIVE_TIER_MARKERS` and the
+`pytest_collection_modifyitems` hook in `conftest.py`, which skips every
+live-tier item before its body runs unless `LIVE=1` is set. Under `LIVE=1`
+both the hook and this sanitizer stand down and the guards see real values
+again.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, MutableMapping, Optional
+
+#: Opt-in switch. `LIVE=1` restores the real `.env` for the live tiers.
+LIVE_OPT_IN_ENV = "LIVE"
+
+#: Accepted truthy spellings of the opt-in. `0` / `false` / `` are NOT
+#: opt-ins — a half-set variable must never re-enable production credentials.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+#: Marker tiers that genuinely need real credentials. Without the opt-in they
+#: are skipped rather than allowed to fail confusingly or pass vacuously.
+#: `bench` is deliberately NOT here: it carries its own independent `BENCH=1`
+#: gate and targets a hardcoded prod URL rather than credentials.
+LIVE_TIER_MARKERS = ("live_unit", "live_db", "integration")
+
+#: Credential and production-endpoint variables whose SAFE state is "absent".
+#: Sourced from a grep of `os.getenv("...")` across `app/` and `scripts/`;
+#: re-run that grep when adding an integration.
+CREDENTIALS_UNSET = (
+    # Observability — init_sentry() no-ops on an empty DSN.
+    "SENTRY_DSN",
+    # Shared production cache — cache_service falls to `redis_client = None`.
+    "UPSTASH_REDIS_URL",
+    "UPSTASH_REDIS_TOKEN",
+    # LLM — the PDPL opt-out key falls back to the shared client when absent.
+    "OPENAI_API_KEY_PRIVATE",
+    # LLM endpoint — absent means stock OpenAI, the flag-OFF default.
+    "OPENAI_BASE_URL",
+    # Paid search / scraping vendors.
+    "SERPER_API_KEY",
+    "SERPER_API_KEYS",
+    "FIRECRAWL_API_KEY",
+    "SCRAPEDO_API_TOKEN",
+    "BRIGHTDATA_API_KEY",
+    "BRIGHTDATA_ZONE",
+    "ZYTE_API_KEY",
+    # Privileged app surfaces.
+    "ADMIN_API_KEY",
+    "NASSER_GUEST_TOKEN",
+    # Deployed API the eval/bench runners point at.
+    "TARGET_BASE_URL",
+)
+
+#: Variables that must stay PRESENT but must never be real. Both entries here
+#: are cases where ABSENCE breaks a legitimately offline test rather than
+#: disabling anything, so the safe state is an unusable value, not no value.
+#: Every host below is under RFC 2606's reserved `.invalid` TLD, which can
+#: never resolve — an unmocked call fails locally and instantly.
+CREDENTIAL_PLACEHOLDERS: Dict[str, str] = {
+    # openai_service.py:20 constructs AsyncOpenAI at module import and raises
+    # OpenAIError on a missing key. Same literal ~120 test modules already
+    # `os.environ.setdefault(...)` for themselves, so nothing new is invented.
+    "OPENAI_API_KEY": "sk-test-dummy",
+    # database_service/auth_service pass these straight to `create_client()`,
+    # which is a PURE CONSTRUCTOR — no I/O. Dozens of offline tests build a
+    # service whose __init__ calls `get_admin_supabase_client()` (e.g.
+    # AbuseDetectionService.__init__) and then mock every query. Popping the
+    # vars turns that pure constructor into a ValueError and fails ~80 tests
+    # that never touch the network; a non-resolvable host keeps them offline
+    # AND makes any genuinely unmocked query fail loudly instead of reaching
+    # production. The live_db tiers are protected by the marker hook, not by
+    # the absence of these vars — see LIVE_TIER_MARKERS.
+    "SUPABASE_URL": "https://neutralized.supabase.invalid",
+    "SUPABASE_ANON_KEY": "test-anon-key-neutralized",
+    "SUPABASE_SERVICE_KEY": "test-service-key-neutralized",
+    # youtube_service.py:47 reads YOUTUBE_API_KEY into a MODULE-LEVEL global,
+    # so whether it is set depends on which test file imported the service
+    # first. The five test_youtube_* modules each `os.environ.setdefault(
+    # "YOUTUBE_API_KEY", "test-yt-key")`, which only wins if none of them was
+    # beaten to the import — popping the var makes 9 of their tests fail in
+    # suite while passing alone. Same literal they use, so the setdefaults
+    # become no-ops and the global is deterministic either way. The absent
+    # branch stays covered: test_youtube_service.py:186 monkeypatches the
+    # module global to None directly.
+    "YOUTUBE_API_KEY": "test-yt-key",
+}
+
+#: What the credential vars actually resolved to the first time the sanitizer
+#: ran against the real process environment (i.e. at conftest import, before
+#: any test could touch them). Tests assert the SESSION-START guarantee against
+#: this rather than against live `os.environ`, which individual tests are free
+#: to mutate with fakes of their own.
+COLLECTION_SNAPSHOT: Dict[str, Optional[str]] = {}
+
+
+def live_mode_enabled(environ: Optional[MutableMapping[str, str]] = None) -> bool:
+    """True when the caller explicitly opted into real credentials."""
+    env = os.environ if environ is None else environ
+    return (env.get(LIVE_OPT_IN_ENV) or "").strip().lower() in _TRUTHY
+
+
+def neutralize_credentials(
+    environ: Optional[MutableMapping[str, str]] = None,
+) -> Dict[str, Optional[str]]:
+    """Strip production credentials from ``environ`` unless ``LIVE`` is set.
+
+    Returns a map of the names acted on to their resulting value (``None``
+    for the ones removed), so a caller can log what changed without ever
+    handling the secret it replaced. A no-op returning ``{}`` under the
+    ``LIVE`` opt-in.
+
+    Feature flags are explicitly out of scope: nothing in
+    :data:`CREDENTIALS_UNSET` or :data:`CREDENTIAL_PLACEHOLDERS` starts with
+    ``ENABLE_``, so the ``setdefault`` semantics in ``conftest.py`` — which
+    encode flag-OFF-in-production — are untouched.
+    """
+    env = os.environ if environ is None else environ
+    if live_mode_enabled(env):
+        return {}
+
+    changed: Dict[str, Optional[str]] = {}
+    for name in CREDENTIALS_UNSET:
+        if env.pop(name, None) is not None:
+            changed[name] = None
+    for name, placeholder in CREDENTIAL_PLACEHOLDERS.items():
+        if env.get(name) != placeholder:
+            env[name] = placeholder
+            changed[name] = placeholder
+
+    if env is os.environ and not COLLECTION_SNAPSHOT:
+        COLLECTION_SNAPSHOT.update(
+            (name, env.get(name))
+            for name in (*CREDENTIALS_UNSET, *CREDENTIAL_PLACEHOLDERS)
+        )
+    return changed
+
+
+def install_dotenv_guard() -> bool:
+    """Re-run :func:`neutralize_credentials` after every ``load_dotenv`` call.
+
+    ``app/main.py``, ``app/services/extraction_service.py`` and
+    ``app/services/url_extraction_service.py`` call ``load_dotenv(override=True)``
+    at import time, which would otherwise re-inject the real ``.env`` over the
+    sanitized environment. Wrapping (rather than disabling) keeps the
+    non-credential half of ``.env`` — feature flags, tuning knobs — working
+    exactly as before.
+
+    Idempotent. Returns False when it was already installed or the opt-in is
+    active, True when a guard was installed.
+    """
+    if live_mode_enabled():
+        return False
+
+    import dotenv
+    import dotenv.main
+
+    real_load_dotenv = dotenv.main.load_dotenv
+    if getattr(real_load_dotenv, "_qaren_env_guard", False):
+        return False
+
+    def guarded_load_dotenv(*args, **kwargs):
+        result = real_load_dotenv(*args, **kwargs)
+        neutralize_credentials()
+        return result
+
+    guarded_load_dotenv._qaren_env_guard = True  # type: ignore[attr-defined]
+    guarded_load_dotenv.__doc__ = real_load_dotenv.__doc__
+    guarded_load_dotenv.__name__ = real_load_dotenv.__name__
+
+    # Patch BOTH bindings: modules do `from dotenv import load_dotenv` and the
+    # `dotenv` package re-exports the `dotenv.main` symbol.
+    dotenv.main.load_dotenv = guarded_load_dotenv
+    dotenv.load_dotenv = guarded_load_dotenv
+    return True
+
+
+def live_tier_skip_reason() -> str:
+    """Message shown when a live-tier test is skipped for lack of the opt-in."""
+    # ASCII only: this string is printed by `pytest -rs` into consoles whose
+    # encoding (Windows cp1252) mangles anything else.
+    return (
+        "live-tier test needs real credentials: re-run with LIVE=1 "
+        "(default runs are credential-free - see tests/_env_safety.py)"
+    )

--- a/tests/_env_safety.py
+++ b/tests/_env_safety.py
@@ -64,9 +64,30 @@ on its own. They are protected instead by :data:`LIVE_TIER_MARKERS` and the
 live-tier item before its body runs unless `LIVE=1` is set. Under `LIVE=1`
 both the hook and this sanitizer stand down and the guards see real values
 again.
+
+`tests/test_drug_database_service.py` carries `live_db` on its Supabase tests
+too, but note the hook skips test BODIES, not module-import side effects:
+that file evaluates `live_db_available = _can_connect_to_drug_table()` at
+module scope, i.e. during COLLECTION, before the hook can act. What keeps
+that call off production is the SENTINEL (it builds a client against a
+non-resolving host and its bare `except Exception` swallows the failure), not
+the marker. Any new module-scope probe needs the same reasoning applied.
+
+SCOPE OF THE GUARANTEE
+----------------------
+This module sanitizes `os.environ` and nothing else. `app/config.py:40` sets
+`env_file = ".env"` on a pydantic-settings `BaseSettings`, which reads the
+file FROM DISK independently of `os.environ` — so `app.config.settings` would
+carry the real credentials straight past everything here. Nothing imports
+`app.config` today (a grep of `app/`, `tests/` and `scripts/` finds no
+`from app.config` / `import app.config`), so this is latent rather than an
+active leak, but REVIVING `app/config.py` REOPENS THE HOLE and needs its own
+fix (its `Settings()` `ValidationError` also renders the offending secret
+VALUES in full).
 """
 from __future__ import annotations
 
+import hashlib
 import os
 from typing import Dict, MutableMapping, Optional
 
@@ -145,12 +166,30 @@ CREDENTIAL_PLACEHOLDERS: Dict[str, str] = {
     "YOUTUBE_API_KEY": "test-yt-key",
 }
 
-#: What the credential vars actually resolved to the first time the sanitizer
-#: ran against the real process environment (i.e. at conftest import, before
-#: any test could touch them). Tests assert the SESSION-START guarantee against
-#: this rather than against live `os.environ`, which individual tests are free
-#: to mutate with fakes of their own.
-COLLECTION_SNAPSHOT: Dict[str, Optional[str]] = {}
+#: SHA-256 fingerprints of what each watched var held the first time the
+#: sanitizer ran against the real process environment -- captured BEFORE the
+#: pop/placeholder loops, so it records what the sanitizer SAW, not what it
+#: left behind. `None` for a name that was already absent.
+#:
+#: Fingerprints, not values: a test asserts "the live value is still the one
+#: the sanitizer found" without this module ever retaining a production secret
+#: that a pytest assertion-rewrite dump, a traceback or a `-l` local-variable
+#: listing could splash into a console or a CI log.
+#:
+#: Every watched name is recorded (mapping to `None` when it was unset), so a
+#: non-empty dict means "the sanitizer ran" even on a credential-free machine.
+PRE_SANITIZE_FINGERPRINTS: Dict[str, Optional[str]] = {}
+
+
+def fingerprint(value: Optional[str]) -> Optional[str]:
+    """One-way digest of an env value. `None` for absent/empty.
+
+    Used so the pre-sanitize record can be compared for equality without
+    holding the plaintext credential anywhere a dump could reach it.
+    """
+    if not value:
+        return None
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def live_mode_enabled(environ: Optional[MutableMapping[str, str]] = None) -> bool:
@@ -178,6 +217,15 @@ def neutralize_credentials(
     if live_mode_enabled(env):
         return {}
 
+    # Record what we are ABOUT to sanitize, before either loop runs. Capturing
+    # after the loops made the record `None`-by-construction for every popped
+    # name, which turned the leak assertion into a tautology.
+    if env is os.environ and not PRE_SANITIZE_FINGERPRINTS:
+        PRE_SANITIZE_FINGERPRINTS.update(
+            (name, fingerprint(env.get(name)))
+            for name in (*CREDENTIALS_UNSET, *CREDENTIAL_PLACEHOLDERS)
+        )
+
     changed: Dict[str, Optional[str]] = {}
     for name in CREDENTIALS_UNSET:
         if env.pop(name, None) is not None:
@@ -187,11 +235,6 @@ def neutralize_credentials(
             env[name] = placeholder
             changed[name] = placeholder
 
-    if env is os.environ and not COLLECTION_SNAPSHOT:
-        COLLECTION_SNAPSHOT.update(
-            (name, env.get(name))
-            for name in (*CREDENTIALS_UNSET, *CREDENTIAL_PLACEHOLDERS)
-        )
     return changed
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,28 @@ import os
 import pytest
 from dotenv import load_dotenv
 
+from tests._env_safety import (
+    LIVE_TIER_MARKERS,
+    install_dotenv_guard,
+    live_mode_enabled,
+    live_tier_skip_reason,
+    neutralize_credentials,
+)
+
 load_dotenv(override=True)
+
+# Issue #48 — the default tier must not carry production credentials.
+# `.env` is still loaded (feature flags and tuning knobs come from it), but the
+# credential and production-endpoint names are stripped immediately afterwards
+# unless the caller opted in with LIVE=1. This has to happen at MODULE scope,
+# not in a fixture: `app.main` (init_sentry) and `cache_service` (module-level
+# Upstash client) are imported during collection, long before any fixture runs.
+# The dotenv guard re-applies it after the `load_dotenv(override=True)` calls
+# that app/main.py:11, extraction_service.py:5 and url_extraction_service.py:6
+# make at their own import time. See tests/_env_safety.py for the full rationale
+# and tests/test_conftest_env_safety.py for the guarantee.
+neutralize_credentials()
+install_dotenv_guard()
 
 # Enable cohort personalization for unit tests so the extraction prompt-block
 # tests exercise the injection path. Tests that need the default-off behaviour
@@ -28,6 +49,25 @@ _RATE_LIMITER_BYPASS_TEST_FILES = (
     "test_auth_demographics.py",
     "test_attribution_endpoint.py",
 )
+
+
+# Issue #48 — keep the marker tiers honest under the credential sanitizer.
+# live_unit / live_db / integration tests exist to exercise REAL services. With
+# the credentials stripped they would either fail with a confusing 401 or — the
+# dangerous case — pass without touching anything live. Skipping them with a
+# reason that names the opt-in is the same posture the live_db suites already
+# take for themselves (`pytest.skip("Supabase env vars not configured ...")`),
+# just applied uniformly. Under LIVE=1 this is a no-op and every tier runs.
+# `bench` is intentionally excluded: it has its own BENCH=1 / RUN_LIVE_BENCH=1
+# gate and targets a hardcoded URL rather than credentials.
+def pytest_collection_modifyitems(config, items):
+    """Skip live-tier tests when the LIVE opt-in restoring credentials is off."""
+    if live_mode_enabled():
+        return
+    skip_marker = pytest.mark.skip(reason=live_tier_skip_reason())
+    for item in items:
+        if any(item.get_closest_marker(name) for name in LIVE_TIER_MARKERS):
+            item.add_marker(skip_marker)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_bundle_c_integration.py
+++ b/tests/test_bundle_c_integration.py
@@ -4,8 +4,9 @@ Runs against live Railway backend with ?nocache=true. Marked
 `@pytest.mark.integration` so the free suite excludes them; promote to ship
 evidence per Section D.6 post-deploy verification.
 
-Run:
-    python -m pytest tests/test_bundle_c_integration.py -v -m integration --timeout=180
+Run (LIVE=1 required — the marker alone no longer opts in, see
+tests/_env_safety.py):
+    LIVE=1 python -m pytest tests/test_bundle_c_integration.py -v -m integration --timeout=180
 
 Covers spec §1c + §8d + edges flagged by qa-bundle-c (absorbed from
 qa's `tests/test_bundle_c_edge_stubs.py` proposal — kept on this file

--- a/tests/test_bundle_e_integration.py
+++ b/tests/test_bundle_e_integration.py
@@ -10,7 +10,9 @@ Cost: ~$0.01 per test (real OpenAI + Serper). ~$0.04 for the full Bundle E
 integration suite. Mark `@pytest.mark.integration` so the default suite
 (`pytest -m "not integration"`) skips these.
 
-Run: `python -m pytest tests/test_bundle_e_integration.py -v --timeout=180 -m integration`
+Run: `LIVE=1 python -m pytest tests/test_bundle_e_integration.py -v --timeout=180 -m integration`
+(`LIVE=1` is required — the marker alone no longer opts in, see
+tests/_env_safety.py.)
 """
 from __future__ import annotations
 

--- a/tests/test_category_selection.py
+++ b/tests/test_category_selection.py
@@ -11,8 +11,12 @@ Covers:
 - Live GPT extraction for new categories (live_unit marker)
 
 Run free tests:   pytest tests/test_category_selection.py -v -m "not live_unit"
-Run live tests:   pytest tests/test_category_selection.py -v -m live_unit  (~$0.02)
-Run all:          pytest tests/test_category_selection.py -v
+Run live tests:   LIVE=1 pytest tests/test_category_selection.py -v -m live_unit  (~$0.02)
+Run all:          LIVE=1 pytest tests/test_category_selection.py -v
+
+`LIVE=1` is required for the live_unit tier: without it the credential
+sanitizer in tests/_env_safety.py is active and the collection hook skips
+every live_unit item, so the bare command reports `skipped`.
 """
 import pytest
 from unittest.mock import patch, AsyncMock

--- a/tests/test_cohort_personalization_load.py
+++ b/tests/test_cohort_personalization_load.py
@@ -22,7 +22,11 @@ This test is double-gated so it does NOT run on default CI:
      spend the credit budget.
 
 Run explicitly:
-    RUN_LOAD=1 python -m pytest tests/test_cohort_personalization_load.py -v --timeout=180 -m live_unit
+    LIVE=1 RUN_LOAD=1 python -m pytest tests/test_cohort_personalization_load.py -v --timeout=180 -m live_unit
+
+`LIVE=1` is a third gate on top of the two above: without it the credential
+sanitizer in tests/_env_safety.py is active and the collection hook skips
+every live_unit item.
 
 Cost: ~$0.05. Wall: ~40-60s end-to-end (5 queries x cold-cache average).
 """

--- a/tests/test_conftest_env_safety.py
+++ b/tests/test_conftest_env_safety.py
@@ -72,26 +72,44 @@ _CONTRACT_SENTINEL = (
 
 
 def test_production_credentials_are_absent_by_default():
-    """No credential-bearing env var survives collection without LIVE=1.
+    """No credential-bearing env var still holds its production value.
 
-    Asserted against the snapshot the sanitizer took at conftest import, which
-    is the moment that matters: `app.main` (init_sentry) and `cache_service`
-    (module-level Upstash client) are imported during collection. Live
-    `os.environ` is the wrong oracle here -- individual tests legitimately
-    install fakes of their own (e.g. `test_analytics.py:245` assigns
-    `ADMIN_API_KEY = "test-admin-key-123"` with no teardown), which would make
-    this assertion order-dependent.
+    The oracle is a COMPARISON between two things, and both halves are load
+    bearing:
 
-    Fails loudly on a developer machine with a populated `.env` until the
-    conftest sanitizer lands. Names only in the message -- never values.
+      * LIVE `os.environ` -- what a test would actually read right now.
+      * the fingerprint the sanitizer took of that same name BEFORE it acted
+        (`tests/_env_safety.PRE_SANITIZE_FINGERPRINTS`), i.e. the real `.env`
+        value as it stood at conftest import.
+
+    Neither alone works. A plain "must be falsy" assertion on `os.environ` is
+    order-dependent: tests legitimately install fakes with no teardown (e.g.
+    `test_analytics.py:245` assigns `ADMIN_API_KEY = "test-admin-key-123"`).
+    The pre-sanitize record alone is worse than useless -- an earlier revision
+    of this test read a record captured AFTER the pop loop, so every watched
+    name was `None` by construction and the test could not fail even with a
+    real credential re-injected into the running process.
+
+    Comparing them is red exactly when it should be: the name is set AND holds
+    the production value the sanitizer saw. A test's own fake fingerprints
+    differently and does not trip it.
+
+    Names only in the message -- never values, and never digests.
     """
-    from tests._env_safety import COLLECTION_SNAPSHOT
+    from tests._env_safety import PRE_SANITIZE_FINGERPRINTS, fingerprint
 
     assert os.getenv("LIVE") is None, (
         "This test asserts the DEFAULT tier; re-run without LIVE set."
     )
-    assert COLLECTION_SNAPSHOT, "sanitizer never ran against the real environment"
-    leaked = [name for name in _CONTRACT_UNSET if COLLECTION_SNAPSHOT.get(name)]
+    assert PRE_SANITIZE_FINGERPRINTS, (
+        "sanitizer never ran against the real environment"
+    )
+    leaked = [
+        name
+        for name in _CONTRACT_UNSET
+        if PRE_SANITIZE_FINGERPRINTS.get(name)
+        and fingerprint(os.getenv(name)) == PRE_SANITIZE_FINGERPRINTS[name]
+    ]
     assert not leaked, (
         "production credentials leaked into the test process: "
         + ", ".join(leaked)
@@ -146,20 +164,66 @@ def test_present_but_unusable_vars_hold_the_sentinel(name):
     )
 
 
-def test_sentinel_hosts_can_never_resolve():
+def _sentinel_hosts():
+    """(name, host) for every placeholder that is a URL."""
+    from tests._env_safety import CREDENTIAL_PLACEHOLDERS
+
+    return [
+        (name, value.split("://", 1)[1].split("/")[0])
+        for name, value in CREDENTIAL_PLACEHOLDERS.items()
+        if "://" in value
+    ]
+
+
+def test_sentinel_hosts_are_reserved_names():
     """Any unmocked call against a sentinel fails locally, never in production.
 
     `.invalid` is reserved by RFC 2606 and is guaranteed not to resolve, so a
-    query that slips past its mock errors instantly instead of reaching a real
-    Supabase project.
+    query that slips past its mock errors instead of reaching a real Supabase
+    project. Measured on Windows: a `supabase-py` query against the sentinel
+    fails in 0.002-0.20s.
     """
-    from tests._env_safety import CREDENTIAL_PLACEHOLDERS
+    hosts = _sentinel_hosts()
+    assert hosts, "no URL sentinel to check -- did the placeholder list change?"
+    for name, host in hosts:
+        assert host.split(":")[0].endswith(".invalid"), (
+            f"{name} sentinel must point at a reserved .invalid host"
+        )
 
-    for name, value in CREDENTIAL_PLACEHOLDERS.items():
-        if "://" in value:
-            assert value.split("://", 1)[1].split("/")[0].endswith(".invalid"), (
-                f"{name} sentinel must point at a reserved .invalid host"
-            )
+
+def test_sentinel_hosts_really_do_not_resolve_here():
+    """The reserved name must also be un-resolvable ON THIS MACHINE.
+
+    The suffix check above is a statement about the RFC; this one is a
+    statement about the resolver actually in front of the developer. Resolvers
+    that hijack NXDOMAIN (some consumer ISPs, some corporate DNS) answer with
+    an A record for a name that does not exist -- and then a query that slips
+    past its mock does not fail fast, it hangs to timeout, in a repo whose
+    stated problem is a suite that hangs on network calls.
+
+    A machine with no DNS at all raises `gaierror` too and passes, which is
+    correct: nothing can be reached from there either.
+    """
+    import socket
+
+    resolvable = []
+    for name, host in _sentinel_hosts():
+        hostname = host.split(":")[0]
+        try:
+            socket.getaddrinfo(hostname, None)
+        except socket.gaierror:
+            continue
+        except OSError:
+            continue
+        resolvable.append(f"{name} ({hostname})")
+
+    assert not resolvable, (
+        "this machine's resolver ANSWERS for a reserved .invalid name, which "
+        "defeats the fail-fast property of the credential sentinel -- an "
+        "unmocked query will hang to timeout instead of erroring. Point the "
+        "resolver at one that returns NXDOMAIN (e.g. 1.1.1.1 / 8.8.8.8) or "
+        "disable NXDOMAIN redirection. Affected: " + ", ".join(resolvable)
+    )
 
 
 def test_later_load_dotenv_cannot_reinject_credentials():
@@ -169,15 +233,29 @@ def test_later_load_dotenv_cannot_reinject_credentials():
     `app.services.extraction_service` restores every real credential before
     `cache_service` reads `UPSTASH_REDIS_URL` at ITS import -- and the
     module-level Upstash client points at production again.
+
+    This has to run against the REAL process environment (that is the thing
+    under test), so it restores `os.environ` exactly afterwards: `override=True`
+    also re-applies the NON-credential half of `.env` -- ENVIRONMENT, DEBUG,
+    LOG_LEVEL, FREE_TIER_DAILY_LIMIT, MAX_MONTHLY_COST, CACHE_DURATION -- over
+    whatever the suite currently holds, which would be an order-dependent flake
+    for any later test that set one of those at module scope.
     """
     import dotenv
 
-    dotenv.load_dotenv(override=True)
+    before = dict(os.environ)
+    try:
+        dotenv.load_dotenv(override=True)
 
-    leaked = [name for name in _CONTRACT_UNSET if os.getenv(name)]
-    assert not leaked, (
-        "load_dotenv re-injected production credentials: " + ", ".join(leaked)
-    )
+        leaked = [name for name in _CONTRACT_UNSET if os.getenv(name)]
+        assert not leaked, (
+            "load_dotenv re-injected production credentials: "
+            + ", ".join(leaked)
+        )
+    finally:
+        for name in [n for n in os.environ if n not in before]:
+            del os.environ[name]
+        os.environ.update(before)
 
 
 def test_helper_covers_the_whole_contract():
@@ -275,35 +353,133 @@ def test_the_two_lists_are_disjoint():
     assert not overlap, f"var is in both lists: {overlap}"
 
 
+# The five modules whose own `os.getenv("SUPABASE_URL") -> pytest.skip(...)`
+# guard the SUPABASE_* sentinel defeats: with a sentinel present that guard
+# sees a truthy value and lets the body run, so what actually keeps them off a
+# real project is the live-tier marker plus the collection hook. Listed as
+# exact node ids and asserted against a REAL pytest collection rather than a
+# substring scan of the file text -- `pytest.mark.live_db` appears in the
+# DOCSTRING of four of these modules, so a text scan stays green even when the
+# decorator itself is deleted.
+_SUPABASE_GUARDED_FILES = (
+    "tests/test_demographics_rls.py",
+    "tests/test_migration_023.py",
+    "tests/test_migration_028_pain_workflow_events.py",
+    "tests/test_migration_032_b1_pre_hardening.py",
+    "tests/test_drug_database_service.py",
+)
+
+_SUPABASE_GUARDED_NODEIDS = frozenset({
+    "tests/test_demographics_rls.py::test_demographics_profile_column_exists",
+    "tests/test_demographics_rls.py::test_user_b_cannot_read_user_a_demographics_via_rls",
+    "tests/test_demographics_rls.py::test_demographics_dismissed_columns_exist",
+    "tests/test_migration_023.py::TestMigration023LiveSchema::test_lifetime_invites_consumed_column_exists",
+    "tests/test_migration_023.py::TestMigration023LiveSchema::test_weekly_invites_used_column_dropped",
+    "tests/test_migration_028_pain_workflow_events.py::TestMigration028LiveSchema::test_pain_workflow_events_table_selectable",
+    "tests/test_migration_028_pain_workflow_events.py::TestMigration028LiveSchema::test_workflow_name_check_rejects_unknown_value",
+    "tests/test_migration_032_b1_pre_hardening.py::TestMigration032LiveSchema::test_comparisons_cache_dropped",
+    "tests/test_migration_032_b1_pre_hardening.py::TestMigration032LiveSchema::test_products_still_writable_via_service_role",
+    "tests/test_drug_database_service.py::TestFindMatchingDrugs::test_exact_trade_name_match",
+    "tests/test_drug_database_service.py::TestFindMatchingDrugs::test_partial_ingredient_match",
+    "tests/test_drug_database_service.py::TestFindMatchingDrugs::test_vitamin_d_search",
+    "tests/test_drug_database_service.py::TestFindMatchingDrugs::test_no_match_returns_empty",
+    "tests/test_drug_database_service.py::TestFindMatchingDrugs::test_limit_parameter",
+    "tests/test_drug_database_service.py::TestFindMatchingDrugs::test_result_fields",
+})
+
+_LIVE_TIER_SELECTION = "live_unit or live_db or integration"
+
+
+def _collect_nodeids(marker_expression):
+    """Node ids pytest really selects for `-m <marker_expression>`.
+
+    Runs `--collect-only` in a subprocess so the assertion goes through the
+    same collection path `pytest_collection_modifyitems` runs in -- the honest
+    oracle for "is this item in the live tier?", and one that a docstring
+    mentioning a marker name cannot satisfy.
+    """
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pytest",
+            *_SUPABASE_GUARDED_FILES,
+            "--collect-only", "-q",
+            "-m", marker_expression,
+            "-p", "no:cacheprovider",
+            "--timeout=45",
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        "collection failed for -m %r\n%s\n%s"
+        % (marker_expression, result.stdout[-3000:], result.stderr[-2000:])
+    )
+    collected = {
+        line.strip().replace("\\", "/")
+        for line in result.stdout.splitlines()
+        if "::" in line and line.strip().startswith("tests")
+    }
+    assert collected, (
+        "collected nothing for -m %r -- the oracle is not looking at anything"
+        % (marker_expression,)
+    )
+    return collected
+
+
 def test_supabase_live_db_guards_are_superseded_by_the_marker_hook():
     """The sentinel is safe only because the marker hook fires first.
 
-    `test_demographics_rls.py`, `test_migration_023.py`,
-    `test_migration_028_pain_workflow_events.py` and
-    `test_migration_032_b1_pre_hardening.py` gate on
-    `os.getenv("SUPABASE_URL") and ...` then `pytest.skip(...)` when absent.
-    A sentinel would defeat that guard on its own -- turning a clean skip into
-    a connection error -- so those suites must all carry a live-tier marker,
-    which the collection hook skips before their body can read the sentinel.
-    Under LIVE=1 both the hook and the sanitizer stand down and the guards see
-    the real values again.
-    """
-    from tests._env_safety import LIVE_TIER_MARKERS
+    Those modules gate on `os.getenv("SUPABASE_URL") and ...` then
+    `pytest.skip(...)` when it is absent. The sentinel makes that guard see a
+    truthy value, so a clean skip would become a live connection attempt --
+    unless the item carries a live-tier marker and the collection hook skips it
+    before the body runs. Under LIVE=1 both stand down and the guards see the
+    real values again.
 
-    guarded = (
-        "test_demographics_rls.py",
-        "test_migration_023.py",
-        "test_migration_028_pain_workflow_events.py",
-        "test_migration_032_b1_pre_hardening.py",
-        "test_drug_database_service.py",
+    Asserted by COLLECTING the five files under the live-tier marker expression
+    and checking every Supabase-touching node id is in that selection. `-m X`
+    and `-m "not X"` partition the same collection, so membership here is also
+    proof of absence from the default tier.
+    """
+    live_tier = _collect_nodeids(_LIVE_TIER_SELECTION)
+
+    unprotected = sorted(_SUPABASE_GUARDED_NODEIDS - live_tier)
+    assert not unprotected, (
+        "these Supabase-touching tests are NOT in the live tier, so the "
+        "collection hook cannot protect them from the sentinel and a default "
+        "`pytest tests/` would run them against a real project: "
+        + ", ".join(unprotected)
     )
-    marker_decorators = tuple(f"pytest.mark.{m}" for m in LIVE_TIER_MARKERS)
-    for file_name in guarded:
-        source = (_REPO_ROOT / "tests" / file_name).read_text(encoding="utf-8")
-        assert any(dec in source for dec in marker_decorators), (
-            f"{file_name} reads SUPABASE_* but carries no live-tier marker, so "
-            "the collection hook cannot protect it from the sentinel"
-        )
+
+
+def test_no_supabase_guarded_test_is_reachable_from_the_default_tier():
+    """The same claim from the other side, and it catches new-test drift.
+
+    `tests/test_demographics_rls.py` marks the WHOLE module
+    (`pytestmark = pytest.mark.live_db`), so a test added there without a
+    marker cannot exist: assert the default tier collects nothing at all from
+    it. For the mixed modules, assert none of the known Supabase node ids has
+    slipped into the default selection.
+    """
+    default_tier = _collect_nodeids("not (%s)" % _LIVE_TIER_SELECTION)
+
+    leaked = sorted(_SUPABASE_GUARDED_NODEIDS & default_tier)
+    assert not leaked, (
+        "Supabase-touching tests are selected by the DEFAULT tier: "
+        + ", ".join(leaked)
+    )
+
+    escaped = sorted(
+        node
+        for node in default_tier
+        if node.startswith("tests/test_demographics_rls.py::")
+    )
+    assert not escaped, (
+        "tests/test_demographics_rls.py is live_db at module scope; these "
+        "items escaped that marker: " + ", ".join(escaped)
+    )
 
 
 def test_live_tier_markers_are_skipped_without_the_opt_in():
@@ -348,29 +524,43 @@ def test_marker_tier_probe():
     raise AssertionError("must never execute without the LIVE opt-in")
 
 
-def test_live_opt_in_restores_the_environment_end_to_end():
-    """LIVE=1 through the REAL conftest: the tier runs and the values survive.
+def test_live_opt_in_restores_the_environment_end_to_end(tmp_path):
+    """LIVE=1 through the REAL conftest: the tier runs and the value survives.
 
     The pure-function test above covers the predicate; this one covers the
     wiring, which is where a sanitizer usually breaks a marker tier. Probes
     `SENTRY_DSN` because it is the cheapest var to prove: stripped by default,
     and never touched by any network call in the probe body.
+
+    Deliberately HERMETIC. `LIVE=1` means "give this process real credentials",
+    and this test is part of the DEFAULT suite -- spawning a fully credentialled
+    child from a plain `pytest tests/` would mean any future import side effect
+    in `conftest.py` runs against production. So the child runs with `cwd` on a
+    scratch dir (no `.env` for `load_dotenv` to find), inherits only this
+    process's already-sanitized environment, and gets one injected sentinel DSN.
+    That is also the sharper assertion: the DSN it sees can only have survived
+    because `LIVE=1` stood the sanitizer down.
     """
     probe_dsn = "https://opt-in-probe@example.invalid/1"
     result = subprocess.run(
         [
             sys.executable, "-m", "pytest",
-            "tests/test_conftest_env_safety.py::test_live_opt_in_probe",
+            str(Path(__file__).resolve()) + "::test_live_opt_in_probe",
             "-m", "live_unit",
             "-p", "no:cacheprovider",
             "--timeout=45",
             "-rs", "-q",
         ],
-        cwd=str(_REPO_ROOT),
+        cwd=str(tmp_path),
         capture_output=True,
         text=True,
         timeout=300,
-        env={**os.environ, "LIVE": "1", "SENTRY_DSN": probe_dsn},
+        env={
+            **os.environ,
+            "LIVE": "1",
+            "SENTRY_DSN": probe_dsn,
+            "PYTHONPATH": str(_REPO_ROOT),
+        },
     )
     assert "1 passed" in result.stdout, result.stdout[-3000:]
 

--- a/tests/test_conftest_env_safety.py
+++ b/tests/test_conftest_env_safety.py
@@ -35,6 +35,30 @@ from pathlib import Path
 
 import pytest
 
+from tests._env_safety import live_mode_enabled
+
+# --- run-mode guards -------------------------------------------------------
+#
+# Most of this file asserts what a DEFAULT (non-LIVE) test process sees. That
+# contract deliberately does not hold under the LIVE=1 opt-in, so those tests
+# SKIP there rather than fail — otherwise the whole-suite command this very
+# commit documents (`LIVE=1 python -m pytest tests/`) could never pass, and a
+# doc that prescribes an impossible command is worse than no doc.
+_DEFAULT_TIER_ONLY = pytest.mark.skipif(
+    live_mode_enabled(),
+    reason="asserts the default (non-LIVE) credential contract; LIVE=1 opts out of it",
+)
+
+# The two marker probes below exist only to be collected by a subprocess in
+# this file. They must never execute in an ordinary run: one raises by design,
+# and the other asserts an environment only its own subprocess arranges. The
+# subprocesses set this variable; nothing else does.
+_PROBE_ENV = "QAREN_ENV_SAFETY_PROBE"
+_PROBE_ONLY = pytest.mark.skipif(
+    os.getenv(_PROBE_ENV) != "1",
+    reason="probe fixture — only meaningful inside its own subprocess",
+)
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # Every credential / production-endpoint variable that must NOT be visible to
@@ -71,6 +95,7 @@ _CONTRACT_SENTINEL = (
 )
 
 
+@_DEFAULT_TIER_ONLY
 def test_production_credentials_are_absent_by_default():
     """No credential-bearing env var still holds its production value.
 
@@ -116,6 +141,7 @@ def test_production_credentials_are_absent_by_default():
     )
 
 
+@_DEFAULT_TIER_ONLY
 def test_no_dotenv_value_is_live_in_the_process():
     """Sharper oracle: no var still holds the literal value from the real `.env`.
 
@@ -141,6 +167,7 @@ def test_no_dotenv_value_is_live_in_the_process():
     )
 
 
+@_DEFAULT_TIER_ONLY
 @pytest.mark.parametrize("name", _CONTRACT_SENTINEL)
 def test_present_but_unusable_vars_hold_the_sentinel(name):
     """The vars that must stay PRESENT resolve to the fake, not the real value.
@@ -226,6 +253,7 @@ def test_sentinel_hosts_really_do_not_resolve_here():
     )
 
 
+@_DEFAULT_TIER_ONLY
 def test_later_load_dotenv_cannot_reinject_credentials():
     """`load_dotenv(override=True)` from app modules must not undo the fix.
 
@@ -508,11 +536,17 @@ def test_live_tier_markers_are_skipped_without_the_opt_in():
         capture_output=True,
         text=True,
         timeout=300,
+        # The probe is _PROBE_ONLY-gated so it can never fire in an ordinary
+        # run; this subprocess is the one caller allowed to reach it. LIVE is
+        # cleared explicitly so the assertion holds even when the PARENT run
+        # was invoked with LIVE=1.
+        env={**os.environ, _PROBE_ENV: "1", "LIVE": ""},
     )
     assert "1 skipped" in result.stdout, result.stdout[-3000:]
     assert "LIVE=1" in result.stdout, result.stdout[-3000:]
 
 
+@_PROBE_ONLY
 @pytest.mark.live_db
 def test_marker_tier_probe():
     """Probe used by `test_live_tier_markers_are_skipped_without_the_opt_in`.
@@ -557,6 +591,7 @@ def test_live_opt_in_restores_the_environment_end_to_end(tmp_path):
         timeout=300,
         env={
             **os.environ,
+            _PROBE_ENV: "1",
             "LIVE": "1",
             "SENTRY_DSN": probe_dsn,
             "PYTHONPATH": str(_REPO_ROOT),
@@ -565,6 +600,7 @@ def test_live_opt_in_restores_the_environment_end_to_end(tmp_path):
     assert "1 passed" in result.stdout, result.stdout[-3000:]
 
 
+@_PROBE_ONLY
 @pytest.mark.live_unit
 def test_live_opt_in_probe():
     """Probe for `test_live_opt_in_restores_the_environment_end_to_end`.

--- a/tests/test_conftest_env_safety.py
+++ b/tests/test_conftest_env_safety.py
@@ -1,0 +1,409 @@
+"""Issue #48 — the default test tier must never carry production credentials.
+
+`tests/conftest.py` calls `load_dotenv(override=True)`, so a local
+`pytest tests/` used to inherit the developer's REAL Sentry DSN, Upstash
+token, Supabase service key, OpenAI key and Serper key. Two of those reach
+production at IMPORT time, before any fixture can intervene:
+
+  * `app/main.py` calls `init_sentry()` at module scope, and
+    `sentry_service.init_sentry()` initialises the real SDK whenever
+    `SENTRY_DSN` is non-empty -> test exceptions land in the production
+    Sentry stream.
+  * `app/services/cache_service.py` builds the Upstash client at module
+    scope from `UPSTASH_REDIS_URL` / `UPSTASH_REDIS_TOKEN` -> a test that
+    forgets to mock READS AND WRITES the shared production cache that the
+    warmer and live users read. `tests/test_algolia_catalog_stores.py:38-48`
+    already documents a suite going RED because of exactly this.
+
+Clearing the vars in `conftest.py` is necessary but NOT sufficient:
+`app/main.py:11`, `app/services/extraction_service.py:5` and
+`app/services/url_extraction_service.py:6` each call
+`load_dotenv(override=True)` themselves at import, which would re-inject
+the real values on top of the sanitized ones. Hence the dotenv guard.
+
+The contract list below is deliberately duplicated from
+`tests/_env_safety.py` rather than imported: it states what the suite
+PROMISES, independent of how the sanitizer happens to be implemented.
+`test_helper_covers_the_whole_contract` catches drift.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Every credential / production-endpoint variable that must NOT be visible to
+# a default (non-LIVE) test process. Absence is the safe state for all of
+# these: every consumer reads them via `os.getenv(...)` and falls to a
+# documented disabled branch, and the live_db suites skip on their absence.
+_CONTRACT_UNSET = (
+    "SENTRY_DSN",
+    "UPSTASH_REDIS_URL",
+    "UPSTASH_REDIS_TOKEN",
+    "OPENAI_API_KEY_PRIVATE",
+    "OPENAI_BASE_URL",
+    "SERPER_API_KEY",
+    "SERPER_API_KEYS",
+    "FIRECRAWL_API_KEY",
+    "SCRAPEDO_API_TOKEN",
+    "BRIGHTDATA_API_KEY",
+    "BRIGHTDATA_ZONE",
+    "ZYTE_API_KEY",
+    "ADMIN_API_KEY",
+    "NASSER_GUEST_TOKEN",
+    "TARGET_BASE_URL",
+)
+
+# Variables that must stay PRESENT but unusable, because absence would break a
+# legitimately offline test rather than disable anything. Every host is under
+# RFC 2606's reserved `.invalid` TLD and can never resolve.
+_CONTRACT_SENTINEL = (
+    "OPENAI_API_KEY",
+    "SUPABASE_URL",
+    "SUPABASE_ANON_KEY",
+    "SUPABASE_SERVICE_KEY",
+    "YOUTUBE_API_KEY",
+)
+
+
+def test_production_credentials_are_absent_by_default():
+    """No credential-bearing env var survives collection without LIVE=1.
+
+    Asserted against the snapshot the sanitizer took at conftest import, which
+    is the moment that matters: `app.main` (init_sentry) and `cache_service`
+    (module-level Upstash client) are imported during collection. Live
+    `os.environ` is the wrong oracle here -- individual tests legitimately
+    install fakes of their own (e.g. `test_analytics.py:245` assigns
+    `ADMIN_API_KEY = "test-admin-key-123"` with no teardown), which would make
+    this assertion order-dependent.
+
+    Fails loudly on a developer machine with a populated `.env` until the
+    conftest sanitizer lands. Names only in the message -- never values.
+    """
+    from tests._env_safety import COLLECTION_SNAPSHOT
+
+    assert os.getenv("LIVE") is None, (
+        "This test asserts the DEFAULT tier; re-run without LIVE set."
+    )
+    assert COLLECTION_SNAPSHOT, "sanitizer never ran against the real environment"
+    leaked = [name for name in _CONTRACT_UNSET if COLLECTION_SNAPSHOT.get(name)]
+    assert not leaked, (
+        "production credentials leaked into the test process: "
+        + ", ".join(leaked)
+    )
+
+
+def test_no_dotenv_value_is_live_in_the_process():
+    """Sharper oracle: no var still holds the literal value from the real `.env`.
+
+    Order-independent in the other direction -- a test that installs its own
+    obvious fake does not trip this, but a real credential does. Compares
+    against `.env` without ever putting a value in an assertion message.
+    """
+    from dotenv import dotenv_values
+
+    env_file = _REPO_ROOT / ".env"
+    if not env_file.is_file():
+        pytest.skip("no .env on this machine (CI) -- nothing could leak")
+
+    real = dotenv_values(env_file)
+    watched = (*_CONTRACT_UNSET, *_CONTRACT_SENTINEL)
+    leaked = [
+        name
+        for name in watched
+        if real.get(name) and os.getenv(name) == real[name]
+    ]
+    assert not leaked, (
+        "the real .env value is live in this process for: " + ", ".join(leaked)
+    )
+
+
+@pytest.mark.parametrize("name", _CONTRACT_SENTINEL)
+def test_present_but_unusable_vars_hold_the_sentinel(name):
+    """The vars that must stay PRESENT resolve to the fake, not the real value.
+
+    `OPENAI_API_KEY`: `app/services/openai_service.py:20` builds
+    `AsyncOpenAI(...)` at module import and raises `OpenAIError` on a missing
+    key, so popping it would break `import app.main` for the whole suite.
+    `SUPABASE_*`: `create_client()` is a pure constructor, and dozens of
+    offline tests build a service whose `__init__` calls
+    `get_admin_supabase_client()` (e.g. `AbuseDetectionService.__init__`)
+    before mocking every query -- popping those three fails ~80 tests that
+    never touch the network.
+    """
+    from tests._env_safety import CREDENTIAL_PLACEHOLDERS
+
+    value = os.getenv(name)
+    assert value, f"{name} must stay non-empty"
+    assert value == CREDENTIAL_PLACEHOLDERS[name], (
+        f"{name} is not the test sentinel -- the real value is live in this "
+        "process"
+    )
+
+
+def test_sentinel_hosts_can_never_resolve():
+    """Any unmocked call against a sentinel fails locally, never in production.
+
+    `.invalid` is reserved by RFC 2606 and is guaranteed not to resolve, so a
+    query that slips past its mock errors instantly instead of reaching a real
+    Supabase project.
+    """
+    from tests._env_safety import CREDENTIAL_PLACEHOLDERS
+
+    for name, value in CREDENTIAL_PLACEHOLDERS.items():
+        if "://" in value:
+            assert value.split("://", 1)[1].split("/")[0].endswith(".invalid"), (
+                f"{name} sentinel must point at a reserved .invalid host"
+            )
+
+
+def test_later_load_dotenv_cannot_reinject_credentials():
+    """`load_dotenv(override=True)` from app modules must not undo the fix.
+
+    Three app modules call it at import time. Without the guard, importing
+    `app.services.extraction_service` restores every real credential before
+    `cache_service` reads `UPSTASH_REDIS_URL` at ITS import -- and the
+    module-level Upstash client points at production again.
+    """
+    import dotenv
+
+    dotenv.load_dotenv(override=True)
+
+    leaked = [name for name in _CONTRACT_UNSET if os.getenv(name)]
+    assert not leaked, (
+        "load_dotenv re-injected production credentials: " + ", ".join(leaked)
+    )
+
+
+def test_helper_covers_the_whole_contract():
+    """The sanitizer's own list must not drift below the promised contract."""
+    from tests._env_safety import CREDENTIALS_UNSET
+
+    missing = sorted(set(_CONTRACT_UNSET) - set(CREDENTIALS_UNSET))
+    assert not missing, f"sanitizer no longer clears: {missing}"
+
+
+def test_live_opt_in_preserves_real_values():
+    """LIVE=1 is the opt-in the live_unit / live_db / integration tiers need.
+
+    Exercised against a throwaway mapping so the real process environment is
+    never mutated (re-importing conftest mid-session is not possible).
+    """
+    from tests._env_safety import neutralize_credentials
+
+    env = {
+        "LIVE": "1",
+        "SUPABASE_URL": "https://real.supabase.co",
+        "UPSTASH_REDIS_TOKEN": "real-token",
+        "OPENAI_API_KEY": "sk-real-key",
+    }
+    before = dict(env)
+
+    changed = neutralize_credentials(env)
+
+    assert changed == {}, "sanitizer must be a no-op under the LIVE opt-in"
+    assert env == before, "LIVE=1 must leave the real .env values untouched"
+
+
+@pytest.mark.parametrize("live_value", ["0", "false", "", "no"])
+def test_non_truthy_live_values_do_not_opt_in(live_value):
+    """A half-set LIVE must not be read as an opt-in."""
+    from tests._env_safety import neutralize_credentials
+
+    env = {"LIVE": live_value, "UPSTASH_REDIS_URL": "https://real.upstash.io"}
+
+    neutralize_credentials(env)
+
+    assert "UPSTASH_REDIS_URL" not in env
+
+
+def test_sanitizer_clears_credentials_and_places_the_sentinels():
+    """The default path: secrets popped, the two present-but-fake vars replaced."""
+    from tests._env_safety import CREDENTIAL_PLACEHOLDERS, neutralize_credentials
+
+    env = {
+        "SENTRY_DSN": "https://real@sentry.io/1",
+        "UPSTASH_REDIS_URL": "https://real.upstash.io",
+        "SUPABASE_URL": "https://real.supabase.co",
+        "OPENAI_API_KEY": "sk-real-key",
+        "ENABLE_COHORT_PERSONALIZATION": "true",
+    }
+
+    changed = neutralize_credentials(env)
+
+    assert "SENTRY_DSN" not in env
+    assert "UPSTASH_REDIS_URL" not in env
+    assert changed["UPSTASH_REDIS_URL"] is None
+    for name, placeholder in CREDENTIAL_PLACEHOLDERS.items():
+        assert env[name] == placeholder
+        assert changed[name] == placeholder
+    assert env["ENABLE_COHORT_PERSONALIZATION"] == "true"
+
+
+def test_sanitizer_never_touches_feature_flags():
+    """`ENABLE_*` semantics are load-bearing (conftest.py:14 / :19).
+
+    The two `os.environ.setdefault` lines encode flag-OFF-in-production; the
+    sanitizer must not clear or invent any `ENABLE_*` variable.
+    """
+    from tests._env_safety import CREDENTIAL_PLACEHOLDERS, CREDENTIALS_UNSET
+
+    touched = sorted(
+        name
+        for name in (*CREDENTIALS_UNSET, *CREDENTIAL_PLACEHOLDERS)
+        if name.startswith("ENABLE_")
+    )
+    assert not touched, f"sanitizer must not manage feature flags: {touched}"
+
+
+def test_conftest_feature_flag_defaults_still_resolve_true():
+    """The setdefault lines survive the sanitizer running before them."""
+    assert os.getenv("ENABLE_COHORT_PERSONALIZATION") == "true"
+    assert os.getenv("ENABLE_REFERRAL_SYSTEM") == "true"
+
+
+def test_the_two_lists_are_disjoint():
+    """A var is either cleared or sentinelled -- never both, never neither."""
+    from tests._env_safety import CREDENTIAL_PLACEHOLDERS, CREDENTIALS_UNSET
+
+    overlap = sorted(set(CREDENTIALS_UNSET) & set(CREDENTIAL_PLACEHOLDERS))
+    assert not overlap, f"var is in both lists: {overlap}"
+
+
+def test_supabase_live_db_guards_are_superseded_by_the_marker_hook():
+    """The sentinel is safe only because the marker hook fires first.
+
+    `test_demographics_rls.py`, `test_migration_023.py`,
+    `test_migration_028_pain_workflow_events.py` and
+    `test_migration_032_b1_pre_hardening.py` gate on
+    `os.getenv("SUPABASE_URL") and ...` then `pytest.skip(...)` when absent.
+    A sentinel would defeat that guard on its own -- turning a clean skip into
+    a connection error -- so those suites must all carry a live-tier marker,
+    which the collection hook skips before their body can read the sentinel.
+    Under LIVE=1 both the hook and the sanitizer stand down and the guards see
+    the real values again.
+    """
+    from tests._env_safety import LIVE_TIER_MARKERS
+
+    guarded = (
+        "test_demographics_rls.py",
+        "test_migration_023.py",
+        "test_migration_028_pain_workflow_events.py",
+        "test_migration_032_b1_pre_hardening.py",
+        "test_drug_database_service.py",
+    )
+    marker_decorators = tuple(f"pytest.mark.{m}" for m in LIVE_TIER_MARKERS)
+    for file_name in guarded:
+        source = (_REPO_ROOT / "tests" / file_name).read_text(encoding="utf-8")
+        assert any(dec in source for dec in marker_decorators), (
+            f"{file_name} reads SUPABASE_* but carries no live-tier marker, so "
+            "the collection hook cannot protect it from the sentinel"
+        )
+
+
+def test_live_tier_markers_are_skipped_without_the_opt_in():
+    """A live_unit/live_db/integration test must never pass vacuously.
+
+    Without LIVE=1 the credentials are gone, so a live-tier test would
+    either fail with a confusing 401 or -- worse -- pass without touching
+    anything live. The collection hook turns that into an explicit skip
+    naming the opt-in, which is the same posture the live_db suites already
+    take when the Supabase vars are missing.
+    """
+    from tests._env_safety import LIVE_TIER_MARKERS
+
+    assert set(LIVE_TIER_MARKERS) == {"live_unit", "live_db", "integration"}
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pytest",
+            "tests/test_conftest_env_safety.py::test_marker_tier_probe",
+            "-m", "live_db",
+            "-p", "no:cacheprovider",
+            "--timeout=45",
+            "-rs", "-q",
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert "1 skipped" in result.stdout, result.stdout[-3000:]
+    assert "LIVE=1" in result.stdout, result.stdout[-3000:]
+
+
+@pytest.mark.live_db
+def test_marker_tier_probe():
+    """Probe used by `test_live_tier_markers_are_skipped_without_the_opt_in`.
+
+    Deselected by the default `-m "not (live_unit or live_db or integration)"`
+    selection; only ever reached by the subprocess above, where the collection
+    hook must skip it before the body can run.
+    """
+    raise AssertionError("must never execute without the LIVE opt-in")
+
+
+def test_live_opt_in_restores_the_environment_end_to_end():
+    """LIVE=1 through the REAL conftest: the tier runs and the values survive.
+
+    The pure-function test above covers the predicate; this one covers the
+    wiring, which is where a sanitizer usually breaks a marker tier. Probes
+    `SENTRY_DSN` because it is the cheapest var to prove: stripped by default,
+    and never touched by any network call in the probe body.
+    """
+    probe_dsn = "https://opt-in-probe@example.invalid/1"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pytest",
+            "tests/test_conftest_env_safety.py::test_live_opt_in_probe",
+            "-m", "live_unit",
+            "-p", "no:cacheprovider",
+            "--timeout=45",
+            "-rs", "-q",
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={**os.environ, "LIVE": "1", "SENTRY_DSN": probe_dsn},
+    )
+    assert "1 passed" in result.stdout, result.stdout[-3000:]
+
+
+@pytest.mark.live_unit
+def test_live_opt_in_probe():
+    """Probe for `test_live_opt_in_restores_the_environment_end_to_end`.
+
+    Reached only from that subprocess, where LIVE=1 must have suppressed both
+    the sanitizer and the collection-hook skip. Asserts truthiness rather than
+    an exact value so it holds whether the DSN came from the injected sentinel
+    or from a real `.env`.
+    """
+    assert os.getenv("SENTRY_DSN"), "LIVE=1 must leave the real environment intact"
+
+
+def test_app_main_still_imports_under_the_sentinels(tmp_path):
+    """`import app.main` must survive the neutralised environment.
+
+    Run in a subprocess (importing app.main into the running suite has
+    side effects other tests do not expect) whose cwd is a scratch dir, so
+    `load_dotenv()` inside `app/main.py` finds no `.env` to fall back on --
+    the sentinels from this process are all it gets.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import app.main; print('IMPORT_OK')"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+    )
+    assert "IMPORT_OK" in result.stdout, (
+        f"app.main failed to import\nstdout:\n{result.stdout[-2000:]}"
+        f"\nstderr:\n{result.stderr[-3000:]}"
+    )

--- a/tests/test_demographics_rls.py
+++ b/tests/test_demographics_rls.py
@@ -8,7 +8,12 @@ the user-scoped Supabase client. RLS quietly filters the row → empty result.
 
 Skipped automatically in the free unit test suite via the live_db marker.
 Run explicitly with:
-    pytest tests/test_demographics_rls.py -v -m live_db
+    LIVE=1 pytest tests/test_demographics_rls.py -v -m live_db
+
+`LIVE=1` is required, not optional: without it the credential sanitizer in
+`tests/_env_safety.py` has replaced SUPABASE_* with unusable sentinels and the
+collection hook skips every live_db item, so the bare `-m live_db` command
+reports `skipped` rather than running anything.
 """
 from __future__ import annotations
 

--- a/tests/test_drug_database_service.py
+++ b/tests/test_drug_database_service.py
@@ -6,7 +6,10 @@ Tests the Bahrain approved drugs lookup and GPT context formatting.
 Tests marked @pytest.mark.live_db require:
 - SUPABASE_URL and SUPABASE_SERVICE_KEY env vars pointing to a project
   with the bahrain_approved_drugs table populated.
-- Run with: pytest tests/test_drug_database_service.py -v -m live_db
+- LIVE=1. Without it the sanitizer in tests/_env_safety.py replaces SUPABASE_*
+  with unusable sentinels and the collection hook skips every live_db item, so
+  a bare `-m live_db` run reports `skipped` instead of testing anything.
+- Run with: LIVE=1 pytest tests/test_drug_database_service.py -v -m live_db
 - Skip live_db tests: pytest tests/test_drug_database_service.py -v -m "not live_db"
 """
 import pytest

--- a/tests/test_lane2_integration.py
+++ b/tests/test_lane2_integration.py
@@ -6,7 +6,9 @@ confidence-low) against live Railway and asserts:
 - Wall time stays under STREAM_HARD_CAP_SECONDS=25s
 - Confidence-driven escalation works for non-luxury categories
 
-Gated by `pytest -m integration`. Requires the deploy at
+Gated by `LIVE=1 pytest -m integration` (the marker alone no longer opts in --
+without `LIVE=1` the collection hook skips the tier, see tests/_env_safety.py).
+Requires the deploy at
 https://web-production-58776.up.railway.app/ to have:
 - ENABLE_FIRECRAWL=true
 - ENABLE_SCRAPEDO=true

--- a/tests/test_migration_023.py
+++ b/tests/test_migration_023.py
@@ -10,7 +10,9 @@ Two test classes:
 2. `TestMigration023LiveSchema` (`@pytest.mark.live_db`) — connects to Supabase
    via `get_admin_supabase_client()` and asserts the live schema matches.
    Skipped from the free unit suite via the live_db marker. Run with:
-       pytest tests/test_migration_023.py -v -m live_db
+       LIVE=1 pytest tests/test_migration_023.py -v -m live_db
+   (`LIVE=1` is required — without it the credential sanitizer in
+   tests/_env_safety.py is active and the collection hook skips the tier.)
 
 Reference:
 - docs/plans/2026-05-12-bundle-bcd-consolidated-design.md § 4.5

--- a/tests/test_migration_028_pain_workflow_events.py
+++ b/tests/test_migration_028_pain_workflow_events.py
@@ -270,7 +270,10 @@ def test_rollback_028_wraps_in_transaction():
 # idx_pwe_workflow_time replaced idx_pwe_recent (volatile predicate) + the
 # redundant idx_pwe_workflow_name. These assertions verify the LIVE prod
 # schema matches the corrected names, and that the removed indexes are gone.
-# Run with: pytest tests/test_migration_028_pain_workflow_events.py -m live_db
+# Run with:
+#   LIVE=1 pytest tests/test_migration_028_pain_workflow_events.py -m live_db
+# `LIVE=1` is required: without it the credential sanitizer is active and the
+# collection hook skips every live_db item (see tests/_env_safety.py).
 # ---------------------------------------------------------------------------
 
 import os  # noqa: E402 — kept local to the live_db section
@@ -297,7 +300,7 @@ REMOVED_INDEXES = {"idx_pwe_recent", "idx_pwe_workflow_name"}
 
 @pytest.mark.live_db
 class TestMigration028LiveSchema:
-    """Live Supabase assertions — run post-apply with `-m live_db`.
+    """Live Supabase assertions — run post-apply with `LIVE=1 ... -m live_db`.
 
     NOTE on index verification: the supabase-py / PostgREST client cannot read
     pg_indexes (no generic SQL surface), so index NAMES are verified out-of-band

--- a/tests/test_migration_032_b1_pre_hardening.py
+++ b/tests/test_migration_032_b1_pre_hardening.py
@@ -240,7 +240,11 @@ def _supabase_available() -> bool:
 
 @pytest.mark.live_db
 class TestMigration032LiveSchema:
-    """Live Supabase assertions — run post-apply with `-m live_db`."""
+    """Live Supabase assertions — run post-apply with `LIVE=1 ... -m live_db`.
+
+    `LIVE=1` is required: without it the credential sanitizer in
+    tests/_env_safety.py is active and the collection hook skips this tier.
+    """
 
     @pytest.fixture
     def admin_client(self):


### PR DESCRIPTION
Closes #48. Three commits: the implementation, a review round, and a fix for the last blocking finding.

## Why
`tests/conftest.py` loaded the real `.env` with `override=True`, so the default suite ran with **production credentials**. Concretely: `cache_service` builds a module-level Upstash client at import, so a test that forgets a mock reads and **writes the production cache** that live users and the warmer share; and `init_sentry()` runs on importing `app.main`, so test exceptions could report into the production Sentry stream. A full-suite run during the audit hit Serper 403 and OpenAI 429 from real network calls.

Credentials are now replaced with safe sentinels unless `LIVE=1` is set, and a collection hook skips `live_unit` / `live_db` / `integration` items without that opt-in so a live-tier test can never pass vacuously against sentinels.

## The headline result
Comparing this branch to main **with** a local `.env` is the wrong test — removing those credentials is the entire point. Against main **without** credentials, which is the environment CI actually runs in (and which reproduces the live CI count of **176 failures** exactly), over 449 shared test files:

| | failures |
|---|---|
| main, no credentials (= CI today) | **176** |
| this branch | **50** |
| branch-only-NEW | **0** |
| tests fixed vs CI | **126** |

35 of the remaining 50 are the RED-by-design `test_value_math` stubs that #86 (#49) contains — so **#48 + #49 together take CI from 176 failures to 15**.

## What review caught
1. **The leak-detection test could never detect a leak.** `COLLECTION_SNAPSHOT` was populated *after* sanitisation, so it was `None` by construction; the reviewer re-injected a real credential and watched the test still report `leaked = []`. A test that cannot fail is worse than no test here, because it broadcasts false assurance about production credentials. The record is now captured *before* the sanitiser runs, and stores fingerprints rather than plaintext.
2. **The Supabase marker guard was a substring scan** for `"pytest.mark.live_db"`, which the phrase in four module docstrings satisfied — deleting the real decorator left it green. Replaced with a real `--collect-only -m ...` subprocess asserting the 15 guarded node ids appear in the live selection.
3. **The doc fix prescribed commands that could not pass.** `LIVE=1 pytest tests/` pulled in this file, which under `LIVE=1` reported 11 failed / 16 passed. Fixed with two run-mode guards: tests asserting the default-tier contract skip under the opt-in (they still run, and can still fail, in the tier that protects credentials), and the two marker probes are gated to their own subprocesses.

## Verification
Default tier 25 passed / 2 skipped; `LIVE=1` 17 passed / 10 skipped. Both guards proven by injection, green → red → green: disabling `neutralize_credentials` makes the leak test fail; forcing `LIVE="1"` into the probe subprocess makes the skip-guard fail.

## Note for the merger
Two tests that pass on a developer machine today — `test_invitee_quiz.py::test_invalid_token_format_does_not_crash` and `test_supplement_branch_genuine.py::test_cde2_...` — pass **only because they reach live production Supabase**. On CI they already error. They are unchanged here and remain in the 50; making them hermetic is worth its own issue.