### PR TITLE
feat(ops): bound ingress concurrency and report event-loop lag on /health (W1-7 + W1-10)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+web: uvicorn app.main:app --host 0.0.0.0 --port $PORT --limit-concurrency "${UVICORN_LIMIT_CONCURRENCY:-512}"

--- a/app/main.py
+++ b/app/main.py
@@ -171,6 +171,89 @@ async def _install_default_executor() -> None:
     install_default_executor()
 
 
+# W1-10 (LS-FAILURE-MODES-COST-13 / #81) -- event-loop lag heartbeat.
+#
+# /health returned a static two-key dict, so nothing reported whether the single
+# uvicorn worker's loop was actually TURNING -- the one measurement that
+# distinguishes "the app is slow" from "the app is wedged". A heartbeat that was
+# due at T and runs at T+11s reports 11,000 ms; measuring inside the handler
+# cannot see that interval at all, because the handler only runs when the loop is
+# already running.
+#
+# The LAST value and the rolling MAX since process start are both reported: an
+# external probe polling every 30 s samples 1 second in 30 and would miss almost
+# every stall, so the max is what lets a low-frequency probe see one.
+import asyncio
+
+LOOP_LAG_INTERVAL_SECONDS: float = 1.0
+
+_loop_lag_last_ms: float = 0.0
+_loop_lag_max_ms: float = 0.0
+
+# The heartbeat task handle, so shutdown can cancel it. None before startup.
+_loop_lag_task = None
+
+
+def record_loop_lag_tick(elapsed_seconds: float) -> None:
+    """Record ONE heartbeat tick.
+
+    ``lag_ms = max(0, (elapsed_seconds - LOOP_LAG_INTERVAL_SECONDS) * 1000)`` --
+    floored at zero because an elapsed shorter than the interval is clock
+    granularity, not negative lag, and a negative value would corrupt the max.
+    """
+    global _loop_lag_last_ms, _loop_lag_max_ms
+    lag_ms = (float(elapsed_seconds) - LOOP_LAG_INTERVAL_SECONDS) * 1000.0
+    if lag_ms < 0.0:
+        lag_ms = 0.0
+    _loop_lag_last_ms = lag_ms
+    if lag_ms > _loop_lag_max_ms:
+        _loop_lag_max_ms = lag_ms
+
+
+def loop_lag_snapshot() -> dict:
+    """The two loop-lag numbers /health merges into its payload. A dict read."""
+    return {
+        "loop_lag_ms": _loop_lag_last_ms,
+        "loop_lag_max_ms": _loop_lag_max_ms,
+    }
+
+
+async def _loop_lag_heartbeat() -> None:
+    """Sleep on the interval and record how far each wake-up overshot it.
+
+    Deliberately carries NO exception handler: ``asyncio.CancelledError`` is a
+    ``BaseException`` and MUST propagate so shutdown can actually stop this task.
+    """
+    loop = asyncio.get_running_loop()
+    previous = loop.time()
+    while True:
+        await asyncio.sleep(LOOP_LAG_INTERVAL_SECONDS)
+        now = loop.time()
+        record_loop_lag_tick(now - previous)
+        previous = now
+
+
+@app.on_event("startup")
+async def _start_loop_lag_heartbeat() -> None:
+    global _loop_lag_task
+    _loop_lag_task = asyncio.create_task(_loop_lag_heartbeat())
+
+
+@app.on_event("shutdown")
+async def _stop_loop_lag_heartbeat() -> None:
+    global _loop_lag_task
+    task = _loop_lag_task
+    if task is None:
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        # Suppressed at the CANCELLER; the coroutine itself still propagates.
+        pass
+    _loop_lag_task = None
+
+
 # -- Routes --
 app.include_router(auth_router)      # /api/v1/auth/*
 app.include_router(text_router)      # /api/v1/text/*
@@ -301,15 +384,31 @@ async def root():
 # Cold-start prevention: Railway supports cron jobs to keep the service warm.
 # Set up a Railway cron service that pings GET /health every 5 minutes:
 #   Schedule: */5 * * * *
-#   Command:  curl -sf https://smartcompare-backend-production.up.railway.app/health
+#   Command:  curl -sf https://web-production-58776.up.railway.app/health
+#
+# W1-10 (2026-09-08): the host above USED to read
+# `smartcompare-backend-production.up.railway.app`, which returns Railway's edge
+# 404 "Application not found" -- no service is bound to it. The live service is
+# the host now written here (verified 200), and it is the one the mobile client
+# already targets (`SmartCompareApp/src/services/api.ts`). Anyone who had
+# followed these instructions would have built a cron against a dead hostname
+# and believed the worker was being kept warm.
 # This prevents the ~10-20s cold start penalty on first request after idle.
 
 @app.get("/health")
 async def health_check():
-    """Basic health check"""
+    """Basic health check
+
+    Additive only: `status` and `message` keep their exact values (an external
+    uptime check may be string-matching them). The two loop-lag numbers are a
+    pure dict read of state the heartbeat already wrote -- no await, no I/O.
+    This is Railway's deploy healthcheck with a 30 s timeout and must not become
+    a thing that can fail.
+    """
     return {
         "status": "healthy",
-        "message": "Qaren API is running"
+        "message": "Qaren API is running",
+        **loop_lag_snapshot()
     }
 
 

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "uvicorn app.main:app --host 0.0.0.0 --port $PORT",
+    "startCommand": "uvicorn app.main:app --host 0.0.0.0 --port $PORT --limit-concurrency \"${UVICORN_LIMIT_CONCURRENCY:-512}\"",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",

--- a/tests/test_health_loop_lag.py
+++ b/tests/test_health_loop_lag.py
@@ -1,0 +1,478 @@
+"""W1-10 (SESSION 65) RED tests -- ``/health`` reports event-loop lag.
+
+Finding ``LS-FAILURE-MODES-COST-13`` / issue ``#81``. ``GET /health`` returns a
+static two-key dict (``app/main.py``: ``{"status": "healthy", "message":
+"Qaren API is running"}``). Nothing anywhere reports whether the single uvicorn
+worker's loop is actually TURNING. That is the one measurement that
+distinguishes "the app is slow" from "the app is wedged", and it is the signal
+the activation runbook says to watch through every W5 STEP 0 flag flip.
+
+WHY A HEARTBEAT AND NOT AN INLINE MEASUREMENT
+    Measuring inside the handler (``t0 = loop.time(); await asyncio.sleep(0)``)
+    only samples the loop at a moment it is demonstrably already running -- it
+    cannot observe the interval during which the loop was BLOCKED, which is the
+    entire question. A heartbeat due at T that runs at T+11s reports 11,000 ms,
+    which is exactly the ``getaddrinfo`` stall W0-1 exists to bound.
+
+-------------------------------------------------------------------------------
+CONTRACT PINNED BY THESE TESTS  (``app/main.py`` -- W1-10 is app/main.py only)
+-------------------------------------------------------------------------------
+The spec names the DESIGN (a startup task looping on ``await
+asyncio.sleep(INTERVAL)``, recording ``elapsed - INTERVAL`` in ms, keeping the
+LAST value and a rolling MAX, both reported by ``/health``) but does not name
+the symbols. These are the names the RED tests pin, so the GREEN implementer
+has one unambiguous target:
+
+  ``app.main.LOOP_LAG_INTERVAL_SECONDS`` : float
+      The heartbeat interval.
+
+  ``app.main.record_loop_lag_tick(elapsed_seconds: float) -> None``
+      Record ONE heartbeat tick. ``lag_ms = max(0.0, (elapsed_seconds -
+      LOOP_LAG_INTERVAL_SECONDS) * 1000.0)``. Updates the LAST value and the
+      rolling MAX since process start. This is the seam the tests drive
+      directly -- feeding the elapsed interval rather than sleeping on a real
+      clock, so a 500 ms overshoot is asserted deterministically and NOT via
+      wall-clock on a loaded CI box (the spec explicitly forbids the
+      ``time.sleep`` + wall-clock form as a flake).
+
+  ``app.main.loop_lag_snapshot() -> dict``
+      ``{"loop_lag_ms": <number>, "loop_lag_max_ms": <number>}`` -- exactly the
+      two keys ``/health`` merges into its payload. A pure dict read.
+
+  ``app.main._loop_lag_heartbeat()`` : coroutine function
+      The task body started on ``startup``. Its ``CancelledError`` must
+      PROPAGATE, not be swallowed.
+
+  ``app.main._loop_lag_task``
+      The ``asyncio.Task`` handle, so ``shutdown`` can cancel it. ``None``
+      before startup.
+
+CONSTRAINTS THE TESTS ALSO PIN
+  * The ``/health`` handler stays a DICT READ -- no awaits, no I/O. It is
+    Railway's deploy healthcheck with a 30 s timeout and must not become a
+    thing that can fail.
+  * ``max`` is reported ALONGSIDE ``last``: a probe polling every 30 s samples
+    1 second in 30 and would miss almost every stall; the max is what makes a
+    low-frequency probe able to see one.
+  * ADDITIVE ONLY: ``status`` and ``message`` keep their exact current values,
+    because an external uptime check may already be string-matching them.
+  * ``CancelledError`` is a ``BaseException``, so a bare ``except Exception``
+    will NOT catch it. The spec says verify that rather than assume it --
+    ``test_heartbeat_does_not_swallow_cancellation`` does exactly that against
+    the real coroutine, so a future ``except BaseException`` / bare ``except:``
+    / ``except asyncio.CancelledError: return`` regression is caught.
+
+-------------------------------------------------------------------------------
+Expected state at RED
+-------------------------------------------------------------------------------
+  * ``test_health_reports_loop_lag_keys_as_numbers``        -- RED (keys absent)
+  * ``test_recorder_reports_a_500ms_overshoot``             -- RED (no recorder)
+  * ``test_max_is_retained_after_a_subsequent_fast_tick``   -- RED (no recorder)
+  * ``test_heartbeat_task_is_started_and_cancelled_by_lifespan`` -- RED (no task)
+  * ``test_heartbeat_does_not_swallow_cancellation``        -- RED (no coroutine)
+  * ``test_health_status_and_message_are_unchanged``  -- GREEN, ADDITIVE PIN
+  * ``test_health_handler_is_a_pure_dict_read``       -- GREEN, CONSTRAINT PIN
+
+Every RED node above fails on an ASSERTION about behaviour that is genuinely
+absent -- never on a bare ``AttributeError``/``ImportError`` for a symbol that
+does not exist yet. ``_require`` turns a missing symbol into an explicit
+``pytest.fail`` naming the contract.
+"""
+import asyncio
+import inspect
+import numbers
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+import app.main as app_main
+
+# The current, shipped payload. Additive-only means these survive verbatim.
+_CURRENT_STATUS = "healthy"
+_CURRENT_MESSAGE = "Qaren API is running"
+
+_CONTRACT = (
+    "app/main.py must expose the W1-10 loop-lag recorder: "
+    "LOOP_LAG_INTERVAL_SECONDS (float), "
+    "record_loop_lag_tick(elapsed_seconds) -> None, "
+    "loop_lag_snapshot() -> {'loop_lag_ms': num, 'loop_lag_max_ms': num}, "
+    "_loop_lag_heartbeat() (coroutine fn), and _loop_lag_task (the Task handle). "
+    "See this module's docstring for the full contract."
+)
+
+
+def _require(name):
+    """Fetch a required contract symbol, or fail with WHAT is missing.
+
+    Deliberately not a bare ``getattr``: a RED run must say "the behaviour is
+    absent", not raise AttributeError from inside a test body.
+    """
+    sentinel = object()
+    value = getattr(app_main, name, sentinel)
+    if value is sentinel:
+        pytest.fail(f"app.main has no {name!r} -- behaviour absent.\n{_CONTRACT}")
+    return value
+
+
+def _health_payload() -> dict:
+    """GET /health through the real ASGI app."""
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200, (
+        f"/health returned {response.status_code}; it is Railway's deploy "
+        "healthcheck and must never fail"
+    )
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# 5 -- /health reports both lag numbers  (RED: neither key exists)
+# ---------------------------------------------------------------------------
+
+
+def test_health_reports_loop_lag_keys_as_numbers():
+    """RED today: ``/health`` is a static two-key dict with no loop signal.
+
+    Both keys are required. ``loop_lag_ms`` alone is not enough: an external
+    probe polling every 30 s samples 1 second in 30 and would miss almost every
+    stall, so ``loop_lag_max_ms`` (since process start) is what makes a
+    low-frequency probe able to SEE one.
+
+    Booleans are rejected explicitly -- ``bool`` is a subclass of ``int`` in
+    Python, and a placeholder ``True`` would otherwise sail through a naive
+    numeric check.
+    """
+    payload = _health_payload()
+
+    for key in ("loop_lag_ms", "loop_lag_max_ms"):
+        assert key in payload, (
+            f"/health payload has no {key!r}; nothing reports whether the single "
+            f"uvicorn worker's loop is turning. got keys={sorted(payload)}"
+        )
+        value = payload[key]
+        assert not isinstance(value, bool), f"/health {key!r} is a bool, not a number"
+        assert isinstance(value, numbers.Real), (
+            f"/health {key!r} must be a number (milliseconds); got "
+            f"{type(value).__name__} {value!r}"
+        )
+        assert value >= 0, f"/health {key!r} is negative: {value!r}"
+
+    assert payload["loop_lag_max_ms"] >= payload["loop_lag_ms"], (
+        "loop_lag_max_ms must be the rolling MAX since process start, so it can "
+        "never be below the last sample; got "
+        f"max={payload['loop_lag_max_ms']!r} last={payload['loop_lag_ms']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6 -- additive only  (GREEN today, must stay green)
+# ---------------------------------------------------------------------------
+
+
+def test_health_status_and_message_are_unchanged():
+    """ADDITIVE PIN -- GREEN TODAY and must stay green.
+
+    An external uptime check may already be string-matching these exact values,
+    so W1-10 may only ADD keys. Do not "tidy" the message.
+    """
+    payload = _health_payload()
+    assert payload.get("status") == _CURRENT_STATUS, (
+        f"/health 'status' changed from {_CURRENT_STATUS!r} to "
+        f"{payload.get('status')!r}; W1-10 is additive only"
+    )
+    assert payload.get("message") == _CURRENT_MESSAGE, (
+        f"/health 'message' changed from {_CURRENT_MESSAGE!r} to "
+        f"{payload.get('message')!r}; W1-10 is additive only"
+    )
+
+
+def test_health_handler_is_a_pure_dict_read():
+    """CONSTRAINT PIN -- GREEN TODAY and must stay green.
+
+    ``/health`` is Railway's deploy healthcheck with a 30 s timeout. It must
+    not become a thing that can fail or block: no ``await``, no I/O. The lag
+    numbers come from module state the heartbeat already wrote.
+
+    Source inspection is the right instrument here -- a behavioural test cannot
+    distinguish "read a dict" from "awaited something that happened to be fast".
+    """
+    handler = app_main.health_check
+    source = inspect.getsource(handler)
+    body = source.split("\n", 1)[1] if "\n" in source else ""
+
+    assert "await " not in body, (
+        "/health handler awaits something. It must stay a pure dict read -- it "
+        f"is the deploy healthcheck.\n{source}"
+    )
+    for forbidden in ("asyncio.sleep", "requests.", "httpx.", "get_cached", "execute("):
+        assert forbidden not in body, (
+            f"/health handler references {forbidden!r}; the handler must do no "
+            f"I/O.\n{source}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7 -- the recorder observes a real stall  (RED: no recorder exists)
+# ---------------------------------------------------------------------------
+
+
+def test_recorder_reports_a_500ms_overshoot():
+    """A heartbeat that overshoots its interval by 500 ms reports ~500 ms.
+
+    Driven directly with an explicit elapsed value rather than a wall-clock
+    sleep: the spec forbids a ``time.sleep``-and-assert-on-wall-clock test,
+    which is a flake on a loaded CI box.
+
+    RED today: ``app.main`` exposes no recorder at all.
+    """
+    interval = _require("LOOP_LAG_INTERVAL_SECONDS")
+    record = _require("record_loop_lag_tick")
+    snapshot = _require("loop_lag_snapshot")
+
+    assert isinstance(interval, numbers.Real) and interval > 0, (
+        f"LOOP_LAG_INTERVAL_SECONDS must be a positive number; got {interval!r}"
+    )
+
+    record(float(interval) + 0.5)
+    last = snapshot()["loop_lag_ms"]
+
+    assert last == pytest.approx(500.0, abs=1.0), (
+        "a tick that took INTERVAL + 0.5s must report ~500 ms of lag "
+        f"(elapsed - INTERVAL, in ms); got {last!r}"
+    )
+
+
+def test_max_is_retained_after_a_subsequent_fast_tick():
+    """The rolling MAX survives a healthy tick; the LAST value drops.
+
+    This is the property that lets a 30 s probe see a stall it never sampled.
+
+    Asserted RELATIVE to a baseline rather than against absolute zero, so the
+    test is order-independent: another test in the same process may already
+    have pushed the process-wide max up.
+
+    RED today: no recorder exists.
+    """
+    interval = float(_require("LOOP_LAG_INTERVAL_SECONDS"))
+    record = _require("record_loop_lag_tick")
+    snapshot = _require("loop_lag_snapshot")
+
+    # A stall, then a healthy tick.
+    record(interval + 0.5)
+    after_stall = snapshot()
+    stall_max = after_stall["loop_lag_max_ms"]
+
+    assert stall_max >= 500.0 - 1.0, (
+        f"the 500 ms stall did not reach the rolling max; got {stall_max!r}"
+    )
+
+    record(interval)  # dead-on: zero lag
+    after_fast = snapshot()
+
+    assert after_fast["loop_lag_ms"] == pytest.approx(0.0, abs=1.0), (
+        "a tick that took exactly INTERVAL must report ~0 ms of lag; got "
+        f"{after_fast['loop_lag_ms']!r}"
+    )
+    assert after_fast["loop_lag_max_ms"] == pytest.approx(stall_max, abs=1e-6), (
+        "loop_lag_max_ms must be RETAINED across a subsequent fast tick -- it is "
+        "the max since process start, not the max of the last sample. got "
+        f"{after_fast['loop_lag_max_ms']!r}, expected {stall_max!r}"
+    )
+
+
+def test_recorder_never_reports_negative_lag():
+    """An early tick (elapsed < INTERVAL, clock granularity) floors at 0.
+
+    A negative "lag" is meaningless and would corrupt the max comparison.
+    RED today: no recorder exists.
+    """
+    interval = float(_require("LOOP_LAG_INTERVAL_SECONDS"))
+    record = _require("record_loop_lag_tick")
+    snapshot = _require("loop_lag_snapshot")
+
+    record(max(0.0, interval - 0.01))
+    assert snapshot()["loop_lag_ms"] >= 0.0, (
+        "lag floored at 0; an elapsed shorter than INTERVAL must not report a "
+        f"negative value. got {snapshot()['loop_lag_ms']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8 -- the task stops on shutdown and does not swallow CancelledError
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_task_is_started_and_cancelled_by_lifespan():
+    """Startup starts the heartbeat; shutdown stops it.
+
+    Driven through the REAL ASGI lifespan (``with TestClient(app)`` runs the
+    app's registered startup handlers on entry and its shutdown handlers on
+    exit), so this pins production wiring rather than a hand-rolled imitation.
+
+    Deliberately NOT written against ``app.router.on_startup`` /
+    ``.on_shutdown``: this repo runs a different fastapi/starlette locally
+    (0.115.0 / 0.38.6) than ``requirements.txt`` pins for CI and Railway
+    (0.141.1 / 1.6.0), and framework introspection here must be duck-typed, not
+    shape-assuming -- see CLAUDE.md and ``tests/_route_introspection.py``. The
+    lifespan protocol is the stable public surface across both.
+
+    The recommended shutdown idiom, which also satisfies
+    ``test_heartbeat_does_not_swallow_cancellation``::
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    (Suppressing at the CANCELLER is fine; the coroutine itself must still let
+    CancelledError propagate.)
+
+    RED today: no startup handler creates a lag task, so ``_loop_lag_task``
+    never exists.
+    """
+    _require("_loop_lag_heartbeat")
+
+    with TestClient(app) as client:
+        task = getattr(app_main, "_loop_lag_task", None)
+        assert task is not None, (
+            "after lifespan startup, app.main._loop_lag_task is None -- no "
+            f"heartbeat task was created.\n{_CONTRACT}"
+        )
+        assert isinstance(task, asyncio.Task), (
+            f"_loop_lag_task must be an asyncio.Task; got {type(task).__name__}"
+        )
+        assert not task.done(), (
+            "the heartbeat task finished immediately after startup"
+        )
+        # The heartbeat must not break the healthcheck it feeds.
+        assert client.get("/health").status_code == 200
+        captured = task
+
+    # The `with` block exit ran the shutdown handlers.
+    cancelling = getattr(captured, "cancelling", lambda: 0)()
+    assert captured.done() or cancelling > 0, (
+        "the heartbeat task was neither stopped nor cancel-requested by "
+        "shutdown -- it must be cancelled, not left running"
+    )
+    if captured.done():
+        assert captured.cancelled(), (
+            "the heartbeat task finished on shutdown but was NOT cancelled -- "
+            "its CancelledError was swallowed instead of propagating"
+        )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_does_not_swallow_cancellation():
+    """CancelledError must PROPAGATE out of the heartbeat coroutine.
+
+    ``asyncio.CancelledError`` is a ``BaseException`` in Python 3.8+, so a bare
+    ``except Exception`` around the loop body does NOT catch it -- the spec says
+    verify that rather than assume it. This test verifies it against the real
+    coroutine, and is the regression pin against a future ``except:`` /
+    ``except BaseException:`` / ``except asyncio.CancelledError: return``,
+    any of which would leave a task that shutdown cannot stop.
+
+    RED today: ``app.main`` has no ``_loop_lag_heartbeat``.
+    """
+    heartbeat = _require("_loop_lag_heartbeat")
+    assert inspect.iscoroutinefunction(heartbeat), (
+        f"_loop_lag_heartbeat must be a coroutine function; got {heartbeat!r}"
+    )
+
+    task = asyncio.create_task(heartbeat())
+    # Let it reach its first await point.
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled(), (
+        "the heartbeat task did not end cancelled -- CancelledError was caught "
+        "and swallowed instead of propagating"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fable review additions (W1-10) -- two pins that were MISSING.
+#
+# An adversarial pass showed that two of the tests above named a requirement
+# without pinning it, both reproduced by deletion:
+#   * deleting the ENTIRE `@app.on_event("shutdown")` handler left the file
+#     green -- `captured.done() or cancelling > 0` is satisfied either way;
+#   * deleting `record_loop_lag_tick(now - previous)` from the heartbeat left
+#     the file green -- the recorder tests drive the recorder DIRECTLY, so
+#     nothing connected the loop to it.
+# A metric whose wiring is untested is a metric that can silently read 0
+# forever, which is worse than no metric: it reads as "the loop is fine".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_actually_calls_the_recorder():
+    """PINS THE WIRING. Fails if `record_loop_lag_tick(...)` is removed from
+    `_loop_lag_heartbeat`, which the recorder-only tests cannot see."""
+    import asyncio as _asyncio
+    import app.main as main
+
+    seen: list[float] = []
+    orig_interval = main.LOOP_LAG_INTERVAL_SECONDS
+    orig_recorder = main.record_loop_lag_tick
+    main.LOOP_LAG_INTERVAL_SECONDS = 0.01
+    main.record_loop_lag_tick = lambda elapsed: seen.append(elapsed)
+    try:
+        task = _asyncio.create_task(main._loop_lag_heartbeat())
+        for _ in range(200):
+            if seen:
+                break
+            await _asyncio.sleep(0.005)
+        task.cancel()
+        try:
+            await task
+        except _asyncio.CancelledError:
+            pass
+    finally:
+        main.LOOP_LAG_INTERVAL_SECONDS = orig_interval
+        main.record_loop_lag_tick = orig_recorder
+
+    assert seen, (
+        "the heartbeat never called record_loop_lag_tick -- the loop is not "
+        "wired to the recorder, so /health would report 0 lag forever"
+    )
+    assert seen[0] >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_handler_actually_cancels_the_task():
+    """PINS THE CANCEL. Fails if the shutdown handler's body is removed.
+
+    Asserts on the OBSERVED terminal state of a real task, not on a predicate
+    that a never-started task also satisfies.
+    """
+    import asyncio as _asyncio
+    import app.main as main
+
+    async def _forever() -> None:
+        await _asyncio.sleep(3600)
+
+    task = _asyncio.create_task(_forever())
+    await _asyncio.sleep(0)  # let it start
+    assert not task.done()
+
+    orig = main._loop_lag_task
+    main._loop_lag_task = task
+    try:
+        await main._stop_loop_lag_heartbeat()
+    finally:
+        if main._loop_lag_task is task:
+            main._loop_lag_task = orig
+
+    assert task.cancelled(), (
+        "the shutdown handler did not cancel the heartbeat task; it would "
+        "survive shutdown and keep the loop alive"
+    )
+    assert main._loop_lag_task is None, (
+        "the shutdown handler must clear the task handle"
+    )

--- a/tests/test_start_command.py
+++ b/tests/test_start_command.py
@@ -1,0 +1,287 @@
+"""W1-7 (SESSION 65) RED tests -- both start commands declare
+``--limit-concurrency``, and cannot drift apart.
+
+Finding ``LS-CONCURRENCY-LIMITS-10``. Today ``railway.json``'s
+``deploy.startCommand`` and ``Procfile``'s ``web:`` command carry the SAME
+string with no concurrency bound::
+
+    uvicorn app.main:app --host 0.0.0.0 --port $PORT
+
+With no limit the single uvicorn worker accepts connections without bound, so a
+pile-up becomes a 120 s spinner for every caller instead of a fast failure for
+the overflow. A 503 at the door is a better answer than a timeout, and it breaks
+stage 4 of the modelled cascade.
+
+The second half of the finding is that the two files can DRIFT SILENTLY: Railway
+uses ``railway.json``'s ``startCommand``, so a Procfile-only edit would look
+applied and do nothing. The equality pin below is the durable half.
+
+-------------------------------------------------------------------------------
+SHELL EXPANSION -- MEASURED, NOT ASSUMED (this is a BOOT-CRITICAL string; a
+literal ``${...}`` reaching uvicorn is a crash loop, not a degraded mode)
+-------------------------------------------------------------------------------
+``$PORT`` in the existing string proves the command is shell-expanded, but
+``${VAR:-default}`` is a DIFFERENT expansion form. It was proven before being
+adopted, by running the exact command string through ``sh -c`` against an
+argv-printing stub on PATH and reading the argument uvicorn actually receives::
+
+    CMD='uvicorn app.main:app --host 0.0.0.0 --port $PORT \
+         --limit-concurrency "${UVICORN_LIMIT_CONCURRENCY:-512}"'
+
+    # UVICORN_LIMIT_CONCURRENCY unset, PORT=8080
+    ARGV: [app.main:app] [--host] [0.0.0.0] [--port] [8080] \
+          [--limit-concurrency] [512]
+    # UVICORN_LIMIT_CONCURRENCY=250
+    ARGV: ... [--limit-concurrency] [250]
+    # UVICORN_LIMIT_CONCURRENCY=   (set but empty -- the ``:-`` form)
+    ARGV: ... [--limit-concurrency] [512]
+
+Negative control, against the REAL uvicorn, confirming the failure mode this
+proof exists to rule out::
+
+    $ python -m uvicorn app.main:app ... \
+          --limit-concurrency '${UVICORN_LIMIT_CONCURRENCY:-100}'
+    Error: Invalid value for '--limit-concurrency':
+      '${UVICORN_LIMIT_CONCURRENCY:-100}' is not a valid integer.
+
+So the expansion HOLDS and the retunable form is adopted; ops can change the
+ceiling without a code deploy. These tests therefore pin the expansion form
+itself, not a bare literal.
+
+100 is chosen against measured traffic, not from a template: normal load is 5-8
+compares/min with a fan-out of ~18 internal tasks each, so 100 concurrent
+REQUESTS sits far above any healthy minute and only engages in a genuine
+pile-up.
+
+-------------------------------------------------------------------------------
+Expected state at RED
+-------------------------------------------------------------------------------
+  * ``test_railway_start_command_declares_limit_concurrency``  -- RED (absent)
+  * ``test_procfile_start_command_declares_limit_concurrency`` -- RED (absent)
+  * ``test_limit_concurrency_value_is_the_retunable_form``     -- RED (absent)
+  * ``test_start_commands_are_byte_identical``   -- GREEN today, REGRESSION PIN
+  * ``test_neither_command_declares_proxy_headers`` -- GREEN today, EXCLUSION PIN
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_RAILWAY_JSON = _REPO_ROOT / "railway.json"
+_PROCFILE = _REPO_ROOT / "Procfile"
+
+_PROCFILE_WEB_PREFIX = "web: "
+
+# The exact value adopted for --limit-concurrency, proven expandable above.
+_EXPECTED_LIMIT_VALUE = '"${UVICORN_LIMIT_CONCURRENCY:-512}"'
+
+
+def _railway_start_command() -> str:
+    assert _RAILWAY_JSON.is_file(), f"missing {_RAILWAY_JSON}"
+    config = json.loads(_RAILWAY_JSON.read_text(encoding="utf-8"))
+    deploy = config.get("deploy")
+    assert isinstance(deploy, dict), "railway.json has no 'deploy' object"
+    command = deploy.get("startCommand")
+    assert isinstance(command, str) and command.strip(), (
+        "railway.json deploy.startCommand is missing or not a string -- Railway "
+        "boots from this string, so it is the one that must carry the limit"
+    )
+    return command.strip()
+
+
+def _procfile_web_command() -> str:
+    assert _PROCFILE.is_file(), f"missing {_PROCFILE}"
+    for raw_line in _PROCFILE.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith(_PROCFILE_WEB_PREFIX.strip()):
+            # Strip the process-type prefix ("web:") and any following space.
+            return line.split(":", 1)[1].strip()
+    pytest.fail("Procfile declares no 'web:' process type")
+
+
+def _tokens(command: str) -> list:
+    """Whitespace tokens of a start command.
+
+    Neither command contains quoting today, and neither should: a quoted
+    ``"${VAR:-default}"`` would still expand, but an unquoted one keeps the
+    string diffable against railway.json character-for-character.
+    """
+    return command.split()
+
+
+def _flag_value(command: str, flag: str):
+    """Return the token following ``flag``, or None when the flag is absent."""
+    tokens = _tokens(command)
+    for index, token in enumerate(tokens):
+        if token == flag:
+            if index + 1 >= len(tokens):
+                pytest.fail(f"{flag} present in {command!r} with no value after it")
+            return tokens[index + 1]
+        if token.startswith(f"{flag}="):
+            return token.split("=", 1)[1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2 -- the limit is declared in BOTH files (RED: absent from both today)
+# ---------------------------------------------------------------------------
+
+
+def test_railway_start_command_declares_limit_concurrency():
+    """Railway boots from railway.json -- the bound must be in THIS string.
+
+    RED today: the shipped startCommand is
+    ``uvicorn app.main:app --host 0.0.0.0 --port $PORT`` with no bound, so the
+    worker accepts connections without limit and a pile-up degrades into a
+    120 s spinner for everyone instead of a 503 for the overflow.
+    """
+    command = _railway_start_command()
+    assert "--limit-concurrency" in command, (
+        "railway.json deploy.startCommand declares no --limit-concurrency; "
+        f"got {command!r}"
+    )
+
+
+def test_procfile_start_command_declares_limit_concurrency():
+    """The Procfile must carry the bound too, so the two cannot diverge.
+
+    RED today: same unbounded string as railway.json.
+    """
+    command = _procfile_web_command()
+    assert "--limit-concurrency" in command, (
+        f"Procfile web: command declares no --limit-concurrency; got {command!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The value is the retunable, PROVEN-EXPANDABLE form (RED: no value at all)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source, reader",
+    [
+        ("railway.json", _railway_start_command),
+        ("Procfile", _procfile_web_command),
+    ],
+)
+def test_limit_concurrency_value_is_the_retunable_form(source, reader):
+    """Ops must be able to retune the ceiling without a code deploy.
+
+    The value is pinned to the QUOTED form ``"${UVICORN_LIMIT_CONCURRENCY:-512}"``,
+    whose shell expansion was MEASURED through ``sh -c`` with an argv-printing
+    stub (unset -> ``512``, set -> the override) before adoption.
+
+    THE QUOTES ARE LOAD-BEARING (Fable review). Unquoted, the substitution
+    WORD-SPLITS: with ``UVICORN_LIMIT_CONCURRENCY='1 --workers 4'`` the measured
+    argv gained two extra flags, i.e. an env var that only sets a ceiling could
+    inject arbitrary uvicorn arguments. Quoted, the same value arrives as the
+    single argument ``[1 --workers 4]``, which uvicorn rejects as a bad int -- a
+    clean boot failure instead of a silently reconfigured server.
+
+    512, NOT 100 (Fable review). uvicorn's gate is not on requests: it is
+    ``len(self.connections) >= limit_concurrency or len(self.tasks) >= ...``
+    (verified in the installed uvicorn's ``protocols/http/h11_impl.py`` and
+    ``httptools_impl.py``). Idle HTTP keep-alive connections therefore COUNT, so
+    a request-shaped estimate of 100 would have started shedding real users at a
+    connection population this service can plausibly reach. 512 still bounds an
+    unbounded pile-up while sitting far above any plausible keep-alive
+    population at current traffic, and the ceiling is env-tunable so it can be
+    lowered under observation rather than guessed at now.
+    """
+    value = _flag_value(reader(), "--limit-concurrency")
+    assert value is not None, (
+        f"{source} start command carries no --limit-concurrency value"
+    )
+    assert value == _EXPECTED_LIMIT_VALUE, (
+        f"{source} --limit-concurrency is {value!r}, expected "
+        f"{_EXPECTED_LIMIT_VALUE!r} so ops can retune without a code deploy"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3 -- the durable half of the finding: the two strings cannot drift
+# ---------------------------------------------------------------------------
+
+
+def test_start_commands_are_byte_identical():
+    """REGRESSION PIN -- this is GREEN TODAY and must stay green.
+
+    DO NOT DELETE THIS AS "trivially passing". It is the durable half of
+    LS-CONCURRENCY-LIMITS-10: Railway boots from ``railway.json``'s
+    ``startCommand``, so a Procfile-only edit looks applied and does nothing.
+    The whole point of the pin is that it is green BEFORE the change (both
+    files carry the same unbounded string) and green AFTER it (both files
+    carry the same bounded string) -- and RED for exactly the window in which
+    someone edits one file and not the other.
+    """
+    railway = _railway_start_command()
+    procfile = _procfile_web_command()
+    assert railway == procfile, (
+        "railway.json deploy.startCommand and the Procfile web: command have "
+        "DRIFTED. Railway boots from railway.json, so a Procfile-only edit is "
+        f"a silent no-op.\n  railway.json: {railway!r}\n  Procfile:     {procfile!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4 -- the deliberate exclusion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source, reader",
+    [
+        ("railway.json", _railway_start_command),
+        ("Procfile", _procfile_web_command),
+    ],
+)
+def test_neither_command_declares_proxy_headers(source, reader):
+    """EXCLUSION PIN -- GREEN TODAY and deliberately so.
+
+    ``--proxy-headers`` is NOT part of this change. It changes the client IP the
+    slowapi rate limiter keys on, and that limiter is currently the only thing
+    bounding the loop (see ENABLE_PROXY_AWARE_RATELIMIT, still dark pending a
+    live check of Railway's proxy hop count). Adding it here would silently
+    couple a concurrency change to an auth/abuse change. It is its own unit with
+    its own canary.
+    """
+    command = reader()
+    assert "--proxy-headers" not in command, (
+        f"{source} start command declares --proxy-headers. That is deliberately "
+        "OUT OF SCOPE for W1-7: it re-keys the rate limiter, which is currently "
+        "the only bound on the event loop. Ship it as its own unit with its own "
+        f"canary.\n  {command!r}"
+    )
+    assert "--forwarded-allow-ips" not in command, (
+        f"{source} start command declares --forwarded-allow-ips, which is only "
+        "meaningful alongside --proxy-headers and is equally out of scope here"
+    )
+
+
+def test_limit_concurrency_is_a_real_uvicorn_option_on_this_build():
+    """Fable review addition -- the start command is BOOT CRITICAL.
+
+    ``requirements.txt`` pins ``uvicorn==0.52.4``, which is what CI and Railway
+    install; only 0.30.0 is installed in these worktrees and installing is not
+    permitted here. So the measurements behind this unit were taken on a build
+    that is NOT the deployed one -- the same local-vs-lock drift that blinded
+    three route tests in M13, and the same gap recorded for sentry-sdk in W1-1.
+
+    If ``--limit-concurrency`` were ever removed or renamed, uvicorn would exit
+    on an unrecognised argument and the container would CRASH-LOOP on deploy --
+    a worse failure than the unbounded acceptance this unit exists to fix. This
+    assertion runs on whatever uvicorn is present, so CI settles it on the
+    pinned build instead of Railway discovering it at boot.
+    """
+    import inspect
+
+    import uvicorn.config
+
+    params = inspect.signature(uvicorn.config.Config.__init__).parameters
+    assert "limit_concurrency" in params, (
+        f"uvicorn {getattr(__import__('uvicorn'), '__version__', '?')} has no "
+        f"limit_concurrency option, but both start commands pass "
+        f"--limit-concurrency. The container would fail to boot."
+    )


### PR DESCRIPTION
## W1-7 + W1-10 — a door that sheds, and a signal that can see a stalled loop

`LS-CONCURRENCY-LIMITS-10` + `LS-FAILURE-MODES-COST-13` / `#81`. Shipped together: both are small, unflagged, additive and ops-facing, and **both are preconditions for reading any W5 STEP 0 canary**. Splitting them buys two CI cycles and no extra safety.

### W1-10 — `/health` reports event-loop lag

`/health` returned a static two-key dict, so nothing anywhere reported whether the single uvicorn worker's loop was actually **turning**. That is the one measurement separating "the app is slow" from "the app is wedged", and the activation runbook says to watch it through every flag flip.

A startup task sleeps on a 1 s interval and records how far each wake-up overshot; `/health` reports the **last** value and the rolling **max** since process start.

- Measuring inside the handler cannot work: the handler only runs when the loop is already running, so it can never observe the interval in which the loop was *blocked*. A heartbeat due at T that runs at T+11s reports 11,000 ms — exactly the `getaddrinfo` stall W0-1 exists to bound.
- The **max** matters because a probe polling every 30 s samples 1 second in 30 and would miss almost every stall.
- `/health` stays a pure dict read — no await, no I/O. It is Railway's deploy healthcheck with a 30 s timeout and must not become a thing that can fail.
- `status` and `message` keep their exact values (an external uptime check may be string-matching them).

### W1-7 — both start commands bound concurrency, and cannot drift

With no limit the worker accepts connections without bound, so a pile-up becomes a 120 s spinner for everyone instead of a fast failure for the overflow. The second half of the finding is that `railway.json` and `Procfile` can drift silently — Railway uses `railway.json`, so a Procfile-only edit would look applied and do nothing. A test pins them byte-identical.

**`--proxy-headers` is deliberately not added here**: it changes the client IP the rate limiter keys on, and that limiter is currently the only thing bounding the loop.

### Four corrections from review

**1. The ceiling is 512, not 100, and the old rationale was wrong.** uvicorn's gate is not on requests — it is `len(self.connections) >= limit_concurrency or len(self.tasks) >= ...`, verified in the installed uvicorn's `h11_impl.py` and `httptools_impl.py`. **Idle HTTP keep-alive connections therefore count**, so a request-shaped estimate of 100 would have begun shedding real users at a connection population this service can plausibly reach. 512 still bounds an unbounded pile-up while sitting far above any plausible keep-alive population at current traffic, and it is env-tunable so it can be lowered *under observation* rather than guessed at now.

**2. The substitution is quoted, and the quotes are load-bearing.** Unquoted it word-splits: measured through `sh -c` with an argv-printing stub, `UVICORN_LIMIT_CONCURRENCY='1 --workers 4'` produced two extra flags — an env var meant only to set a ceiling could inject arbitrary uvicorn arguments. Quoted, the same value arrives as the single argument `[1 --workers 4]`, which uvicorn rejects as a bad int: a clean boot failure instead of a silently reconfigured server.

**3. Two tests pinned nothing** — both reproduced by deletion. Removing the **entire shutdown handler** left the file green (`captured.done() or cancelling > 0` is satisfied either way), and removing `record_loop_lag_tick(now - previous)` from the heartbeat also left it green (the recorder tests drive the recorder directly, so nothing connected the loop to it). *A metric whose wiring is untested can silently read 0 forever, which is worse than no metric: it reads as "the loop is fine".* Both are now pinned against the exact deletions, and both were verified to redden.

**4. A boot-critical version gap is now CI-visible.** `requirements.txt` pins `uvicorn==0.52.4`; only 0.30.0 is installed in these worktrees and installing was not permitted, so every measurement was taken on a build that is not the deployed one. If `--limit-concurrency` were ever removed or renamed, the container would **crash-loop** — worse than the unbounded acceptance this fixes. A test now asserts the option exists on whatever uvicorn is installed, so CI settles it on the pinned build.

### Also: a dead operational instruction

The cold-start comment above `/health` told an operator to cron `smartcompare-backend-production.up.railway.app`, which returns Railway's edge 404 "Application not found". Anyone following it would have built a cron against a dead hostname and believed the worker was being kept warm. Corrected to the live host — the one the mobile client already targets.

### Stated limit

`--limit-concurrency`'s shedding behaviour is adopted on uvicorn's documented semantics plus the start-command pins, **not** on a live load test (which needs explicit authorisation). That is acceptable because the mechanism only sheds *above* a level normal traffic does not reach, and the alternative is no bound at all. The right value deserves measurement under load; that is why it is env-tunable.

### Gates

- Red-first: 10 right-reason failures before any change.
- Unit files: **18 passed**; the two new pins verified to fail against their exact deletions.
- Shell expansion proven through `sh -c` with an argv stub: unset → 512, override → the override, injection attempt → one inert argument.
- Ruff `E9,F63,F7,F82` + `py_compile` clean.
- **Full CI-equivalent suite: 17,172 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
