### PR TITLE
M21 wave 1 — two live breakages + four small wins (M18 P2/P3)

### DIFF
--- a/SmartCompareApp/__tests__/ContactUsScreen.test.tsx
+++ b/SmartCompareApp/__tests__/ContactUsScreen.test.tsx
@@ -8,6 +8,12 @@
  * - submit POSTs to /api/v1/feedback with the category encoded inline in
  *   change_suggestion (operators grep `[Bug]%` etc. without backend schema
  *   changes)
+ * - M18 CD-uncovered-02 / MB-flows-09: the prefix is the STABLE ENGLISH enum
+ *   tag, never the localized label — the `t` mock below returns raw keys
+ *   (a stand-in for any non-English locale), so these tests fail if the
+ *   prefix is ever derived from t() again. Also: `useful` derives from the
+ *   category (bug -> false), and MAX_MESSAGE fits the backend's 1000-char
+ *   change_suggestion cap so nothing is silently truncated.
  * - success state replaces the form
  * - "Send another" returns to the form
  * - rate-limit guard prevents a 2nd submission within RATE_LIMIT_MS
@@ -83,7 +89,7 @@ describe('ContactUsScreen', () => {
     expect(node?.props.accessibilityState.disabled).toBe(true);
   });
 
-  it('selecting a non-default category routes the prefix into change_suggestion', async () => {
+  it('selecting a non-default category routes the STABLE ENGLISH prefix into change_suggestion', async () => {
     const { getByPlaceholderText, getByText } = renderScreen();
     fireEvent.press(getByText('contact.category.suggestion'));
     fireEvent.changeText(
@@ -93,15 +99,20 @@ describe('ContactUsScreen', () => {
     fireEvent.press(getByText('contact.submit'));
 
     await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    // The t mock returns raw keys — if the prefix were localized (built from
+    // t()), it would be "[contact.category.suggestion]" here, which is exactly
+    // the Arabic-cohort triage-loss bug. It must be the English enum tag.
     expect(mockPost).toHaveBeenCalledWith(
       '/api/v1/feedback',
       expect.objectContaining({
-        change_suggestion: expect.stringMatching(/^\[contact\.category\.suggestion\] /),
+        // Suggestion/business/other contact is not a negative signal
+        useful: true,
+        change_suggestion: expect.stringMatching(/^\[Suggestion\] /),
       }),
     );
   });
 
-  it('POSTs to /api/v1/feedback with category prefix in change_suggestion', async () => {
+  it('POSTs to /api/v1/feedback with the stable [Bug] prefix regardless of locale', async () => {
     const { getByPlaceholderText, getByText } = renderScreen();
     fireEvent.changeText(
       getByPlaceholderText('contact.message.placeholder'),
@@ -113,11 +124,40 @@ describe('ContactUsScreen', () => {
     expect(mockPost).toHaveBeenCalledWith(
       '/api/v1/feedback',
       expect.objectContaining({
-        useful: true,
+        // A bug report must not register as positive feedback
+        useful: false,
         mattered_most: [],
-        change_suggestion: expect.stringMatching(/^\[contact\.category\.bug\] /),
+        change_suggestion: expect.stringMatching(/^\[Bug\] /),
       }),
     );
+  });
+
+  it('message input cap matches what survives the backend 1000-char limit (no silent truncation)', () => {
+    const { getByPlaceholderText, getByText } = renderScreen();
+    // Backend FeedbackRequest.change_suggestion has max_length=1000.
+    // Worst-case overhead: "[Suggestion] " (13) + subject 120 + "\n\n" (2) = 135,
+    // so the honest message cap is 865 — not the old 2000, which silently
+    // dropped up to ~1135 chars of a long report.
+    const messageInput = getByPlaceholderText('contact.message.placeholder');
+    expect(messageInput.props.maxLength).toBe(865);
+    // The char counter must advertise the same honest cap
+    expect(getByText('0 / 865')).toBeTruthy();
+  });
+
+  it('a max-length report with a max-length subject survives untruncated', async () => {
+    const { getByPlaceholderText, getByText } = renderScreen();
+    const subject = 's'.repeat(120);
+    const body = 'b'.repeat(865);
+    fireEvent.changeText(getByPlaceholderText('contact.subject.placeholder'), subject);
+    fireEvent.changeText(getByPlaceholderText('contact.message.placeholder'), body);
+    fireEvent.press(getByText('contact.submit'));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    const payload = mockPost.mock.calls[0][1];
+    // Fits the backend cap AND the full body arrived intact — no silent slice
+    expect(payload.change_suggestion.length).toBeLessThanOrEqual(1000);
+    expect(payload.change_suggestion.endsWith(body)).toBe(true);
+    expect(payload.change_suggestion.startsWith(`[Bug] ${subject}`)).toBe(true);
   });
 
   it('replaces the form with success state after a successful submission', async () => {

--- a/SmartCompareApp/__tests__/InviteeQuizScreen.matchScore.m18.test.tsx
+++ b/SmartCompareApp/__tests__/InviteeQuizScreen.matchScore.m18.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * M18 MB-contract-10 (InviteeQuiz half) — the match score must come from the
+ * REAL scoring payload, not a phantom key.
+ *
+ * Backend `scoring` block emits {scores: {product_N: {overall, ...}}, ...}
+ * (response_builder.py:1557-1564) and run_invitee_quiz returns the sanitized
+ * comparison payload with that same block tagged scoring_method:'invitee_quiz'
+ * (referral_service.py). There is NO `scoring.products` key on any backend
+ * shape — so `result?.scoring?.products ?? []` always fell through to the
+ * hardcoded 78 and every invitee saw a fabricated match score.
+ *
+ * Mock block mirrors InviteeQuizScreen.test.tsx.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import InviteeQuizScreen from '../src/screens/InviteeQuizScreen';
+
+jest.mock('react-native-reanimated', () => {
+  const RealRN = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View: RealRN.View,
+      Text: RealRN.Text,
+      Image: RealRN.Image,
+      ScrollView: RealRN.View,
+      createAnimatedComponent: <P,>(C: any) => C,
+    },
+    FadeIn: { duration: () => ({ delay: () => ({}) }), delay: () => ({}) },
+    FadeInDown: {
+      duration: () => ({ delay: () => ({}) }),
+      delay: () => ({ duration: () => ({}) }),
+    },
+    useSharedValue: (init: any) => ({ value: init }),
+    useAnimatedStyle: (fn: any) => fn(),
+    useAnimatedReaction: (_p: any, _r: any) => undefined,
+    useDerivedValue: (fn: any) => ({ value: fn() }),
+    interpolate: (_v: number, _i: number[], o: number[]) => o[0],
+    withTiming: (v: any) => v,
+    withSpring: (v: any) => v,
+    withRepeat: (a: any) => a,
+    withDelay: (_: any, a: any) => a,
+    withSequence: (...a: any[]) => a[a.length - 1],
+    runOnJS: (fn: any) => fn,
+    Easing: {
+      inOut: () => (t: number) => t,
+      out: () => (t: number) => t,
+      ease: (t: number) => t,
+      cubic: (t: number) => t,
+      bezier: () => (t: number) => t,
+    },
+  };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, any>) => {
+      if (opts) {
+        const argSummary = Object.entries(opts)
+          .filter(([k]) => k !== 'defaultValue')
+          .map(([, v]) => v)
+          .join('|');
+        return `${key}|${argSummary}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+const mockSubmitInviteeQuiz = jest.fn();
+
+jest.mock('../src/services/referralService', () => ({
+  submitInviteeQuiz: (...args: any[]) => mockSubmitInviteeQuiz(...args),
+  ReferralError: class extends Error {
+    code: string;
+    status: number | null;
+    constructor(message: string, code: string, status: number | null) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  },
+}));
+
+const mockNavigation: any = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  reset: jest.fn(),
+};
+
+const baseRoute: any = {
+  params: {
+    share_token: 'tok-123',
+    invite_id: 'invite-uuid-1',
+    ref: 'QR-ABCDEF',
+  },
+};
+
+/** Real backend shape: scoring.scores.product_N.overall (no scoring.products). */
+const RESULT_WITH_SCORING = {
+  overview: {
+    winner: {
+      product_index: 1,
+      name: 'Galaxy S24',
+      reason: 'Better camera for your priority.',
+    },
+  },
+  scoring: {
+    scoring_method: 'invitee_quiz',
+    scores: {
+      product_0: { overall: 55.2, breakdown: {}, weights_used: {} },
+      product_1: { overall: 91.4, breakdown: {}, weights_used: {} },
+    },
+  },
+};
+
+const RESULT_WITHOUT_SCORING = {
+  overview: {
+    winner: {
+      product_index: 0,
+      name: 'iPhone 15',
+      reason: 'Simpler for you.',
+    },
+  },
+};
+
+async function walkToResult(payload: any) {
+  mockSubmitInviteeQuiz.mockResolvedValueOnce(payload);
+  const utils = render(
+    <InviteeQuizScreen navigation={mockNavigation} route={baseRoute} />
+  );
+  const { getByText } = utils;
+  fireEvent.press(getByText('onboarding.priorities.quality'));
+  fireEvent.press(getByText('referrals.quiz.next'));
+  fireEvent.press(getByText('onboarding.budget.premium'));
+  fireEvent.press(getByText('referrals.quiz.next'));
+  fireEvent.press(getByText('referrals.quiz.brand.open_to_emerging'));
+  fireEvent.press(getByText('referrals.quiz.next'));
+  fireEvent.press(getByText('referrals.quiz.submit'));
+  await utils.findByText('referrals.quiz.resultTitle');
+  return utils;
+}
+
+describe('InviteeQuizScreen — match score reads the real scoring payload (M18 MB-contract-10)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the winner's scoring.scores.product_N.overall as the match score", async () => {
+    const { findByText, queryByText } = await walkToResult(RESULT_WITH_SCORING);
+    // winner product_index=1 → product_1.overall 91.4 → rounds to 91.
+    expect(await findByText('91%')).toBeTruthy();
+    // The fabricated fallback must NOT render when real scores exist.
+    expect(queryByText('78%')).toBeNull();
+  });
+
+  it('keeps the 78 fallback ONLY when the payload carries no scores at all', async () => {
+    const { findByText } = await walkToResult(RESULT_WITHOUT_SCORING);
+    expect(await findByText('78%')).toBeTruthy();
+  });
+});

--- a/SmartCompareApp/__tests__/ResultsScreen.comparisonId.m18.test.ts
+++ b/SmartCompareApp/__tests__/ResultsScreen.comparisonId.m18.test.ts
@@ -1,0 +1,106 @@
+/**
+ * M18 comparison-id unit — MB-contract-01 / MB-contract-03 / MB-contract-10.
+ *
+ * Source-string assertions (the established ResultsScreen convention — see
+ * ResultsScreen.guards.test.tsx: the full render needs the whole Reanimated
+ * surface + 9 service mocks, so the wiring contract is pinned structurally;
+ * the behavioral halves live in api.getComparison.comparisonId.m18.test.ts
+ * and InviteeQuizScreen.matchScore.m18.test.tsx).
+ *
+ * Contract:
+ *  - MB-contract-01: ResultsScreen must NEVER send metadata.query as
+ *    comparison_id. The backend (M13-29, feedback_routes.py:89-124)
+ *    UUID-validates comparison_id on BOTH /feedback and /events, so a query
+ *    string 422s the whole batch — and trackEvents swallows the error, so
+ *    every Results event batch + every feedback row was silently dropped.
+ *  - MB-contract-03: sharableComparisonId must read the real id
+ *    (result.comparison_id, surfaced by getComparison, with
+ *    route.params.comparison_id as fallback) — not phantom keys.
+ *  - MB-contract-10: ctaVariant's margin must come from scoring_v2.win_margin
+ *    or overview.winner.margin — scoring.win_margin never exists on the wire
+ *    (response_builder.py:1557-1564 emits six keys, none of them win_margin).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = (rel: string) => fs.readFileSync(path.resolve(__dirname, rel), 'utf8');
+
+const RESULTS = SRC('../src/screens/ResultsScreen.tsx');
+const TYPES = SRC('../src/types/types.ts');
+const QUIZ = SRC('../src/screens/InviteeQuizScreen.tsx');
+
+describe('ResultsScreen — comparisonId is the real UUID, never metadata.query (MB-contract-01)', () => {
+  it('does NOT derive comparisonId from metadata.query', () => {
+    expect(RESULTS).not.toMatch(/const\s+comparisonId\s*=\s*metadata\?\.query/);
+  });
+
+  it('derives comparisonId from result.comparison_id with the route param as fallback', () => {
+    expect(RESULTS).toMatch(
+      /const\s+comparisonId\s*=\s*result\?\.comparison_id\s*\?\?\s*route\?\.params\?\.comparison_id/
+    );
+  });
+});
+
+describe('ResultsScreen — sharableComparisonId reads the real id (MB-contract-03)', () => {
+  it('no longer reads the phantom (metadata as any)?.comparison_id key', () => {
+    expect(RESULTS).not.toMatch(/\(metadata as any\)\?\.comparison_id/);
+  });
+
+  it('no longer needs the (result as any) cast for comparison_id (typed on ComparisonResult)', () => {
+    expect(RESULTS).not.toMatch(/\(result as any\)\?\.comparison_id/);
+  });
+
+  it('sharableComparisonId is the same real id threaded into events/feedback', () => {
+    expect(RESULTS).toMatch(/const\s+sharableComparisonId\s*=\s*comparisonId/);
+  });
+});
+
+describe('ResultsScreen — ctaVariant margin reads real keys (MB-contract-10)', () => {
+  it('does NOT read the phantom scoring.win_margin', () => {
+    expect(RESULTS).not.toMatch(/scoring\?\.win_margin/);
+  });
+
+  it('reads scoring_v2.win_margin with overview.winner.margin as fallback', () => {
+    expect(RESULTS).toMatch(
+      /scoring_v2\?\.win_margin\s*\?\?\s*result\?\.overview\?\.winner\?\.margin/
+    );
+  });
+});
+
+describe('types.ts — ScoringResult matches the wire (MB-contract-10)', () => {
+  const scoringBlock = (() => {
+    const m = TYPES.match(/export interface ScoringResult \{([\s\S]*?)\n\}/);
+    return m ? m[1] : '';
+  })();
+
+  it('ScoringResult interface exists and keeps the real keys', () => {
+    expect(scoringBlock).toContain('scores');
+    expect(scoringBlock).toContain('scoring_method');
+  });
+
+  it('ScoringResult no longer declares the phantom win_margin', () => {
+    expect(scoringBlock).not.toContain('win_margin');
+  });
+
+  it('ScoringResult no longer declares the phantom winner_index', () => {
+    expect(scoringBlock).not.toContain('winner_index');
+  });
+
+  it('ComparisonResult declares the optional comparison_id the client now threads', () => {
+    const m = TYPES.match(/export interface ComparisonResult \{([\s\S]*?)\n\}/);
+    expect(m).toBeTruthy();
+    expect(m![1]).toMatch(/comparison_id\?\:\s*string/);
+  });
+});
+
+describe('InviteeQuizScreen — no phantom scoring.products read (MB-contract-10)', () => {
+  it('does NOT read result.scoring.products', () => {
+    expect(QUIZ).not.toMatch(/scoring\?\.products/);
+  });
+
+  it('reads the real scoring.scores.product_N.overall shape', () => {
+    expect(QUIZ).toMatch(/scoring\?\.scores/);
+    expect(QUIZ).toMatch(/overall/);
+  });
+});

--- a/SmartCompareApp/__tests__/api.getComparison.comparisonId.m18.test.ts
+++ b/SmartCompareApp/__tests__/api.getComparison.comparisonId.m18.test.ts
@@ -1,0 +1,106 @@
+/**
+ * M18 MB-contract-03 (comparison-id unit) — getComparison must surface the
+ * persisted row id (`wrapper.comparison.id`, returned by
+ * GET /api/v1/comparisons/{id}, history_routes.py:156-166) on the payload it
+ * hands back, as `comparison_id`.
+ *
+ * Why: prior code unwrapped `wrapper.comparison.full_response` and DISCARDED
+ * `wrapper.comparison.id`, so ResultsScreen's `sharableComparisonId` was
+ * permanently undefined (share/referral Loop-1 unreachable from Results) and
+ * the screen fell back to metadata.query — a raw query string the backend's
+ * M13-29 UUID validators 422-reject on /events and /feedback.
+ *
+ * Mock pattern mirrors api.demographics.test.ts (the precedent for importing
+ * out of src/services/api.ts without the network surface).
+ */
+
+jest.mock('axios', () => {
+  const instance = {
+    get: jest.fn(),
+    put: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+  };
+  return { create: jest.fn(() => instance), __instance: instance };
+});
+
+jest.mock('../src/services/certificatePinning', () => ({
+  setupCertificatePinning: jest.fn(),
+}));
+
+jest.mock('../src/services/authService', () => ({
+  getToken: jest.fn().mockResolvedValue('fake-jwt'),
+  refreshSession: jest.fn(),
+  clearSession: jest.fn(),
+}));
+
+jest.mock('expo-image-manipulator', () => ({
+  manipulateAsync: jest.fn(),
+  SaveFormat: { JPEG: 'jpeg' },
+}));
+
+import axios from 'axios';
+import { getComparison } from '../src/services/api';
+
+const axiosInstance = (axios as any).__instance;
+
+const ROW_ID = '3f2b8c1d-9a4e-4f6b-8c2d-1e5a7b9c0d2f';
+
+const FULL_RESPONSE = {
+  success: true,
+  products: [{ name: 'iPhone 15' }, { name: 'Galaxy S24' }],
+  metadata: { query: 'iPhone 15 vs Galaxy S24', region: 'bahrain' },
+};
+
+const WRAPPER = {
+  success: true,
+  comparison: {
+    id: ROW_ID,
+    query: 'iPhone 15 vs Galaxy S24',
+    full_response: FULL_RESPONSE,
+  },
+};
+
+describe('getComparison — comparison_id surfacing (M18 MB-contract-03)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GETs /api/v1/comparisons/{id} and returns the full_response shape', async () => {
+    axiosInstance.get.mockResolvedValueOnce({ data: WRAPPER });
+    const result = await getComparison(ROW_ID);
+    expect(axiosInstance.get).toHaveBeenCalledWith(`/api/v1/comparisons/${ROW_ID}`);
+    expect(result.products).toHaveLength(2);
+    expect(result.metadata.query).toBe('iPhone 15 vs Galaxy S24');
+  });
+
+  it('surfaces wrapper.comparison.id as comparison_id on the returned payload', async () => {
+    axiosInstance.get.mockResolvedValueOnce({ data: WRAPPER });
+    const result = await getComparison(ROW_ID);
+    // THE fix: the persisted row UUID must ride the payload so ResultsScreen
+    // can use it for share + events + feedback. Base code discards it.
+    expect(result.comparison_id).toBe(ROW_ID);
+  });
+
+  it('comparison_id is a UUID, never the query string (M13-29 contract)', async () => {
+    axiosInstance.get.mockResolvedValueOnce({ data: WRAPPER });
+    const result = await getComparison(ROW_ID);
+    expect(result.comparison_id).not.toBe('iPhone 15 vs Galaxy S24');
+    expect(result.comparison_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+  });
+
+  it('still throws the 404-shaped error when full_response is missing (Path A R2 contract preserved)', async () => {
+    axiosInstance.get.mockResolvedValueOnce({
+      data: { success: true, comparison: { id: ROW_ID, full_response: null } },
+    });
+    await expect(getComparison(ROW_ID)).rejects.toMatchObject({
+      response: { status: 404 },
+    });
+  });
+});

--- a/SmartCompareApp/__tests__/hooks/useComparisonCounter.test.ts
+++ b/SmartCompareApp/__tests__/hooks/useComparisonCounter.test.ts
@@ -1,18 +1,28 @@
 /**
- * useComparisonCounter hook tests — M13-14.
+ * useComparisonCounter hook tests — M13-14 + M18 CD-interactions-04.
  *
- * The compare gate MUST derive from the already-fetched UsageStatus rather
- * than a hardcoded `used < 3`, so that:
- *   - premium tier is never paywalled,
- *   - an earned referral bonus raises the free cap (the referral loop no
- *     longer dead-ends), and
- *   - a MISSING field / offline hydrate degrades to today's behaviour
- *     (`used < 3`) — the safe fallback that derisks the change with no flag.
+ * CD-interactions-04 (CONFIRMED): the M13-14 gate compared the WRONG AXES —
+ * `used < lifetimeFree + bonusRemaining`, where `used` is the backend's
+ * NEVER-RESETTING lifetime counter and `bonusRemaining` a MONTHLY-expiring
+ * referral bonus. Consequences pinned here:
+ *   1. a free user past lifetime-3 was client-paywalled even when the backend
+ *      gate (check_usage_allowed: daily 3 / monthly 10+bonus) would allow, and
+ *   2. every consumed bonus permanently eroded all FUTURE bonus windows
+ *      (lifetime 8 makes a fresh +5 grant compute 8 < 3+5 = false forever).
  *
- * These two directions (field present → tier-aware; field absent → used<3)
- * are the pins the finding calls for.
+ * The gate now derives from the SAME axes the backend enforces, all served by
+ * GET /usage/status (usage_service.get_usage_status → `remaining`):
+ *   canCompare = premium
+ *     || remaining.lifetime_free > 0                       (lifetime-free path)
+ *     || (remaining.daily > 0 && remaining.monthly > 0)    (recurring path)
+ * minus any compares consumed locally since hydration (increment()).
+ *
+ * Degrade directions retained from M13-14 (the no-flag derisking):
+ *   - status null / fetch rejected (offline)      → used < 3 fallback
+ *   - status present but `remaining` axes absent  → used < 3 fallback
+ * Neither degrade path is ever MORE permissive than the historical gate.
  */
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useComparisonCounter } from '../../src/hooks/useComparisonCounter';
 import { getUsageStatus, UsageStatus } from '../../src/services/usageService';
@@ -31,7 +41,7 @@ function makeStatus(overrides: Partial<UsageStatus> = {}): UsageStatus {
     tier: 'free',
     used: { daily: 0, monthly: 0, lifetime: 0 },
     limits: { daily: 3, monthly: 10, lifetime_free: 3, monthly_bonus: 0 },
-    remaining: { daily: 3, monthly: 10 },
+    remaining: { daily: 3, monthly: 10, lifetime_free: 3 },
     ...overrides,
   } as UsageStatus;
 }
@@ -41,53 +51,86 @@ beforeEach(async () => {
   await AsyncStorage.clear();
 });
 
-describe('useComparisonCounter — M13-14 tier-aware gate (field PRESENT)', () => {
-  it('free tier: at the lifetime-free cap with no bonus → blocked (used < 3)', async () => {
+describe('useComparisonCounter — CD-interactions-04 backend-axis gate (fields PRESENT)', () => {
+  it('post-lifetime free user with recurring allowance left → ALLOWED (backend would allow)', async () => {
+    // The exact case the M13-14 formula got wrong: lifetime 8 >= 3, but the
+    // backend gate checks daily/monthly for post-lifetime users and passes.
     mockedGetUsageStatus.mockResolvedValue(
-      makeStatus({ used: { daily: 0, monthly: 0, lifetime: 3 } })
+      makeStatus({
+        used: { daily: 0, monthly: 0, lifetime: 8 },
+        remaining: { daily: 3, monthly: 10, lifetime_free: 0 },
+      })
+    );
+    const { result } = renderHook(() => useComparisonCounter());
+    await waitFor(() => expect(result.current.used).toBe(8));
+    expect(result.current.canCompare).toBe(true);
+    expect(result.current.shouldShowPaywall).toBe(false);
+  });
+
+  it('bonus-erosion worked example: lifetime 8 after a consumed +5 window, FRESH +5 grant → ALLOWED', async () => {
+    // Old formula: 8 < 3 + 5 = false → permanently paywalled, referral loop
+    // dead after one window. Backend: monthly_cap 10+5, monthly_used 0 → allow.
+    mockedGetUsageStatus.mockResolvedValue(
+      makeStatus({
+        used: { daily: 0, monthly: 0, lifetime: 8 },
+        limits: { daily: 3, monthly: 15, lifetime_free: 3, monthly_bonus: 5 },
+        remaining: { daily: 3, monthly: 15, lifetime_free: 0 },
+      })
+    );
+    const { result } = renderHook(() => useComparisonCounter());
+    await waitFor(() => expect(result.current.used).toBe(8));
+    expect(result.current.canCompare).toBe(true);
+    expect(result.current.shouldShowPaywall).toBe(false);
+  });
+
+  it('daily allowance exhausted → BLOCKED even though old formula would allow (3 < 3+5)', async () => {
+    mockedGetUsageStatus.mockResolvedValue(
+      makeStatus({
+        used: { daily: 3, monthly: 3, lifetime: 3 },
+        limits: { daily: 3, monthly: 15, lifetime_free: 3, monthly_bonus: 5 },
+        remaining: { daily: 0, monthly: 12, lifetime_free: 0 },
+      })
     );
     const { result } = renderHook(() => useComparisonCounter());
     await waitFor(() => expect(result.current.used).toBe(3));
     expect(result.current.canCompare).toBe(false);
     expect(result.current.shouldShowPaywall).toBe(true);
-    // Pill denominator stays the BASE cap; bonus is shown separately.
-    expect(result.current.total).toBe(3);
   });
 
-  it('free tier: a referral bonus raises the cap (used 5 < 3+5) → allowed', async () => {
+  it('monthly allowance exhausted → BLOCKED', async () => {
     mockedGetUsageStatus.mockResolvedValue(
       makeStatus({
-        used: { daily: 0, monthly: 0, lifetime: 5 },
-        limits: { daily: 3, monthly: 15, lifetime_free: 3, monthly_bonus: 5 },
+        used: { daily: 1, monthly: 10, lifetime: 13 },
+        remaining: { daily: 2, monthly: 0, lifetime_free: 0 },
       })
     );
     const { result } = renderHook(() => useComparisonCounter());
-    await waitFor(() => expect(result.current.used).toBe(5));
-    // 5 < (3 + 5) → still allowed: the referral loop no longer dead-ends.
-    expect(result.current.canCompare).toBe(true);
-    expect(result.current.shouldShowPaywall).toBe(false);
-    // Bonus is NOT folded into `total` (the pill renders it as "+N").
-    expect(result.current.total).toBe(3);
-  });
-
-  it('free tier: beyond base+bonus → blocked (used 8, cap 3+3)', async () => {
-    mockedGetUsageStatus.mockResolvedValue(
-      makeStatus({
-        used: { daily: 0, monthly: 0, lifetime: 8 },
-        limits: { daily: 3, monthly: 13, lifetime_free: 3, monthly_bonus: 3 },
-      })
-    );
-    const { result } = renderHook(() => useComparisonCounter());
-    await waitFor(() => expect(result.current.used).toBe(8));
+    await waitFor(() => expect(result.current.used).toBe(13));
     expect(result.current.canCompare).toBe(false);
+    expect(result.current.shouldShowPaywall).toBe(true);
   });
 
-  it('premium tier is never paywalled, even well past any free cap', async () => {
+  it('lifetime-free path: remaining.lifetime_free > 0 → ALLOWED, pill total = base cap', async () => {
+    mockedGetUsageStatus.mockResolvedValue(
+      makeStatus({
+        used: { daily: 0, monthly: 0, lifetime: 1 },
+        remaining: { daily: 3, monthly: 10, lifetime_free: 2 },
+      })
+    );
+    const { result } = renderHook(() => useComparisonCounter());
+    await waitFor(() => expect(result.current.used).toBe(1));
+    expect(result.current.canCompare).toBe(true);
+    // Pill denominator stays the BASE lifetime-free cap.
+    expect(result.current.total).toBe(3);
+  });
+
+  it('premium tier is never client-paywalled (backend 429 is the backstop)', async () => {
     mockedGetUsageStatus.mockResolvedValue(
       makeStatus({
         tier: 'premium',
         used: { daily: 0, monthly: 0, lifetime: 100 },
         limits: { daily: 10, monthly: 70, lifetime_free: 0, monthly_bonus: 0 },
+        remaining: { daily: 10, monthly: 70, lifetime_free: 0 },
       })
     );
     const { result } = renderHook(() => useComparisonCounter());
@@ -98,21 +141,30 @@ describe('useComparisonCounter — M13-14 tier-aware gate (field PRESENT)', () =
     expect(result.current.total).toBe(3);
   });
 
-  it('status present but monthly_bonus absent → bonus defaults to 0', async () => {
+  it('compares consumed locally since hydration count against the remaining axes', async () => {
+    // Hydrate with exactly 1 daily compare left. The old formula blocked this
+    // user at mount (5 >= 3); the backend allows exactly one more.
     mockedGetUsageStatus.mockResolvedValue(
       makeStatus({
-        used: { daily: 0, monthly: 0, lifetime: 2 },
-        // No monthly_bonus field — degrade to +0.
-        limits: { daily: 3, monthly: 10, lifetime_free: 3 } as any,
+        used: { daily: 2, monthly: 5, lifetime: 5 },
+        remaining: { daily: 1, monthly: 5, lifetime_free: 0 },
       })
     );
     const { result } = renderHook(() => useComparisonCounter());
-    await waitFor(() => expect(result.current.used).toBe(2));
-    expect(result.current.canCompare).toBe(true); // 2 < 3
+    await waitFor(() => expect(result.current.used).toBe(5));
+    expect(result.current.canCompare).toBe(true);
+
+    await act(async () => {
+      await result.current.increment();
+    });
+    // used 6, one compare consumed locally → effective remaining.daily 0.
+    expect(result.current.used).toBe(6);
+    expect(result.current.canCompare).toBe(false);
+    expect(result.current.shouldShowPaywall).toBe(true);
   });
 });
 
-describe('useComparisonCounter — M13-14 degrade path (field ABSENT / offline)', () => {
+describe('useComparisonCounter — degrade paths (offline / older backend)', () => {
   it('offline (status null), cached used=1 → allowed via used < 3', async () => {
     mockedGetUsageStatus.mockResolvedValue(null);
     await AsyncStorage.setItem(COUNTER_KEY, '1');
@@ -134,10 +186,34 @@ describe('useComparisonCounter — M13-14 degrade path (field ABSENT / offline)'
   it('fetch rejects (offline), no cache → used 0, allowed (used < 3)', async () => {
     mockedGetUsageStatus.mockRejectedValue(new Error('offline'));
     const { result } = renderHook(() => useComparisonCounter());
-    // No cached value → used stays 0; canCompare true from the outset.
     await waitFor(() => expect(mockedGetUsageStatus).toHaveBeenCalled());
     expect(result.current.used).toBe(0);
     expect(result.current.canCompare).toBe(true);
     expect(result.current.total).toBe(3);
+  });
+
+  it('older backend: `remaining` axes ABSENT → used < 3 fallback (used 2 → allowed)', async () => {
+    mockedGetUsageStatus.mockResolvedValue(
+      makeStatus({
+        used: { daily: 0, monthly: 0, lifetime: 2 },
+        remaining: undefined as any,
+      })
+    );
+    const { result } = renderHook(() => useComparisonCounter());
+    await waitFor(() => expect(result.current.used).toBe(2));
+    expect(result.current.canCompare).toBe(true);
+  });
+
+  it('older backend: `remaining` axes ABSENT → used < 3 fallback (used 5 → blocked, never MORE permissive)', async () => {
+    mockedGetUsageStatus.mockResolvedValue(
+      makeStatus({
+        used: { daily: 0, monthly: 0, lifetime: 5 },
+        remaining: undefined as any,
+      })
+    );
+    const { result } = renderHook(() => useComparisonCounter());
+    await waitFor(() => expect(result.current.used).toBe(5));
+    expect(result.current.canCompare).toBe(false);
+    expect(result.current.shouldShowPaywall).toBe(true);
   });
 });

--- a/SmartCompareApp/__tests__/screens/ResultsScreen.test.tsx
+++ b/SmartCompareApp/__tests__/screens/ResultsScreen.test.tsx
@@ -89,12 +89,15 @@ describe('ResultsScreen — Bundle E Task 0.1 defensive guards', () => {
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('uses optional chaining on `result.comparison_id` (line 210 fix)', () => {
-    // Design § 1a explicit before/after. The current source has
-    // `(result as any).comparison_id || ...` — must become
-    // `(result as any)?.comparison_id || ...`.
+  it('uses optional chaining on the comparison id read (line 210 fix, M18-updated)', () => {
+    // Design § 1a intent: never a non-optional `result.` access that can
+    // throw before the empty-state early return. M18 MB-contract-01/03
+    // replaced the any-cast phantom-key read with the typed, still
+    // optional-chained real id (`result?.comparison_id ??
+    // route?.params?.comparison_id`) — the crash guard this pin protects
+    // is preserved.
     expect(SOURCE).toMatch(
-      /\(result as any\)\?\.comparison_id\s*\|\|\s*\(metadata as any\)\?\.comparison_id/,
+      /result\?\.comparison_id\s*\?\?\s*route\?\.params\?\.comparison_id/,
     );
     // Negative assertion: the non-optional form must NOT remain in source.
     expect(SOURCE).not.toMatch(/\(result as any\)\.comparison_id/);
@@ -129,14 +132,19 @@ describe('ResultsScreen — Bundle E Task 0.1 defensive guards', () => {
     );
   });
 
-  it('v2 row with comparison_id still uses metadata fallback (no regression)', () => {
-    // The `|| (metadata as any)?.comparison_id` tail of the sharable id
-    // must survive the fix. History rows persist the id at
-    // `result.comparison_id` (top-level), while live SSE responses put
-    // it at `result.metadata.comparison_id` — both must work.
-    expect(SOURCE).toMatch(
-      /sharableComparisonId\s*=\s*\(result as any\)\?\.comparison_id\s*\|\|\s*\(metadata as any\)\?\.comparison_id/,
-    );
+  it('sharable id survives for history rows (M18-updated: real id, phantom metadata tail removed)', () => {
+    // STALE-PIN UPDATE (M18 MB-contract-03): the old assertion protected a
+    // `(metadata as any)?.comparison_id` tail on the belief that live SSE
+    // responses carry `result.metadata.comparison_id`. Verified false —
+    // response_builder.py has ZERO comparison_id emit sites, so that tail
+    // could never fire and the sharable id was permanently null (share
+    // Loop-1 unreachable). The invariant this pin exists for — a history
+    // row's sharable id must survive into ShareBottomSheet — now holds via
+    // the real id: getComparison surfaces wrapper.comparison.id as
+    // result.comparison_id, with route.params.comparison_id as fallback,
+    // and sharableComparisonId is that same id.
+    expect(SOURCE).toMatch(/const\s+sharableComparisonId\s*=\s*comparisonId/);
+    expect(SOURCE).not.toMatch(/\(metadata as any\)\?\.comparison_id/);
   });
 });
 

--- a/SmartCompareApp/src/hooks/useComparisonCounter.ts
+++ b/SmartCompareApp/src/hooks/useComparisonCounter.ts
@@ -45,22 +45,41 @@ export function useComparisonCounter() {
     return newCount;
   }, [used]);
 
-  // M13-14: derive the gate from the already-fetched UsageStatus rather than
-  // hardcoding `used < 3`. The backend grants premium unlimited and free users a
-  // lifetime-free window plus any active referral bonus, so a hardcoded `used < 3`
-  // dead-ends BOTH the base allowance and the entire referral incentive loop at a
-  // fixed 3 — every blocked entry point routes to the "Coming soon" paywall.
+  // M18 CD-interactions-04 (supersedes the M13-14 formula): derive the gate from
+  // the SAME AXES the backend enforces. The old formula compared the backend's
+  // NEVER-RESETTING lifetime counter against a MONTHLY-expiring referral bonus
+  // (`used < lifetime_free + monthly_bonus`), so a free user past lifetime-3 was
+  // client-paywalled even when check_usage_allowed would pass (daily 3 / monthly
+  // 10+bonus), and every consumed bonus permanently eroded all FUTURE bonus
+  // windows (lifetime 8 makes a fresh +5 grant compute 8 < 3+5 = false forever).
   //
-  // Safe-fallback derisking (no flag needed — RN has no per-call env flag): every
-  // field is read defensively so a MISSING field degrades to today's behaviour.
-  // When `status` is null (offline hydrate) or the fields are absent (older
-  // backend), `tier` is undefined, `lifetimeFree` falls back to FREE_LIMIT and
-  // `bonusRemaining` to 0, so `canCompare` collapses to `used < 3` — never MORE
-  // permissive than today, only tier-aware when the data is actually present.
+  // Backend gate (usage_service.check_usage_allowed), mirrored here off the
+  // `remaining` block get_usage_status already serves:
+  //   free with lifetime-free left → allowed (remaining.lifetime_free > 0)
+  //   otherwise                    → allowed iff daily AND monthly remain
+  // Compares consumed locally since hydration (increment()) are subtracted from
+  // each axis so the gate moves within a session without a refetch; the backend
+  // increments all three counters per compare, so one shared delta is faithful.
+  //
+  // Safe-fallback derisking retained from M13-14 (no flag — RN has no per-call
+  // env flag): when `status` is null (offline) or the `remaining` axes are
+  // absent (older backend), the gate collapses to the historical `used < 3` —
+  // never MORE permissive than the data actually present supports.
   const lifetimeFree = status?.limits?.lifetime_free ?? FREE_LIMIT;
-  const bonusRemaining = status?.limits?.monthly_bonus ?? 0;
   const isPremium = status?.tier === 'premium';
-  const canCompare = isPremium || used < lifetimeFree + bonusRemaining;
+  const remaining = status?.remaining;
+  const hasBackendAxes =
+    typeof remaining?.daily === 'number' && typeof remaining?.monthly === 'number';
+  const fetchedLifetime = status?.used?.lifetime;
+  const sessionConsumed =
+    typeof fetchedLifetime === 'number' ? Math.max(0, used - fetchedLifetime) : 0;
+  const backendAllows =
+    hasBackendAxes &&
+    ((remaining.lifetime_free ?? 0) - sessionConsumed > 0 ||
+      (remaining.daily - sessionConsumed > 0 &&
+        remaining.monthly - sessionConsumed > 0));
+  const canCompare =
+    isPremium || (hasBackendAxes ? backendAllows : used < FREE_LIMIT);
   const shouldShowPaywall = !canCompare;
 
   // Pill denominator = the BASE lifetime-free cap only. The header pill renders

--- a/SmartCompareApp/src/screens/ContactUsScreen.tsx
+++ b/SmartCompareApp/src/screens/ContactUsScreen.tsx
@@ -31,9 +31,28 @@ type Props = NativeStackScreenProps<RootStackParamList, 'ContactUs'>;
 type Category = 'bug' | 'suggestion' | 'business' | 'other';
 
 const CATEGORIES: Category[] = ['bug', 'suggestion', 'business', 'other'];
+
+// M18 CD-uncovered-02 / MB-flows-09: the change_suggestion prefix is the
+// operators' triage key (`change_suggestion LIKE '[Bug]%'`), so it must be a
+// STABLE ENGLISH tag independent of the device locale. t() is for the
+// on-screen chip labels only — an Arabic reporter previously produced
+// a localized Arabic prefix, invisible to the documented grep.
+const CATEGORY_TAGS: Record<Category, string> = {
+  bug: 'Bug',
+  suggestion: 'Suggestion',
+  business: 'Business',
+  other: 'Other',
+};
+
 const MIN_MESSAGE = 10;
-const MAX_MESSAGE = 2000;
 const MAX_SUBJECT = 120;
+// Backend FeedbackRequest.change_suggestion caps at 1000 chars.
+// Composed payload = "[<tag>] <subject>\n\n<body>"; worst-case overhead is
+// "[Suggestion] " (13) + MAX_SUBJECT (120) + "\n\n" (2) = 135, so the honest
+// message cap is 1000 - 135 = 865. (Was 2000, which silently truncated.)
+const BACKEND_MAX_CHANGE_SUGGESTION = 1000;
+const MAX_MESSAGE =
+  BACKEND_MAX_CHANGE_SUGGESTION - ('[Suggestion] '.length + MAX_SUBJECT + '\n\n'.length);
 const RATE_LIMIT_MS = 30_000;
 
 export default function ContactUsScreen({ navigation }: Props) {
@@ -58,15 +77,21 @@ export default function ContactUsScreen({ navigation }: Props) {
     setErrorKey(null);
     try {
       // Category encoded inline so we don't need a new backend endpoint.
-      // Operators query: `change_suggestion LIKE '[Bug]%'` etc.
-      const categoryLabel = t(`contact.category.${category}`);
+      // Operators query: `change_suggestion LIKE '[Bug]%'` etc. — the tag is
+      // the stable English enum (CATEGORY_TAGS), NEVER the localized label,
+      // so the grep works for every locale.
+      const categoryTag = CATEGORY_TAGS[category];
       const composed = subject.trim()
-        ? `[${categoryLabel}] ${subject.trim()}\n\n${trimmedMessage}`
-        : `[${categoryLabel}] ${trimmedMessage}`;
+        ? `[${categoryTag}] ${subject.trim()}\n\n${trimmedMessage}`
+        : `[${categoryTag}] ${trimmedMessage}`;
       await api.post('/api/v1/feedback', {
-        useful: true,
+        // A bug report is not positive feedback; other contact reasons are
+        // neutral-to-positive. (`useful` is required by FeedbackRequest.)
+        useful: category !== 'bug',
         mattered_most: [],
-        change_suggestion: composed.slice(0, 1000),
+        // MAX_MESSAGE + MAX_SUBJECT are sized so this never exceeds the
+        // backend cap; the slice is a defensive backstop, not a truncator.
+        change_suggestion: composed.slice(0, BACKEND_MAX_CHANGE_SUGGESTION),
       });
       try { Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success); } catch {}
       setSuccess(true);

--- a/SmartCompareApp/src/screens/InviteeQuizScreen.tsx
+++ b/SmartCompareApp/src/screens/InviteeQuizScreen.tsx
@@ -149,15 +149,18 @@ export default function InviteeQuizScreen({ navigation, route }: Props) {
     const winnerReason: string | undefined =
       result?.overview?.winner?.reason ?? result?.recommendation;
 
-    // Phase 4 § 4e — match score animates 0→N. Backend ships per-product
-    // scores via `result.scoring.products[i].score`; pick the winner's
-    // and clamp to [0, 100]. Falls back to a sensible 78 when scoring
-    // data is absent (anonymous/quiz path may skip personalization).
-    const scoringProducts: any[] = result?.scoring?.products ?? [];
+    // Phase 4 § 4e — match score animates 0→N. M18 MB-contract-10: the
+    // backend ships per-product scores at `scoring.scores.product_N.overall`
+    // (response_builder.py:1557-1564) — the previously-read
+    // `scoring.products[i].score` exists on NO backend payload shape, so
+    // every invitee saw the fabricated 78 fallback. Pick the winner's
+    // overall and clamp to [0, 100]; 78 remains the fallback only when
+    // scoring data is genuinely absent.
     const winnerIdx: number =
       result?.overview?.winner?.product_index ??
       (typeof result?.winner_index === 'number' ? result.winner_index : 0);
-    const rawScore: number = scoringProducts[winnerIdx]?.score ?? 78;
+    const rawScore: number =
+      result?.scoring?.scores?.[`product_${winnerIdx}`]?.overall ?? 78;
     const matchScore = Math.max(0, Math.min(100, Math.round(rawScore)));
 
     return (

--- a/SmartCompareApp/src/screens/ResultsScreen.tsx
+++ b/SmartCompareApp/src/screens/ResultsScreen.tsx
@@ -328,7 +328,17 @@ export default function ResultsScreen({ route, navigation }: ResultsScreenProps)
   const pendingEventsRef = useRef<
     Array<{ event_type: string; event_data?: Record<string, any>; comparison_id?: string }>
   >([]);
-  const comparisonId = metadata?.query;
+  // M18 MB-contract-01 — the REAL persisted-row UUID, or undefined.
+  // metadata.query was sent here before, but it is the raw query string
+  // ("iPhone 15 vs S24"), which the backend's M13-29 UUID validators
+  // 422-reject on BOTH /events and /feedback — silently killing every
+  // Results event batch and every feedback row (trackEvents swallows the
+  // error). The id exists on the History path only: getComparison surfaces
+  // wrapper.comparison.id as result.comparison_id, and the route param
+  // carries the same id. Fresh compares have NO id (the backend never
+  // echoes it), so comparisonId stays undefined there — JSON.stringify
+  // drops it and the batch passes validation without an anchor.
+  const comparisonId = result?.comparison_id ?? route?.params?.comparison_id;
 
   const trackEvent = (eventType: string, eventData?: Record<string, any>) => {
     pendingEventsRef.current.push({
@@ -409,15 +419,25 @@ export default function ResultsScreen({ route, navigation }: ResultsScreenProps)
   // F2.4: Result-aware CTA variant. Strong/close mapping per design 3.1.
   // 'saved' variant deferred until ResultsScreen Save tap actually persists state.
   const ctaVariant: 'strong' | 'close' | 'default' = (() => {
-    const margin = scoring?.win_margin;
+    // M18 MB-contract-10 — scoring.win_margin never exists on the wire
+    // (response_builder emits six scoring keys, none of them win_margin),
+    // so this was permanently undefined → 'default'. The real keys are
+    // scoring_v2.win_margin and overview.winner.margin.
+    const margin = scoring_v2?.win_margin ?? result?.overview?.winner?.margin;
     if (typeof margin !== 'number') return 'default';
     if (margin >= 15) return 'strong';
     if (margin < 8) return 'close';
     return 'default';
   })();
 
-  const sharableComparisonId =
-    (result as any)?.comparison_id || (metadata as any)?.comparison_id;
+  // M18 MB-contract-03 — the same real id threaded into events/feedback.
+  // The old read consulted an any-cast result/metadata `comparison_id` pair
+  // that no backend payload ever carried, so this was permanently null and
+  // the share/referral Loop-1 flow was unreachable from Results
+  // (handleShare always fell to text-only Share.share). Fresh compares
+  // still have no id — text-only by design until the backend echoes the
+  // saved id.
+  const sharableComparisonId = comparisonId;
 
   const winnerName = isNewFormat
     ? result!.overview!.winner.name

--- a/SmartCompareApp/src/services/api.ts
+++ b/SmartCompareApp/src/services/api.ts
@@ -242,6 +242,13 @@ export async function deleteComparison(comparisonId: string) {
  * wrapper as-is, leaving ResultsScreen with `result.products === undefined`
  * → empty-state branch even though the row loaded fine. Ahmed flagged
  * "History still doesn't show comparison content".
+ *
+ * M18 MB-contract-03: surface `wrapper.comparison.id` on the payload as
+ * `comparison_id` (additive, shape-preserving). Prior code discarded it,
+ * which left ResultsScreen's sharableComparisonId permanently null (the
+ * share/referral Loop-1 flow was unreachable) and pushed the screen onto
+ * metadata.query as its comparison id — a raw query string the backend's
+ * M13-29 UUID validators 422-reject on /events and /feedback.
  */
 export async function getComparison(comparisonId: string) {
   const response = await api.get(`/api/v1/comparisons/${comparisonId}`);
@@ -253,7 +260,7 @@ export async function getComparison(comparisonId: string) {
       response: { status: 404, data: wrapper },
     });
   }
-  return full;
+  return comparison?.id ? { ...full, comparison_id: comparison.id } : full;
 }
 
 /**

--- a/SmartCompareApp/src/types/types.ts
+++ b/SmartCompareApp/src/types/types.ts
@@ -279,6 +279,14 @@ export interface MetadataSection {
 
 export interface ComparisonResult {
   success: boolean;
+  // M18 MB-contract-01/03 — the persisted comparisons-row UUID. NOT emitted
+  // by /text/compare (the id is created at save time and never echoed back);
+  // present only on payloads that came through getComparison(), which
+  // surfaces wrapper.comparison.id here. ResultsScreen threads it into
+  // /events + /feedback (backend M13-29 UUID-validates comparison_id) and
+  // into the share/referral Loop-1 flow. Optional: fresh compares omit it,
+  // and JSON.stringify drops the undefined so event batches still pass.
+  comparison_id?: string;
   products: Product[];
   comparison: Comparison;
   winner_index: number;
@@ -343,11 +351,22 @@ export interface DimensionWinner {
   margin: number | null;
 }
 
+// M18 MB-contract-10 — corrected to the six keys the backend actually emits
+// (response_builder.py:1557-1564: scores, dimension_winners, price_tiers,
+// is_cross_tier, scoring_method, category_weights). The previously-declared
+// required `winner_index`/`win_margin` NEVER exist on the wire (win_margin
+// lives at overview.winner.margin and scoring_v2.win_margin), so tsc was
+// asserting phantom fields and consumers read undefined. scoring_method
+// widened to the full backend enum (CLAUDE.md scoring_method contract).
 export interface ScoringResult {
   scores: Record<string, ProductScores>;
-  winner_index: number;
-  win_margin: number;
-  scoring_method: 'personalized' | 'default' | 'category_weighted';
+  scoring_method:
+    | 'personalized'
+    | 'default'
+    | 'category_weighted'
+    | 'behavioral'
+    | 'cohort'
+    | 'invitee_quiz';
   dimension_winners?: Record<string, DimensionWinner>;
   price_tiers?: Record<string, string>;
   is_cross_tier?: boolean;

--- a/app/services/extraction_service.py
+++ b/app/services/extraction_service.py
@@ -348,7 +348,13 @@ CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE: Dict[str, List[str]] = {
     "skincare":    ["volume", "ingredients", "active_ingredient"],
     "haircare":    ["volume", "ingredients"],
     "makeup":      ["volume", "shade_range"],
-    "grocery":     ["weight", "ingredients"],
+    # M18 PO-prompts-06: was ["weight", "ingredients"] — but the grocery
+    # schema defines "size", not "weight", so the prompt never asked for
+    # it, extract_specs' schema filter dropped any volunteered value, and
+    # every cold grocery compare paid Tier-2 (Serper+GPT) and Tier-3
+    # (gpt-4o) chasing a field that could never be filled. "size" is the
+    # canonical key (grocery.chocolate aliases weight_g -> size).
+    "grocery":     ["size", "ingredients"],
     "other":       [],
 }
 
@@ -483,10 +489,12 @@ Output spec:
   model: "Tobacco Vanille"
   variant: "50 ml"
   concentration: "EDP"
-  notes: "Tobacco, vanilla, cocoa, dried fruit, ginger, tonka bean"
+  notes_top: "Tobacco leaf, ginger"
+  notes_heart: "Vanilla, cocoa, tonka bean"
+  notes_base: "Dried fruit, woody notes"
   longevity: "8-10 hours"
   sillage: "Heavy"
-Reasoning: EDP is the canonical concentration for Tobacco Vanille; notes ordered top-to-base where source distinguishes. Longevity range, sillage as one qualitative term.
+Reasoning: EDP is the canonical concentration for Tobacco Vanille; notes are split into the schema's notes_top/notes_heart/notes_base pyramid, top-to-base as the source distinguishes. Longevity range, sillage as one qualitative term.
 
 Example 5 (fashion, minimal schema):
 Input: "Nike Air Force 1"
@@ -503,7 +511,7 @@ Output spec:
   brand: "Bioderma"
   model: "Sensibio H2O Micellar Water"
   variant: "500 ml"
-  volume_ml: "500 ml"
+  volume: "500 ml"
   ingredients: "Water, PEG-6 caprylic/capric glycerides, cucumber extract, mannitol, xylitol, rhamnose, fructooligosaccharides"
 Reasoning: ingredient list is from the official Bioderma INCI label; volume matches the variant.
 """

--- a/app/services/referral_service.py
+++ b/app/services/referral_service.py
@@ -410,7 +410,7 @@ class ReferralService:
         # 2. Lookup the comparison by share_token
         comp_resp = (
             self.client.table("comparisons")
-            .select("id, user_id, response_data, share_token")
+            .select("id, user_id, full_response, share_token")
             .eq("share_token", share_token)
             .single()
             .execute()
@@ -442,7 +442,7 @@ class ReferralService:
 
         # 4. Sanitize comparison — strip personalization first, then apply
         #    the referrer's privacy choices on top.
-        sanitized = _strip_personalization(comp.get("response_data") or {})
+        sanitized = _strip_personalization(comp.get("full_response") or {})
         sanitized = _apply_privacy(sanitized, privacy)
         sanitized["id"] = comp["id"]
 
@@ -476,7 +476,7 @@ class ReferralService:
         # 1. Lookup the cached comparison
         comp_resp = (
             self.client.table("comparisons")
-            .select("id, response_data")
+            .select("id, full_response")
             .eq("share_token", share_token)
             .single()
             .execute()
@@ -485,7 +485,7 @@ class ReferralService:
         if not comp:
             return None
 
-        response = comp.get("response_data") or {}
+        response = comp.get("full_response") or {}
         sanitized = _strip_personalization(response)
         sanitized["id"] = comp["id"]
 

--- a/app/services/response_builder.py
+++ b/app/services/response_builder.py
@@ -1250,6 +1250,48 @@ def _QUALITATIVE_WINNER_REASON(winner_name: str) -> str:
     )
 
 
+# M18 CD-ci-truth-11 / PO-prompts-07-marker — the internal fabrication-provenance
+# marker value. Tier 3 outputs are tagged inference_source="model_knowledge"
+# (spec §2f) for QA/dashboards ONLY; it must NEVER reach the serialized API
+# response. Pinned by
+# tests/test_extraction_prompt_bundle_c.py::test_response_builder_strips_inference_source.
+_INFERENCE_MARKER_VALUE = "model_knowledge"
+
+
+def _strip_inference_markers(obj) -> None:
+    """Recursively strip the internal inference-provenance marker from the
+    assembled response, IN PLACE (preserves object identity for every dict the
+    builder already mutated in place — rating, price-pending, pros/cons).
+
+    Drops:
+    - any dict key whose name contains "inference_source" (e.g.
+      "processor_inference_source", "inference_source"), whatever its value;
+    - any dict entry / list item whose value is the internal marker string
+      "model_knowledge" (e.g. a bare {"source": "model_knowledge"}).
+
+    Belt-and-braces: applied to the WHOLE result at the single exit of
+    build_comparison_response, so the marker cannot leak through any
+    projection (products alias, overview, specs block, metadata).
+    """
+    if isinstance(obj, dict):
+        _doomed = [
+            k for k, v in obj.items()
+            if (isinstance(k, str) and "inference_source" in k)
+            or (isinstance(v, str) and v == _INFERENCE_MARKER_VALUE)
+        ]
+        for k in _doomed:
+            del obj[k]
+        for v in obj.values():
+            _strip_inference_markers(v)
+    elif isinstance(obj, list):
+        obj[:] = [
+            v for v in obj
+            if not (isinstance(v, str) and v == _INFERENCE_MARKER_VALUE)
+        ]
+        for v in obj:
+            _strip_inference_markers(v)
+
+
 def build_comparison_response(
     *,
     product_data: Optional[List[Dict[str, Any]]] = None,
@@ -1951,5 +1993,13 @@ def build_comparison_response(
         "price_tiers": scoring_result.get("price_tiers", {}),
         "is_cross_tier": scoring_result.get("is_cross_tier", False),
     }
+
+    # M18 CD-ci-truth-11 — final serialization walk: the internal
+    # fabrication-provenance marker (inference_source="model_knowledge",
+    # Tier 3 QA/dashboards only) must never ship to API clients. Applied at
+    # the function's single exit so every projection (products alias,
+    # overview, specs block, metadata) is covered. In-place, so all the
+    # object identities established above are preserved.
+    _strip_inference_markers(result)
 
     return result

--- a/tests/test_critical_schema_fields_split.py
+++ b/tests/test_critical_schema_fields_split.py
@@ -112,8 +112,11 @@ def test_makeup_split():
 
 
 def test_grocery_split():
+    # M18 PO-prompts-06: spec §2f said "weight", but the grocery schema
+    # defines "size" (the prompt/filter never carry "weight", so it was an
+    # unfillable paid Tier-2/3 chase). Pin the schema-reconciled value.
     assert set(CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE["grocery"]) == {
-        "weight", "ingredients",
+        "size", "ingredients",
     }
     # Spec lists `nutrition_*` — we use the discrete schema keys.
     assert set(CRITICAL_SCHEMA_FIELDS_PREFERRED["grocery"]) == {

--- a/tests/test_extraction_prompt_bundle_c.py
+++ b/tests/test_extraction_prompt_bundle_c.py
@@ -32,7 +32,10 @@ EXPECTED_NON_NEGOTIABLE = {
     "skincare":    {"volume", "ingredients", "active_ingredient"},
     "haircare":    {"volume", "ingredients"},
     "makeup":      {"volume", "shade_range"},
-    "grocery":     {"weight", "ingredients"},
+    # M18 PO-prompts-06: spec §2f said "weight", but CATEGORY_SPEC_SCHEMAS
+    # ["grocery"] defines "size" — "weight" was an unfillable paid chase
+    # (never prompted, always filter-dropped). Reconciled to the schema key.
+    "grocery":     {"size", "ingredients"},
     "other":       set(),  # all preferred
 }
 

--- a/tests/test_grocery_schema_reconcile.py
+++ b/tests/test_grocery_schema_reconcile.py
@@ -1,0 +1,109 @@
+"""M18 PO-prompts-06 + PO-prompts-07 — grocery-schema reconciliation.
+
+PO-prompts-06: CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE['grocery'] demanded
+'weight', but CATEGORY_SPEC_SCHEMAS['grocery'] defines 'size' — so the
+prompt never asks for 'weight', extract_specs' schema filter drops any
+volunteered 'weight', and every cold grocery compare fires paid
+Tier-2 (Serper+GPT) and Tier-3 (gpt-4o) chases for a field that can
+never be filled. Fix: 'weight' -> 'size'. The fence tests here make the
+whole drift class impossible for every category.
+
+PO-prompts-07: the prod-default specs prompt (SPECS_SYSTEM_STATIC_PREFIX,
+flag OFF) taught off-schema keys in its worked examples — Example 4
+fragrance used a single 'notes' field (schema has only
+notes_top/notes_heart/notes_base) and Example 6 skincare used
+'volume_ml' (schema key is 'volume', which is NON-NEGOTIABLE for
+skincare) — so a model imitating the examples emits keys the filter
+silently drops, then the paid refill cascade re-buys the values. The
+flag-ON EVIDENCE_ONLY_EXAMPLES copies were already corrected; these
+tests pin the flag-OFF copies to the same schema keys.
+"""
+from __future__ import annotations
+
+import re
+
+from app.services.extraction_service import (
+    CATEGORY_SPEC_SCHEMAS,
+    CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE,
+    CRITICAL_SCHEMA_FIELDS_PREFERRED,
+    SPECS_SYSTEM_STATIC_PREFIX,
+)
+
+
+# ---------------------------------------------------------------------------
+# PO-prompts-06 — the fence: every chased field must exist in its schema
+# ---------------------------------------------------------------------------
+
+
+def test_non_negotiable_fields_exist_in_category_schema():
+    """Every NON_NEGOTIABLE field must be a member of its category's
+    CATEGORY_SPEC_SCHEMAS list — otherwise Tier-2/Tier-3 pay to chase a
+    field the prompt never requests and the filter always drops.
+    RED at base: grocery lists 'weight' but the schema defines 'size'."""
+    drift = {}
+    for category, fields in CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE.items():
+        schema = set(CATEGORY_SPEC_SCHEMAS.get(category, []))
+        missing = [f for f in fields if f not in schema]
+        if missing:
+            drift[category] = missing
+    assert not drift, (
+        f"NON_NEGOTIABLE fields absent from their category schema "
+        f"(unfillable paid chase): {drift}"
+    )
+
+
+def test_preferred_fields_exist_in_category_schema():
+    """Same fence for the PREFERRED map (smart-fallback chases these)."""
+    drift = {}
+    for category, fields in CRITICAL_SCHEMA_FIELDS_PREFERRED.items():
+        schema = set(CATEGORY_SPEC_SCHEMAS.get(category, []))
+        missing = [f for f in fields if f not in schema]
+        if missing:
+            drift[category] = missing
+    assert not drift, (
+        f"PREFERRED fields absent from their category schema: {drift}"
+    )
+
+
+def test_grocery_non_negotiable_is_size_and_ingredients():
+    """PO-prompts-06 direct pin: grocery chases 'size' (the schema key),
+    never the off-schema 'weight'."""
+    assert set(CRITICAL_SCHEMA_FIELDS_NON_NEGOTIABLE["grocery"]) == {
+        "size", "ingredients",
+    }
+
+
+# ---------------------------------------------------------------------------
+# PO-prompts-07 — prod-default worked examples must use schema keys
+# ---------------------------------------------------------------------------
+
+
+def test_prod_prompt_example4_uses_fragrance_note_pyramid_keys():
+    """Example 4 (fragrance) must teach the schema's notes_top /
+    notes_heart / notes_base, never a bare 'notes' key (aliased nowhere,
+    dropped by the extract_specs filter)."""
+    bare_notes_lines = re.findall(
+        r"^\s*notes:\s", SPECS_SYSTEM_STATIC_PREFIX, flags=re.MULTILINE
+    )
+    assert not bare_notes_lines, (
+        "prod-default prompt still teaches the off-schema 'notes' key"
+    )
+    for key in ("notes_top:", "notes_heart:", "notes_base:"):
+        assert key in SPECS_SYSTEM_STATIC_PREFIX, (
+            f"Example 4 should model the schema key {key!r}"
+        )
+
+
+def test_prod_prompt_example6_uses_schema_volume_key():
+    """Example 6 (skincare) must teach 'volume' (NON-NEGOTIABLE for
+    skincare), never 'volume_ml' (only a fragrance-subtype alias — for
+    skincare the filter drops it and Tier-2/3 re-buy the value)."""
+    volume_ml_lines = re.findall(
+        r"^\s*volume_ml:\s", SPECS_SYSTEM_STATIC_PREFIX, flags=re.MULTILINE
+    )
+    assert not volume_ml_lines, (
+        "prod-default prompt still teaches the off-schema 'volume_ml' key"
+    )
+    assert re.search(
+        r'^\s*volume:\s*"500 ml"', SPECS_SYSTEM_STATIC_PREFIX, flags=re.MULTILINE
+    ), "Example 6 should model the schema key 'volume'"

--- a/tests/test_referral_full_response_column.py
+++ b/tests/test_referral_full_response_column.py
@@ -1,0 +1,167 @@
+"""MB-contract-05 — referral landing + invitee quiz must read comparisons.full_response.
+
+The comparisons table has NO ``response_data`` column: migration
+001_update_comparisons.sql defines ``full_response JSONB`` and the only
+writer of comparison payloads (database_service.save_comparison, :215)
+persists under ``full_response``.  ``grep -rn response_data migrations/``
+returns nothing.  referral_service previously selected and read a
+``response_data`` column at four sites (resolve_invite + run_invitee_quiz),
+so with ENABLE_REFERRAL_SYSTEM ON every invite landing / invitee quiz
+either PostgREST-errored (42703) or rendered an empty comparison.
+
+These tests mock the comparison row AS THE DATABASE ACTUALLY RETURNS IT
+(``full_response`` key, no ``response_data`` key) and assert the payload
+reaches the invitee.  At the broken base they fail because the service
+reads the nonexistent key and degrades to ``{}``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The row shape the real DB serves: full_response only.
+_REAL_ROW_PAYLOAD = {
+    "products": [{"name": "iPhone 15"}, {"name": "Galaxy S24"}],
+    "winner": {"name": "iPhone 15"},
+    "winner_index": 0,
+    "scoring": {"scoring_method": "category_weighted"},
+    "preferences": {"priorities": ["best_price"]},  # must be stripped
+    "personalization": {"user_id": "ref-1"},  # must be stripped
+}
+
+
+def _make_resolve_client(select_columns_sink=None):
+    """Mock supabase client serving a REAL-shaped comparisons row."""
+    client = MagicMock()
+    client.rpc.return_value.execute.return_value = MagicMock(
+        data=[{"referrer_user_id": "ref-1", "display_name": "Ahmed"}]
+    )
+
+    comp = MagicMock(
+        data={
+            "id": "cmp-1",
+            "user_id": "ref-1",
+            "share_token": "tok-aaaaaaaaaaaaaaaaaa",
+            "full_response": dict(_REAL_ROW_PAYLOAD),
+        }
+    )
+    invite_resp = MagicMock(data=[{"id": "invite-1", "first_viewed_at": "2026-05-04T00:00:00Z"}])
+
+    def table_side_effect(name):
+        t = MagicMock()
+        if name == "comparisons":
+            def capture_select(*cols):
+                if select_columns_sink is not None:
+                    select_columns_sink.append(", ".join(cols))
+                inner = MagicMock()
+                inner.eq.return_value.single.return_value.execute.return_value = comp
+                return inner
+
+            t.select.side_effect = capture_select
+        elif name == "referral_invites":
+            chain = (
+                t.select.return_value.eq.return_value.eq.return_value
+                .order.return_value.limit.return_value
+            )
+            chain.execute.return_value = invite_resp
+        return t
+
+    client.table.side_effect = table_side_effect
+    return client
+
+
+class TestResolveInviteReadsFullResponse:
+    @pytest.mark.asyncio
+    async def test_landing_comparison_carries_products_from_full_response(self):
+        from app.services.referral_service import ReferralService
+
+        client = _make_resolve_client()
+        with patch(
+            "app.services.referral_service.get_admin_supabase_client", return_value=client
+        ):
+            svc = ReferralService()
+            result = await svc.resolve_invite(
+                share_token="tok-aaaaaaaaaaaaaaaaaa", ref_code="QR-AHMED1"
+            )
+
+        assert result is not None
+        comparison = result["comparison"]
+        # The invitee landing must actually receive the referrer's products —
+        # a service reading the nonexistent response_data column yields {}.
+        assert comparison.get("products") == [
+            {"name": "iPhone 15"},
+            {"name": "Galaxy S24"},
+        ]
+        assert comparison.get("winner") == {"name": "iPhone 15"}
+        # Privacy invariants still hold on the real column
+        assert "preferences" not in comparison
+        assert "personalization" not in comparison
+
+    @pytest.mark.asyncio
+    async def test_resolve_invite_selects_full_response_column(self):
+        """The SELECT must name the column that exists — response_data 42703s."""
+        from app.services.referral_service import ReferralService
+
+        sink: list[str] = []
+        client = _make_resolve_client(select_columns_sink=sink)
+        with patch(
+            "app.services.referral_service.get_admin_supabase_client", return_value=client
+        ):
+            svc = ReferralService()
+            await svc.resolve_invite(
+                share_token="tok-aaaaaaaaaaaaaaaaaa", ref_code="QR-AHMED1"
+            )
+
+        assert sink, "comparisons.select was never called"
+        assert "full_response" in sink[0]
+        assert "response_data" not in sink[0]
+
+
+class TestRunInviteeQuizReadsFullResponse:
+    @pytest.mark.asyncio
+    async def test_quiz_rescores_the_full_response_payload(self):
+        from app.services.referral_service import ReferralService
+
+        client = MagicMock()
+        select_sink: list[str] = []
+        comp = MagicMock(
+            data={"id": "cmp-1", "full_response": dict(_REAL_ROW_PAYLOAD)}
+        )
+
+        def table_side_effect(name):
+            t = MagicMock()
+            if name == "comparisons":
+                def capture_select(*cols):
+                    select_sink.append(", ".join(cols))
+                    inner = MagicMock()
+                    inner.eq.return_value.single.return_value.execute.return_value = comp
+                    return inner
+
+                t.select.side_effect = capture_select
+            return t
+
+        client.table.side_effect = table_side_effect
+
+        with patch(
+            "app.services.referral_service.get_admin_supabase_client", return_value=client
+        ):
+            svc = ReferralService()
+            result = await svc.run_invitee_quiz(
+                share_token="tok-aaaaaaaaaaaaaaaaaa",
+                priority="best_price",
+                budget="mid",
+                brand_attitude="function_first",
+            )
+
+        assert result is not None
+        # The quiz result must carry the referrer's actual products, not {}.
+        assert result.get("products") == [
+            {"name": "iPhone 15"},
+            {"name": "Galaxy S24"},
+        ]
+        assert result["scoring"]["scoring_method"] == "invitee_quiz"
+        assert "preferences" not in result
+
+        assert select_sink, "comparisons.select was never called"
+        assert "full_response" in select_sink[0]
+        assert "response_data" not in select_sink[0]

--- a/tests/test_referral_service.py
+++ b/tests/test_referral_service.py
@@ -455,7 +455,7 @@ class TestResolveInvite:
             "id": "cmp-1",
             "user_id": "ref-1",
             "share_token": "tok-aaaaaaaaaaaaaaaaaa",
-            "response_data": {
+            "full_response": {
                 "products": [{"name": "iPhone"}],
                 "winner": {"name": "iPhone"},
                 "preferences": {"priorities": ["best_price"]},  # MUST be stripped
@@ -534,7 +534,7 @@ class TestResolveInvite:
 
         # Comparison owner is DIFFERENT from referrer
         wrong_comp = MagicMock(data={
-            "id": "c", "user_id": "DIFFERENT-USER", "share_token": "t", "response_data": {},
+            "id": "c", "user_id": "DIFFERENT-USER", "share_token": "t", "full_response": {},
         })
         client.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = wrong_comp
 
@@ -555,7 +555,7 @@ class TestResolveInvite:
         )
 
         comp = MagicMock(data={
-            "id": "c", "user_id": "ref-1", "share_token": "t", "response_data": {},
+            "id": "c", "user_id": "ref-1", "share_token": "t", "full_response": {},
         })
         invite_already_viewed = MagicMock(data=[{"id": "i", "first_viewed_at": "2026-05-04T00:00:00Z"}])
 
@@ -595,7 +595,7 @@ class TestRunInviteeQuiz:
         client = MagicMock()
         comp = MagicMock(data={
             "id": "c1",
-            "response_data": {
+            "full_response": {
                 "products": [{"name": "iPhone"}, {"name": "Galaxy"}],
                 "winner": {"name": "iPhone"},
                 "scoring": {"scoring_method": "category_weighted"},

--- a/tests/test_referral_share_privacy.py
+++ b/tests/test_referral_share_privacy.py
@@ -100,7 +100,7 @@ class TestResolveInviteHonorsPrivacy:
                 "id": "cmp-1",
                 "user_id": "ref-1",
                 "share_token": "tok",
-                "response_data": {
+                "full_response": {
                     "products": [{"name": "iPhone"}, {"name": "Galaxy"}],
                     "winner": {"name": "iPhone"},
                     "winner_index": 0,
@@ -143,7 +143,7 @@ class TestResolveInviteHonorsPrivacy:
                 "id": "c",
                 "user_id": "ref",
                 "share_token": "tok",
-                "response_data": {
+                "full_response": {
                     "products": [{"name": "A"}, {"name": "B"}],
                     "winner": {"name": "A"},
                     "winner_index": 0,
@@ -183,7 +183,7 @@ class TestResolveInviteHonorsPrivacy:
                 "id": "c",
                 "user_id": "ref",
                 "share_token": "tok",
-                "response_data": {
+                "full_response": {
                     "products": [{"name": "A"}, {"name": "B"}],
                     "winner": {"name": "A"},
                     "verdict": "Detailed verdict prose here",
@@ -226,7 +226,7 @@ class TestResolveInviteHonorsPrivacy:
                 "id": "c",
                 "user_id": "ref",
                 "share_token": "tok",
-                "response_data": {
+                "full_response": {
                     "products": [{"name": "A"}],
                     "winner": {"name": "A"},
                     "verdict": "A wins",


### PR DESCRIPTION
First wave from the M18 **P2/P3** backlog. All 147 findings were re-triaged against current `main` first — and the result corrected an assumption worth recording: **only 12 were already fixed. 130 survive.** The seven P1 waves fixed the P1s and left the backlog essentially untouched.

Two of the survivors turned out to be **live production breakage**, both filed as P2.

## 1. Every referral invite landing has been broken

`referral_service` selected and read a `response_data` column at four sites. **No migration has ever defined that column** — `grep -rn response_data migrations/` returns nothing — and the only writer of comparison payloads uses `full_response` (migration 001, `database_service.py:215`). With `ENABLE_REFERRAL_SYSTEM` ON in Railway, every invite landing and invitee quiz either PostgREST-errored or rendered empty products.

The existing referral tests **mocked the wrong column**, which is why they never caught it. Their fixture keys are corrected here; no assertion was changed.

Confirmed before renaming that `full_response`'s shape is what the consumers actually expect — it is the same payload `share_routes` already serves with the same personalization strip, so a rename is sufficient.

## 2. All Results analytics and all feedback have been silently dead

`ResultsScreen` sent `metadata.query` as `comparison_id`. The backend UUID-validates that field on **both** `/feedback` and `/events` (added in M13 wave 1), so every Results event batch and every feedback submission returned **422** — and `trackEvents` swallows the error, so nothing ever surfaced.

The same root cause left `sharableComparisonId` permanently null, which is why the share and referral Loop-1 flow was unreachable from Results. `getComparison` now keeps `wrapper.comparison.id` instead of discarding it.

## Four small wins

- **Grocery schema** — the non-negotiable field list demanded `weight`; the schema defines `size`. Every cold grocery compare chased an unfillable field through paid Tier-2/3 extraction. A new fence asserts every non-negotiable and preferred field exists in its category's schema, so this drift class cannot recur.
- **`model_knowledge` marker** — the internal fabrication-provenance marker shipped to API clients. The strip also closes a RED baseline pin, `test_response_builder_strips_inference_source`.
- **Freemium counter axes** — the on-phone gate compared LIFETIME used against lifetime + **monthly** bonus. Wrong in both directions: free users past lifetime-3 were client-paywalled when the backend would have allowed the compare, and each consumed bonus permanently eroded future windows. Now mirrors `check_usage_allowed`.
- **ContactUs prefix** — built from the *localized* label, so Arabic reporters produced `[خلل]`, invisible to the documented `LIKE '[Bug]%'` triage grep. Support tickets from the primary market were silently falling on the floor. Also fixed a 2000-vs-1000 silent truncation and a hardcoded `useful: true`.

## Gates

- TDD red-first per unit, each failing at base for its predicted reason.
- Mobile: **`npx tsc --noEmit` exit 0**, **jest 2153 passed**. (The IDE flagged a `win_margin` type error and an unused `CATEGORY_TAGS`; both are stale-LSP false positives — `tsc` is clean and `CATEGORY_TAGS` is used at `ContactUsScreen.tsx:83-86`. CLAUDE.md's warning about Windows LSP diagnostics held.)
- Backend: targeted suites green, `ruff` blocking tier clean, per-unit module-reference comm gates with `branch-only-NEW == []`.
- Byte-identity **N/A** — the price-extraction path is untouched.

## Two things for the merger

**Every mobile fix here is main-only until `eas update` publishes it.** Until then phones keep 422-ing analytics, keep the wrong paywall math, and keep the localized contact prefix.

**One semantic shift to expect:** ContactUs now sends `useful: false` for bug reports instead of a hardcoded `true`. Any dashboard averaging `comparison_feedback.useful` will move once bug reports stop counting as positive — that is the correct reading, but it will look like a metric regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)