### PR TITLE
docs: replace the scraper desk-research verdict with a measured bake-off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,14 +446,30 @@ measured 78 — raise it to the number CI now reports.
 **TWO LIVE BLOCKERS (observed directly 2026-08-25):** Serper returns **403 Unauthorized** on every
 `/search`; OpenAI returns **429**. Nothing in the product works properly until both are restored.
 
-**SCRAPER TOOLING — evaluated and rejected 2026-08-25.** `Socialcrawl.dev` **resells Firecrawl**
-(its own status page says so) and is ~96% a social-media API. `crawl4ai`'s "undetected browser" IS
-patchright + playwright-stealth, and the one independent benchmark scores **curl_cffi 26 OK vs
-patchright 25 OK — the tool this repo already uses ranks higher**; its non-browser path is `aiohttp`
-(stock TLS), strictly worse than curl_cffi impersonation. Self-hosting the Akamai residual saves
-~$10/month in cash and costs $100-400/month in maintenance. **One idea worth stealing: Common Crawl
-as a discovery channel** (prototype natively, ~1 day). The win is DELETING Firecrawl/Scrape.do —
-Firecrawl's proxies are NL/US-only so it structurally cannot render a Bahrain-localised page.
+**SCRAPER TOOLING — MEASURED bake-off 2026-08-25 (not desk research).** 9 real registry targets, every
+contender judged by the repo's OWN `extract_price_from_html`. Scoreboard (priced/9): **curl_cffi 4,
+Scrape.do 4, crawl4ai default 4, crawl4ai+patchright 4, Firecrawl 0, Zyte 0 (account suspended).**
+Full write-up: `docs/investigations/2026-08-25-scraper-bakeoff.md`.
+- **`curl_cffi` READ sephora.me** — 200, zero `_abck`, JSON-LD **77.000 BHD**, 1.39s, free: the exact
+  price Zyte was procured for, while plain Playwright AND crawl4ai AND crawl4ai+patchright all got 403.
+  **ONE sample — not actionable.** #93 specifies 20+ samples over 24h from Railway egress before
+  retiring the Zyte tier. Do not rewire sephora on the strength of one lucky fetch.
+- **Firecrawl's 0/9 is OUR bug (#92, P1):** `firecrawl_service.py` hardcodes `formats:["html"]` =
+  Firecrawl's CLEANED html, which returns **0 script tags / 0 ld+json**. The extractor reads ld+json,
+  so the integration **cannot return a price on any page, ever**, while billing 1 credit each. With
+  `formats:["rawHtml"]` the same URL yields 1.400 BHD and is 5.4x faster. Firecrawl also 500s on both
+  controls curl cracks free, and returns **HTTP 200 + bills on a real 404**.
+- **crawl4ai — rejected on measurement.** Its patchright "undetected" mode was **byte-identical to
+  default on all 9 targets** and contributed zero, including both walled ones. It beat plain
+  Playwright on 1 of 9, purely via its default User-Agent — and crawl4ai under-rendered that page
+  into a confident-wrong "6.02 BHD" where bare Playwright returned the correct 16.0.
+- **Scrape.do — narrow keeper**, behind a "curl returned a WAF block" trigger only. Its single real
+  win was eros.ae (Link11 491, blocks curl+Playwright+crawl4ai). The other 3 duplicated free curl
+  results at 9-50x latency, two of them EXCEEDING the 15s live clock.
+- **Registry is wrong on 4 of 9 rows (#94):** `matalanme` + `xcite` are flagged `render-only` but
+  plain curl reads them in <1s, so they have been escalating to PAID render for free pages; `bfab`'s
+  sample_url is a category page; `letoile`'s is a 404. The registry needs a cleanup pass more than
+  the stack needs a vendor.
 
 
 A full audit of `main c630436` produced **GitHub issues #46–#81** (12 P1, 23 P2, 1 P3), each self-contained with verified `file:line`. Three are implemented and pushed, **no PRs opened, nothing merged, nothing deployed**: `fix/46-dependency-lock` (`d6c52ab`), `fix/58-model-config` (`b9e962e`), `fix/59-subtype-specs` (`48daac6`). Each passed the repo comm gate against `origin/main` with **branch-only-NEW == []**.

--- a/docs/investigations/2026-08-25-scraper-bakeoff.md
+++ b/docs/investigations/2026-08-25-scraper-bakeoff.md
@@ -1,0 +1,96 @@
+# Scraper bake-off — measured, not researched (2026-08-25)
+
+Nine real product pages from `data/bh_gcc_sources.json`, fetched once each by every contender, with
+**every contender's HTML judged by this repo's own `extract_price_from_html` / `extract_jsonld_price`.**
+The question was "did we get a PRICE", not "did we get HTML". Zero Serper; one attempt per
+(contender, target); no retries.
+
+This exists because prior desk research reached a conclusion and desk research is not evidence.
+
+## Scoreboard
+
+| Contender | Priced | Fetched | Cost / speed |
+|---|---|---|---|
+| **curl_cffi** (incumbent) | **4 / 9** | 7 / 9 | $0, median 0.70s |
+| Scrape.do | 4 / 9 | 6 / 9 | 35 credits, 9–50× slower |
+| crawl4ai 0.9.2 default | 4 / 9 | 7 / 9 | full browser tier |
+| crawl4ai 0.9.2 undetected (patchright) | 4 / 9 | 7 / 9 | **byte-identical to default** |
+| Firecrawl (as wired) | **0 / 9** | 5 / 9 | 6 credits burned |
+| Zyte | 0 / 10 | 0 / 10 | account suspended (403) |
+
+## Two findings that change decisions
+
+### 1. `curl_cffi` read sephora.me — the site Zyte was procured for → #93
+
+HTTP 200, 2.58 MB, **zero `_abck` / AkamaiGHost markers**, JSON-LD `priceCurrency BHD, price 77,
+InStock` — the identical **77.000 BHD** Zyte was feasibility-proven on in June — in **1.39s, free**.
+On the same target in the same run, plain Playwright, crawl4ai default, and crawl4ai+patchright
+**all** returned 403 / 331 bytes.
+
+**Not actionable yet: one sample, one non-GCC IP, stochastic anti-bot.** The repo's own lesson runs
+both ways — 9 of 11 "failures" in the Phase-1 promotion were one unlucky sample; one lucky sample is
+not a capability. #93 specifies 20+ samples over 24h from Railway egress, judged through the
+production adapter.
+
+### 2. Firecrawl's 0/9 is a bug in THIS repo → #92 (P1)
+
+`app/services/firecrawl_service.py` hardcodes `formats: ["html"]` — Firecrawl's *cleaned* HTML.
+Every successful fetch returned **0 `<script>` tags and 0 `ld+json` blocks**. The extractor reads
+`ld+json`. So the integration **cannot return a price on any page, ever, by construction**, while
+billing 1 credit per page.
+
+Controlled probe, same URL, `formats: ["rawHtml"]`: 615 KB, 158 scripts, 5 ld+json,
+**1.400 BHD — and 5.4× faster** (2.49s vs 13.48s).
+
+Firecrawl was also the least reliable fetcher on the panel: HTTP 500 on **both** controls curl
+cracks free (bolo, boutiqaat), 408 on sephora and eros, an empty 200 on ubuy, and **HTTP 200 +
+billed on a real 404** — it does not surface upstream 404s, so a dead registry row looks like a
+successful render.
+
+## Verdicts on the tools that were recommended
+
+**crawl4ai — rejected on measurement.** Its patchright "undetected" mode — the specific reason it is
+recommended for hard sites — was **byte-for-byte identical to default on all nine targets** and
+contributed exactly zero, including both walled ones. It beat plain Playwright on 1 of 9 (ubuy), and
+the entire cause was its default User-Agent (Playwright advertises `HeadlessChrome`). Copying two
+lines of UA + `sec-ch-ua` into bare Playwright reproduced the win **and returned the correct 16.0
+BHD**, where crawl4ai under-rendered the page into a confident-wrong "6.02 BHD" — the exact failure
+class this codebase exists to prevent. Adopting it buys a UA default for ~190 MB of dependency and a
+measured wrong-price regression.
+
+**Scrape.do — a narrow keeper.** One genuine win in nine: `eros.ae`, an HTTP 491 Link11 WAF that
+blocks curl, Playwright and crawl4ai alike — 8.6s, 5 credits, AED 3898.99. The other three duplicate
+free curl results at 9–50× the latency, and two of those (19.8s, 23.0s) **exceed the 15s live
+request clock**, so production could not have used them on-clock anyway. 26 of its 35 credits went
+to duplicating free results. It belongs behind a narrow "curl returned a WAF block" trigger, not in
+a general fan-out.
+
+**Zyte — unmeasurable.** All calls returned HTTP 403 in ~1s; the body reads `"Account Suspended…
+If you have reached your spending limit, increasing your spending limit will immediately lift your
+account suspension."` The key authenticates; the account is suspended. Sequence any revival **after**
+#93 — if curl holds sephora, that spend solves a solved problem.
+
+## Registry data is wrong on 4 of the 9 rows → #94
+
+- `matalanme.com` and `xcite.com` are flagged **`render-only`** but plain curl reads them in under a
+  second (1.400 BHD / 229.900 KWD). They have been escalating to the **paid** render wave for pages
+  that are free. The other 14 `render-only` rows deserve the same check.
+- `bfab.com`'s `sample_url` 308-redirects to a category listing, not a PDP.
+- `letoile.ae`'s `sample_url` is a dead 404.
+
+## Two smaller defects surfaced
+
+- **bolo.bh**: curl fetches it fine (200, correct PDP title) but its JSON-LD Offer publishes
+  `price "0.00"` with the real value in a non-schema JS blob. The extractor correctly refuses 0.00.
+  That is an adapter gap, not a scraping gap.
+- **xcite.com**: the PDP renders `itemprop=price 229.9` + `priceCurrency KWD`, and
+  `_extract_microdata_price` returns it in isolation, but `extract_price_from_html` returns `None`
+  because `_page_identity_ok` rejects under the `electronics` category across four query-name
+  variants. This zeroes every contender equally — an over-rejection worth its own look.
+
+## Bottom line
+
+The community advice does not survive measurement. The incumbent free path ties or beats every paid
+and open-source contender, including on the one target the render tier was bought for. **The
+registry needs a cleanup pass more than the stack needs a vendor**, and Firecrawl's score is
+self-inflicted by a one-word bug that should be fixed before any buy/keep decision is made about it.


### PR DESCRIPTION
Docs only. Nine real registry targets, one fetch each per contender, every contender's HTML judged by this repo's own `extract_price_from_html` — so the question is *did we get a price*, not *did we get HTML*.

**Priced out of 9:** curl_cffi **4** · Scrape.do **4** · crawl4ai default **4** · crawl4ai+patchright **4** · Firecrawl **0** · Zyte **0** (account suspended).

Two findings that change decisions:
- **curl_cffi read sephora.me** — 200, zero `_abck`, JSON-LD **77.000 BHD**, 1.39s, free: the exact price the Zyte tier was procured for, while plain Playwright, crawl4ai and crawl4ai+patchright all got 403. Recorded as **not actionable** — one sample, one IP, stochastic anti-bot. #93 specifies the multi-sample re-test.
- **Firecrawl's 0/9 is our bug** — `formats:["html"]` returns cleaned HTML with every script stripped, so no `ld+json` ever reaches the extractor and no price can ever be produced, at 1 credit/page. #92 (P1).

Also records that crawl4ai's patchright mode was byte-identical to its default on all nine targets, that Scrape.do earns its keep on exactly one row type, and that **4 of the 9 registry rows tested are wrong** — two flagged `render-only` while plain curl reads them in under a second (#94).