### PR TITLE
fix(rtl): revert the textAlign double-flip — RN already mirrors physical sides (W3-11a, OTA blocker)

### DIFF
--- a/SmartCompareApp/__tests__/UpdateRequiredScreen.a9.test.tsx
+++ b/SmartCompareApp/__tests__/UpdateRequiredScreen.a9.test.tsx
@@ -125,9 +125,13 @@ describe('UpdateRequiredScreen', () => {
       path.resolve(__dirname, '../src/screens/UpdateRequiredScreen.tsx'),
       'utf8'
     );
-    // The M21 W4 fences (__tests__/rtl/*) enforce these repo-wide by an
-    // explicit file table; a new screen has to hold the same line or it
-    // silently bypasses the sweep.
+    // SCOPE: this rule is about THIS screen, which is centred and
+    // direction-neutral, so any physical left/right here is a smell.
+    // It is NOT a repo-wide policy, and the comment that used to say so
+    // was wrong (corrected in W3-11a). RN mirrors physical textAlign
+    // under RTL on every platform path, so elsewhere the BARE literal is
+    // the correct form and __tests__/rtl/textAlignLogical.contract.test.ts
+    // now requires it. Do not generalise the assertion below.
     expect(src).not.toMatch(/textAlign:\s*'(left|right)'/);
     expect(src).not.toMatch(/<(ArrowLeft|ChevronLeft|ChevronRight)\b/);
     expect(src).not.toMatch(/(marginLeft|marginRight|paddingLeft|paddingRight):/);

--- a/SmartCompareApp/__tests__/rtl/textAlignLogical.contract.test.ts
+++ b/SmartCompareApp/__tests__/rtl/textAlignLogical.contract.test.ts
@@ -1,23 +1,65 @@
 /**
- * Physical textAlign fence — M21 W4 rtl-i18n (MB-i18n-rtl-05).
+ * Physical textAlign fence — W3-11a, the revert of the M21 W4 double-flip
+ * (finding MB-I18N-RTL-03).
  *
- * RN's `textAlign: 'left' | 'right'` is PHYSICAL — it does not follow
- * I18nManager.isRTL. Five style sites hard-coded a physical side, so under
- * RTL (where the surrounding flex rows DO mirror) the text aligned away
- * from its anchor:
+ * ---------------------------------------------------------------------------
+ * THE PREMISE THE M21 W4 FIX WAS BUILT ON IS FALSE.
+ * ---------------------------------------------------------------------------
+ * The previous version of this file asserted, in prose and in its assertions,
+ * that "RN's `textAlign: 'left' | 'right'` is PHYSICAL — it does not follow
+ * I18nManager.isRTL". That is wrong, and it is what produced the wrong fix.
  *
- *   - ResultsAccordion.specsCellValueLeft / specsCellValueRight — the two
- *     spec-value columns hug the centered label; physical align pushes
- *     them off the label under RTL.
- *   - DimensionBars.legendNameRight — product-B legend name.
- *   - ContactUsScreen.charCount — char counter should sit at the logical
- *     END of the textarea.
- *   - ProfileEditorialSections.prioritiesPercent — percent column at the
- *     logical end of the priorities bar row.
+ * MEASURED against the pinned `react-native@0.81.5` source in node_modules.
+ * All four platform paths already mirror `left`/`right` under RTL:
  *
- * Contract: each site derives its side from I18nManager.isRTL. (isRTL is
- * fixed for the app lifetime — a direction change forces an app restart —
- * so StyleSheet.create-time evaluation is correct.)
+ *  1. iOS (classic + Fabric) —
+ *     `Libraries/Text/RCTTextAttributes.mm:107-115` (`effectiveParagraphStyle`):
+ *     under `UIUserInterfaceLayoutDirectionRightToLeft`, `NSTextAlignmentRight`
+ *     becomes `Left` and `NSTextAlignmentLeft` becomes `Right`. This is the one
+ *     shared implementation — `effectiveParagraphStyle` is reached only via
+ *     `effectiveTextAttributes`, which every Text/TextInput shadow view uses.
+ *
+ *  2. Android (classic) —
+ *     `ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java:294-297`:
+ *       "left"  -> isRTL ? Gravity.RIGHT : Gravity.LEFT
+ *       "right" -> isRTL ? Gravity.LEFT  : Gravity.RIGHT
+ *
+ *  3. Android (Fabric) —
+ *     `ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt:169-198`.
+ *     Reaches the same outcome by a different route, and the route matters
+ *     because it LOOKS content-dependent and is not. Android resolves
+ *     `ALIGN_NORMAL` against the SCRIPT direction, so RN computes
+ *     `swapNormalAndOpposite = (isParagraphRTL != isScriptRTL)` (`:180`) to
+ *     re-anchor alignment to the PARAGRAPH direction. Working the cases
+ *     through, `'right'` lands on physical right in an LTR paragraph and
+ *     physical left in an RTL paragraph — for Arabic AND Latin content alike.
+ *     The compensation exists precisely to make the outcome script-independent.
+ *
+ * CONSEQUENCE: `textAlign: I18nManager.isRTL ? 'left' : 'right'` applies a
+ * SECOND flip on top of RN's own, landing back on the physical side it started
+ * from. Under RTL every site below aligns to the WRONG edge — the exact defect
+ * M21 W4 set out to fix. The LTR branch of each ternary is a no-op; the RTL
+ * branch is pure regression.
+ *
+ * Corroborated in-repo: `src/components/TwoInputShell.tsx` already learned
+ * this same lesson for `flexDirection` ("RN mirrors it natively under
+ * forceRTL; an explicit reverse cancelled that mirroring"). The app calls
+ * `allowRTL(true)` + `forceRTL(...)` and never `swapLeftAndRightInRTL(false)`,
+ * so RN's default mirroring is fully active.
+ *
+ * ---------------------------------------------------------------------------
+ * CONTRACT (inverted vs the M21 W4 version of this file)
+ * ---------------------------------------------------------------------------
+ * Each style in SITES carries the BARE physical literal. For the five M21 W4
+ * sites that is exactly what stood at `593ec1e`; the sixth
+ * (`InviteeQuizScreen.charCount`) predates `593ec1e` and pins its own
+ * pre-`acca7434` value — see the note on that row. The `I18nManager.isRTL`
+ * ternary is FORBIDDEN on these styles: RN already mirrors them, so
+ * re-introducing it re-introduces the bug.
+ *
+ * If you are here because you think one of these sites aligns to the wrong
+ * edge under RTL, read the three source locations above FIRST — they take
+ * about a minute to check — and do not re-apply the ternary.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -35,22 +77,131 @@ function styleBody(src: string, styleName: string): string {
   return m[0];
 }
 
-const SITES: Array<[file: string, style: string]> = [
-  ['components/results/ResultsAccordion.tsx', 'specsCellValueLeft'],
-  ['components/results/ResultsAccordion.tsx', 'specsCellValueRight'],
-  ['components/results/DimensionBars.tsx', 'legendNameRight'],
-  ['screens/ContactUsScreen.tsx', 'charCount'],
-  ['components/ProfileEditorialSections.tsx', 'prioritiesPercent'],
+/**
+ * Return the bare physical literal a style assigns to `textAlign`, or — when
+ * the value is not a bare literal — the raw expression, so a failure reads
+ * `Expected: "right" / Received: "I18nManager.isRTL ? 'left' : 'right'"`.
+ */
+function textAlignValue(body: string): string {
+  const bare = body.match(/textAlign:\s*'([a-z]+)'\s*,/);
+  if (bare) return bare[1];
+  const raw = body.match(/textAlign:\s*([^\n]+?),?\s*$/m);
+  return raw ? raw[1].trim() : '<no textAlign in style body>';
+}
+
+interface Site {
+  file: string;
+  style: string;
+  /**
+   * The bare literal to restore. For the five M21 W4 sites this is the value
+   * at `593ec1e` — what every build users have ever run shipped. For the
+   * sixth (InviteeQuizScreen) it is the pre-`acca7434` value, since the
+   * double-flip there predates `593ec1e`.
+   */
+  expected: 'left' | 'right';
+}
+
+const SITES: Site[] = [
+  {
+    file: 'components/results/ResultsAccordion.tsx',
+    style: 'specsCellValueLeft',
+    expected: 'right',
+  },
+  {
+    file: 'components/results/ResultsAccordion.tsx',
+    style: 'specsCellValueRight',
+    expected: 'left',
+  },
+  {
+    file: 'components/results/DimensionBars.tsx',
+    style: 'legendNameRight',
+    expected: 'right',
+  },
+  { file: 'screens/ContactUsScreen.tsx', style: 'charCount', expected: 'right' },
+  {
+    file: 'components/ProfileEditorialSections.tsx',
+    style: 'prioritiesPercent',
+    expected: 'right',
+  },
+  // SIXTH SITE — not in the W3-11a spec's five-row table, and NOT an M21 W4
+  // site. The double-flip here predates `593ec1e`: it was introduced by
+  // `acca7434` (2026-05-07, "use logical properties ... for direction-aware
+  // spacing"), so `593ec1e` already carries the ternary. Its pre-`acca7434`
+  // value was the bare `'right'` this pins, so restoring it is still a revert
+  // — just to an older baseline. It is the identical twin of the
+  // `ContactUsScreen.charCount` row above: same style name, same widget (a
+  // `{n}/{max}` counter under a textarea), same intended trailing edge.
+  //
+  // RISK-CLASS DIFFERENCE, deliberately recorded: `acca7434` IS an ancestor of
+  // `97b5f15`, the `preview` build on phones, so unlike the five rows above
+  // this one is a LIVE Arabic misalignment today rather than a main-only
+  // regression. The "restores exactly the bytes users have already run"
+  // safety argument therefore does NOT cover this row — it wants the
+  // on-device Arabic check, and it is one line for a reviewer to drop.
+  {
+    file: 'screens/InviteeQuizScreen.tsx',
+    style: 'charCount',
+    expected: 'right',
+  },
 ];
 
-describe('textAlign left/right sites are I18nManager-conditional (MB-i18n-rtl-05)', () => {
-  for (const [file, style] of SITES) {
-    it(`${file} :: ${style}`, () => {
+describe('textAlign sites carry the bare physical literal — RN mirrors it (MB-I18N-RTL-03)', () => {
+  for (const { file, style } of SITES) {
+    it(`${file} :: ${style} has no I18nManager.isRTL ternary`, () => {
       const body = styleBody(read(file), style);
-      // The physical literal may only appear as a branch of an
-      // I18nManager.isRTL conditional, never bare.
-      expect(body).toMatch(/textAlign:\s*I18nManager\.isRTL\s*\?/);
-      expect(body).not.toMatch(/textAlign:\s*'(left|right)'/);
+      // RN already flips left/right under RTL on all four platform paths, so a
+      // second flip here lands back on the wrong edge. Bare literal only.
+      expect(body).toMatch(/textAlign:\s*'(left|right)'/);
+      expect(body).not.toMatch(/textAlign:\s*I18nManager\.isRTL\s*\?/);
     });
   }
+});
+
+describe('the restored literal is a REVERT, not a new opinion', () => {
+  for (const { file, style, expected } of SITES) {
+    it(`${file} :: ${style} is '${expected}' as at its pre-flip baseline`, () => {
+      // Pins the exact pre-M21-W4 value. Under LTR the M21 W4 ternary already
+      // evaluated to this same literal, so this is also the proof that the
+      // revert is a no-op for every LTR user.
+      expect(textAlignValue(styleBody(read(file), style))).toBe(expected);
+    });
+  }
+});
+
+describe('no textAlign anywhere in src/ is written as an I18nManager.isRTL ternary', () => {
+  const TERNARY = /textAlign:\s*I18nManager\.isRTL\s*\?/;
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full, out);
+      else if (/\.tsx?$/.test(entry.name)) out.push(full);
+    }
+    return out;
+  }
+
+  it('catches a re-application in any file, including ones SITES does not name', () => {
+    // Scanned over the WHOLE FILE TEXT, not line by line (Fable review, W3-11a).
+    // A line-scoped version of this pin was blind to a WRAPPED re-application:
+    //     textAlign: I18nManager.isRTL
+    //       ? 'left'
+    //       : 'right',
+    // The pattern's whitespace class spans newlines, but testing each line in
+    // isolation means the '?' on the next line is never seen. Prettier produces
+    // exactly that wrap once the expression grows. This is the ONLY fence
+    // covering files SITES does not name, and it is the fence that caught the
+    // sixth site - a gap here is the difference between a real guard and a
+    // decorative one.
+    const hits: string[] = [];
+    for (const file of walk(ROOT)) {
+      const text = fs.readFileSync(file, 'utf8');
+      const rx = new RegExp(TERNARY.source, 'g');
+      for (const m of text.matchAll(rx)) {
+        const rel = path.relative(ROOT, file).split(path.sep).join('/');
+        const line = (text.slice(0, m.index).match(/\n/g) || []).length + 1;
+        hits.push('src/' + rel + ':' + line);
+      }
+    }
+    expect(hits).toEqual([]);
+  });
 });

--- a/SmartCompareApp/src/components/ProfileEditorialSections.tsx
+++ b/SmartCompareApp/src/components/ProfileEditorialSections.tsx
@@ -32,7 +32,6 @@ import {
   TouchableOpacity,
   ScrollView,
   StyleSheet,
-  I18nManager,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Check, Plus } from 'lucide-react-native';
@@ -615,9 +614,11 @@ const styles = StyleSheet.create({
   },
   prioritiesPercent: {
     width: 36,
-    // Percent column reads toward the LOGICAL end of the mirrored bar
-    // row; physical align must swap under RTL (M21 W4 MB-i18n-rtl-05).
-    textAlign: I18nManager.isRTL ? 'left' : 'right',
+    // Percent column reads toward the trailing end of the mirrored bar row.
+    // RN mirrors physical left/right under RTL on every platform path, so the
+    // bare literal is already correct in both directions — see
+    // __tests__/rtl/textAlignLogical.contract.test.ts before adding a ternary.
+    textAlign: 'right',
     ...typography.small,
     color: colors.text.secondary,
   },

--- a/SmartCompareApp/src/components/results/DimensionBars.tsx
+++ b/SmartCompareApp/src/components/results/DimensionBars.tsx
@@ -26,7 +26,7 @@
  */
 
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, I18nManager } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import * as Haptics from 'expo-haptics';
 import { ChevronDown, ChevronUp } from 'lucide-react-native';
@@ -449,9 +449,10 @@ const styles = StyleSheet.create({
     color: colors.text.secondary,
   },
   legendNameRight: {
-    // Physical align must swap with the mirrored legend row under RTL
-    // (M21 W4 MB-i18n-rtl-05); isRTL is fixed for the app lifetime.
-    textAlign: I18nManager.isRTL ? 'left' : 'right',
+    // RN mirrors physical left/right under RTL on every platform path, so
+    // this bare literal lands on the trailing edge in both directions — see
+    // __tests__/rtl/textAlignLogical.contract.test.ts before adding a ternary.
+    textAlign: 'right',
   },
   legendDot: {
     fontSize: 12,

--- a/SmartCompareApp/src/components/results/ResultsAccordion.tsx
+++ b/SmartCompareApp/src/components/results/ResultsAccordion.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, I18nManager } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { ChevronDown, Star, ListChecks, BarChart3, Info } from 'lucide-react-native';
 import { useTranslation } from 'react-i18next';
 import { colors, spacing } from '../../theme';
@@ -878,17 +878,16 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: colors.text.primary,
   },
-  // First value cell hugs the centered label; the second reads outward
-  // from it. RN textAlign left/right is PHYSICAL (it does not follow
-  // I18nManager), while the surrounding flex row DOES mirror under RTL —
-  // so the sides must swap with direction (M21 W4 MB-i18n-rtl-05).
-  // isRTL is fixed for the app lifetime (direction change = restart), so
-  // StyleSheet.create-time evaluation is safe.
+  // Left value cell hugs the centered label (right-aligned per mockup).
+  // RN mirrors physical left/right under RTL on every platform path, so the
+  // bare literal already lands on the correct edge in both directions — see
+  // __tests__/rtl/textAlignLogical.contract.test.ts before adding a ternary.
   specsCellValueLeft: {
-    textAlign: I18nManager.isRTL ? 'left' : 'right',
+    textAlign: 'right',
   },
+  // Right value cell reads outward from the centered label (left-aligned).
   specsCellValueRight: {
-    textAlign: I18nManager.isRTL ? 'right' : 'left',
+    textAlign: 'left',
   },
   // Lane A-L3 Task L3.2 — winning spec cell paints emerald (accent),
   // bold weight, per design Screen 4.

--- a/SmartCompareApp/src/screens/ContactUsScreen.tsx
+++ b/SmartCompareApp/src/screens/ContactUsScreen.tsx
@@ -18,7 +18,6 @@ import {
   Platform,
   Linking,
   ActivityIndicator,
-  I18nManager,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft } from 'lucide-react-native';
@@ -304,9 +303,11 @@ const styles = StyleSheet.create({
   charCount: {
     ...typography.small,
     color: colors.text.placeholder,
-    // Counter sits at the LOGICAL end of the textarea; textAlign is
-    // physical in RN so it must swap under RTL (M21 W4 MB-i18n-rtl-05).
-    textAlign: I18nManager.isRTL ? 'left' : 'right',
+    // Counter sits at the trailing end of the textarea. RN mirrors physical
+    // left/right under RTL on every platform path, so the bare literal is
+    // already correct in both directions — see
+    // __tests__/rtl/textAlignLogical.contract.test.ts before adding a ternary.
+    textAlign: 'right',
     marginBottom: spacing.md,
   },
   btn: {

--- a/SmartCompareApp/src/screens/InviteeQuizScreen.tsx
+++ b/SmartCompareApp/src/screens/InviteeQuizScreen.tsx
@@ -22,7 +22,6 @@ import {
   ActivityIndicator,
   SafeAreaView,
   Platform,
-  I18nManager,
 } from 'react-native';
 import Animated, { FadeIn, FadeInDown } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
@@ -501,9 +500,12 @@ const styles = StyleSheet.create({
     ...typography.small,
     color: colors.text.placeholder,
     marginTop: spacing.xs,
-    // Trailing-edge alignment — flips to 'left' under RTL so the counter
-    // stays at the bottom-trailing corner of the textarea in both locales.
-    textAlign: I18nManager.isRTL ? 'left' : 'right',
+    // Trailing-edge alignment. RN mirrors physical left/right under RTL on
+    // every platform path, so the bare literal already keeps the counter at
+    // the bottom-trailing corner in both locales — an explicit isRTL ternary
+    // double-flips it back to the leading edge. See
+    // __tests__/rtl/textAlignLogical.contract.test.ts before adding one.
+    textAlign: 'right',
   },
   errorText: {
     ...typography.small,


### PR DESCRIPTION
## W3-11a — revert the M21 W4 `textAlign` double-flip (`MB-I18N-RTL-03`)

**This is the last code blocker on the `eas update --branch preview` OTA.** Precondition (1) — the W1-4 `/auth/refresh` 503 fix — is live at `98f320fb`. This is precondition (2). W3-12 (Sentry-init ordering) is the remaining "if possible" item.

### The premise the fix was built on is false

`__tests__/rtl/textAlignLogical.contract.test.ts` stated it outright:

> RN's `textAlign: 'left' | 'right'` is PHYSICAL — it does not follow `I18nManager.isRTL`

Measured against the **pinned `react-native@0.81.5` source in `node_modules`**, not from docs or memory. All four platform paths already mirror it under RTL:

| path | location | behaviour |
|---|---|---|
| iOS (classic + Fabric) | `Libraries/Text/RCTTextAttributes.mm:107-115` | under `RightToLeft`, `NSTextAlignmentRight`↔`Left`. One shared impl — every Text/TextInput reaches it via `effectiveTextAttributes` |
| Android (classic) | `TextAttributeProps.java:294-297` | `"left"`→`isRTL ? RIGHT : LEFT`; `"right"`→`isRTL ? LEFT : RIGHT` |
| Android (Fabric) | `TextLayoutManager.kt:169-198` | same outcome via `swapNormalAndOpposite = (isParagraphRTL != isScriptRTL)`, which exists precisely to make the result script-independent |

So `isRTL ? 'left' : 'right'` applies a **second** flip and lands back where it started. Under RTL these sites align to the wrong edge — the exact defect M21 W4 set out to fix.

The shape is mechanical: every site was `isRTL ? <opposite of baseline> : <baseline>`. The LTR branch is a no-op; the RTL branch is pure regression.

### What changed

Six sites reverted to the bare literal; five dead `I18nManager` imports removed; the fence **inverted** (requires the bare literal, forbids the ternary) and its docstring rewritten with the three source citations.

| site | restored to | baseline |
|---|---|---|
| `ResultsAccordion.specsCellValueLeft` | `'right'` | `593ec1e` |
| `ResultsAccordion.specsCellValueRight` | `'left'` | `593ec1e` |
| `DimensionBars.legendNameRight` | `'right'` | `593ec1e` |
| `ContactUsScreen.charCount` | `'right'` | `593ec1e` |
| `ProfileEditorialSections.prioritiesPercent` | `'right'` | `593ec1e` |
| `InviteeQuizScreen.charCount` | `'right'` | pre-`acca7434` |

### The sixth site is not like the other five — read this before merging

Five are M21 W4's and are **main-only**: zero ternaries in the phones' `preview` build `97b5f15`, so no user has ever seen them. For those, this restores exactly the bytes every shipped build has run.

`InviteeQuizScreen.charCount` is different. It was introduced by `acca7434`, which **is an ancestor of `97b5f15`** (`git merge-base --is-ancestor` exits 0, ternary present at line 500). So it is a **live Arabic misalignment today**, on the referral path (`ENABLE_REFERRAL_SYSTEM=true` in production). Its pre-`acca7434` value was the same bare `'right'` restored here, so it is still a revert — to an older baseline.

It was **not in my spec**. The repo-wide fence found it on its first run, which is the fence doing its job; I ruled it in rather than narrowing the pin, because shipping the Arabic-OTA-unblocking change with a proven Arabic misalignment still in it would be incoherent. Practical reachability is limited — the screen is only reachable via `q/:share_token` deep links, which currently target the unconfigured `qaren.app` origin.

### Verification limit — stated plainly

**The RTL branch has zero executed test coverage.** `__mocks__/react-native.ts` pins `isRTL: false`, so all 2,737 passing tests and 44 snapshots exercise only the LTR path. An adversarial check restored the *full* double-flip and ran the estate with only the contract file excluded: **277 suites and 2,724 tests passed, 44/44 snapshots passed.** A snapshot even records `"textAlign": "right"` for an affected cell and is byte-stable across the fix and its reversal — it looks like coverage of this exact property and is not.

Only the source-text contract fence can catch this class. Correctness under RTL rests on the pinned RN source above. **The on-device Arabic walkthrough remains required**, and it matters most for `InviteeQuizScreen.charCount`, the one site whose rendering a user could already have formed an expectation about.

### Review hardening beyond the revert

- The repo-wide fence now scans **whole file text**, not line by line. The line-scoped version was blind to a prettier-wrapped re-application (`\s` spans newlines, but per-line testing never sees the `?`). Verified: a wrapped probe is now caught at the right line, and the pin goes green when removed. This is the only fence covering files the site table does not name — and it is what caught the sixth site.
- Corrected a comment in `UpdateRequiredScreen.a9.test.tsx` claiming the rtl fences enforce "no physical textAlign" repo-wide. That is now the opposite of the policy. Its assertion is legitimately scoped to one centred screen and is unchanged.

### Gates

- Red-first: 11 right-reason failures before any `src/` edit.
- `npx --no-install tsc --noEmit` → exit 0. `eslint` clean.
- Contract file 13/13. Full suite **278 suites / 2,737 tests / 44 snapshots, 0 failures**.
- Fence proven to fail with a re-planted ternary (3 failures) and with a wrapped one.
- Six literals verified independently against their git baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
