### PR TITLE
fix(fact-check): parse bare-numeral rows under the target currency (#106)

### DIFF
--- a/app/services/fact_check_service.py
+++ b/app/services/fact_check_service.py
@@ -447,7 +447,13 @@ def _verify_price_currency_normalized(
             # digits + junk the currency detector cannot resolve: basis unknown
             unresolved += 1
             continue
-        amount = parse_price_string(raw, detected, display_text=True)
+        # A bare numeral carries no currency signal, so it is read as already
+        # being in the TARGET currency (same rule the numeric-row branch above
+        # applies). It must be PARSED under that currency too: BHD has three
+        # decimals, so the ordinary Bahraini string "99.500" is 99.5 -- parsing
+        # it with no currency reads 99500.0 and inverts the verdict on a
+        # correct price. Same M13-10 canon as `BHD 12,500` -> 12.5.
+        amount = parse_price_string(raw, detected or target, display_text=True)
         if amount is None or amount <= 0:
             continue
         if detected and detected != target:

--- a/tests/test_fact_checking.py
+++ b/tests/test_fact_checking.py
@@ -645,6 +645,46 @@ class TestVerifyPriceCurrencyNormalization:
     +/-30% cross-check (flag ON), and degrade to a None verdict — never a
     confident one — when no row's currency basis can be resolved."""
 
+    def test_bare_numeral_rows_parse_under_the_target_currency(self, service, monkeypatch):
+        """A bare-numeral row must be parsed under the TARGET currency.
+
+        BHD carries three decimals, so `99.500` is the ordinary way a Bahraini
+        price is written -- and Bahrain is the primary market. Parsing it with
+        no currency hint reads it as 99500.0 (a 1000x error) and inverts the
+        verdict on a CORRECT price: the flag-ON path reported
+        price_verified False at 99.9% deviation for rows that match the final
+        price exactly. `parse_price_string("99.500", "BHD")` returns 99.5,
+        which is the same M13-10 canon CLAUDE.md pins for `BHD 12,500` -> 12.5.
+        """
+        monkeypatch.setenv("ENABLE_FACTCHECK_CURRENCY_NORMALIZATION", "true")
+        price = {"amount": 99.5, "currency": "BHD", "estimated": False}
+        rows = [{"price": "99.500"}, {"price": "99.500"}, {"price": "99.500"}]
+        result = service._verify_price(price, rows)
+        assert result["price_verified"] is True, (
+            "a bare-numeral BHD row matching the final price exactly must "
+            f"verify, got deviation {result['deviation_pct']}%"
+        )
+        assert result["deviation_pct"] == 0.0
+
+    def test_bare_numeral_thousands_group_parses_under_target(self, service, monkeypatch):
+        """`12,500` under a BHD target is 12.5, not 12500 (M13-10 canon)."""
+        monkeypatch.setenv("ENABLE_FACTCHECK_CURRENCY_NORMALIZATION", "true")
+        price = {"amount": 12.5, "currency": "BHD", "estimated": False}
+        rows = [{"price": "12,500"}, {"price": "12,500"}]
+        result = service._verify_price(price, rows)
+        assert result["price_verified"] is True
+        assert result["deviation_pct"] == 0.0
+
+    def test_bare_numeral_under_two_decimal_target_is_unchanged(self, service, monkeypatch):
+        """The fix must be per-currency, not a blanket re-parse: SAR has two
+        decimals, so `99.500` stays 99500.0 there and must NOT verify against
+        a 99.5 SAR final price. Guards against 'fix BHD, break everyone else'."""
+        monkeypatch.setenv("ENABLE_FACTCHECK_CURRENCY_NORMALIZATION", "true")
+        price = {"amount": 99.5, "currency": "SAR", "estimated": False}
+        rows = [{"price": "99.500"}, {"price": "99.500"}]
+        result = service._verify_price(price, rows)
+        assert result["price_verified"] is False
+
     def test_raw_foreign_amount_stamped_bhd_is_not_verified(self, service, monkeypatch):
         """A raw AED amount stamped BHD must NOT pass against AED rows."""
         monkeypatch.setenv("ENABLE_FACTCHECK_CURRENCY_NORMALIZATION", "true")


### PR DESCRIPTION
A one-line fix to the #106 implementation already on main (033052a, refined by b073918), which carried a **1000x parsing error in the app's primary market**.

Closes #106

## The defect, reproduced against main

With `ENABLE_FACTCHECK_CURRENCY_NORMALIZATION` on, three shopping rows of `99.500` cross-checked against a final price of **99.5 BHD** returned:

```
{'price_verified': False, 'deviation_pct': 99.9, 'source_count': 3}
```

A bare-numeral row carries no currency signal, so it reached `parse_price_string(raw, detected, ...)` with `detected=None`. BHD has three decimals, so:

- `parse_price_string("99.500", None)` -> **99500.0**
- `parse_price_string("99.500", "BHD")` -> **99.5**

`99.500` is the ordinary way a Bahraini price is written. Flipping this flag would have marked correct local prices as unverified — the check inverting its verdict on exactly the prices it exists to confirm.

## The fix

Pass `detected or target`, so a bare numeral is parsed under the same currency the surrounding code already assumes it is denominated in — the rule the numeric-row branch immediately above it already applies. It is the same M13-10 canon CLAUDE.md pins for `BHD 12,500` -> 12.5.

**Per-currency, not a blanket reparse.** A SAR (2-decimal) target still reads `99.500` as 99500 and still does not verify. That guard test was checked for vacuousness: reparsing the SAR row as-if-BHD would flip it green, so it genuinely discriminates.

## Accepted trade-off, stated plainly

A bare `"1,250"` genuinely meaning 1250 BHD now reads as 1.25. That is the repo's existing canon rather than a new defect — the *labeled* form `"BHD 1,250"` already parses to 1.25 on the unflagged shopping path, and the minor-unit rule measured 371/371 on the corpus. The shape it sacrifices (a >1000-BHD comma-grouped bare row with no decimals) is far rarer in the primary market than the shape it repairs.

## Gates

- **TDD red-first**: 2 of 3 tests red at base for the stated 99.9%-deviation reason; the SAR guard is green by design and documented as such.
- **Module-reference comm gate** over 105 files (selected by grepping the test tree for the changed symbols): base and head FAILED sets **identical**, `branch-only-NEW == []`. The 5 failures are known pre-existing baseline reds.
- **Flag-OFF untouched** — the change lives entirely inside the flag-ON branch.
- **Byte-identity N/A** — `fact_check_service` is not in the price-extraction path.
- **Independent Fable verification: SHIP**, including an adversarial sweep over 0/2/3-decimal targets, unknown currencies, missing/empty `currency`, mixed bare+tagged rows, and Arabic-Indic digits.

Found by the M18 review's verification chain: a parallel implementation of #106 was rejected at its gate for this defect, and the prediction was then confirmed against the version already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)