### PR TITLE
fix(boot): arm Sentry before the module graph is evaluated (W3-12, last OTA precondition)

### DIFF
--- a/SmartCompareApp/App.tsx
+++ b/SmartCompareApp/App.tsx
@@ -3,11 +3,12 @@
  * Bottom tabs navigation with splash, auth, and onboarding flows
  */
 
-// Crash reporting MUST init before any other module so we capture
-// failures during early imports (font loading, i18n, native bridge).
-// See src/services/sentry.ts for the DSN + scrubbing config.
-import { initSentry } from './src/services/sentry';
-initSentry();
+// W3-12 — crash reporting is armed by `src/services/sentryBootstrap`, imported
+// FIRST in index.ts. It used to be `initSentry()` here, in this module's body,
+// which only runs AFTER this file's whole import graph has been evaluated — so
+// the certificate-pinning "running unpinned" alarm raised from api.ts's module
+// body, and any boot crash in an imported module, reached an uninitialised
+// Sentry and was dropped. See src/services/sentry.ts for DSN + scrubbing.
 
 import * as Sentry from '@sentry/react-native';
 import React, { useState, useEffect, useCallback } from 'react';

--- a/SmartCompareApp/__tests__/bootRegressionPins.w312.test.ts
+++ b/SmartCompareApp/__tests__/bootRegressionPins.w312.test.ts
@@ -1,0 +1,237 @@
+/**
+ * W3-12 — REGRESSION PINS. Everything in this file is ALREADY GREEN at this
+ * base and is kept deliberately.
+ *
+ * The consolidated report asked W3-12 for three red tests. Two of them
+ * describe behaviour that already exists, so building them as "red tests"
+ * would have produced green tests that prove nothing. They are pinned HERE
+ * instead, because W3-12 reorders application boot and must not regress the
+ * other session's B5 work while doing it.
+ *
+ *   (a) "a throwing getLocales strands the splash" — ALREADY FIXED.
+ *       App.tsx now reads `init().catch(...).finally(() => setIsLoading(false))`,
+ *       so the splash gate is released on every path.
+ *       ALREADY GREEN, REGRESSION PIN — do not delete as trivial.
+ *
+ *   (c) "a synchronously-throwing initializeSslPinning still produces a
+ *       captureMessage" — ALREADY TRUE, and as worded it does not describe a
+ *       defect: certificatePinning.ts awaits inside a try, so a synchronous
+ *       throw, a rejected promise and an undefined native binding are all
+ *       caught identically and the catch calls Sentry.captureMessage.
+ *       ALREADY GREEN, REGRESSION PIN — do not delete as trivial.
+ *       (The REAL defect is that this call reaches an UNINITIALISED Sentry;
+ *       that is red, and lives in `bootSentryAlarm.w312.test.ts`.)
+ *
+ *   (idempotence) The unit spec lists "calling initSentry() twice initialises
+ *       once" among its red tests, but `sentry.ts` already carries the
+ *       `_initialized` guard, so this is green at this base too.
+ *       ALREADY GREEN, REGRESSION PIN — it becomes load-bearing the moment
+ *       the fix adds a second arming site (index.ts's bootstrap) alongside
+ *       any surviving call in App.tsx.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+jest.mock('@sentry/react-native', () => ({
+  __esModule: true,
+  init: jest.fn(),
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  setTag: jest.fn(),
+  setUser: jest.fn(),
+  setContext: jest.fn(),
+  setExtra: jest.fn(),
+  withScope: jest.fn(),
+  getCurrentScope: jest.fn(() => ({ setTag: jest.fn(), clear: jest.fn() })),
+}));
+
+const mockInitializeSslPinning = jest.fn();
+jest.mock('react-native-ssl-public-key-pinning', () => ({
+  __esModule: true,
+  initializeSslPinning: (...args: unknown[]) => mockInitializeSslPinning(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// (a) ALREADY GREEN, REGRESSION PIN — the splash gate releases on every path.
+// ---------------------------------------------------------------------------
+describe('W3-12 pin (a) [ALREADY GREEN, REGRESSION PIN] — splash .finally() still releases', () => {
+  const APP_PATH = path.resolve(__dirname, '../App.tsx');
+  // Normalised to LF so the block markers behave the same on the Windows
+  // checkout (CRLF) and on CI (LF).
+  const appSrc = fs.readFileSync(APP_PATH, 'utf8').replace(/\r\n/g, '\n');
+  const BLOCK_START = '    async function init() {';
+  const BLOCK_END = '\n  }, []);';
+
+  function extractBootBlock(): string {
+    const start = appSrc.indexOf(BLOCK_START);
+    if (start === -1) {
+      throw new Error('App.tsx: could not find the `async function init()` boot block');
+    }
+    const end = appSrc.indexOf(BLOCK_END, start);
+    if (end === -1) {
+      throw new Error('App.tsx: could not find the end of the boot useEffect');
+    }
+    return appSrc.slice(start, end);
+  }
+
+  async function settle(): Promise<void> {
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+
+  async function runBootBlock(getSavedLanguage: jest.Mock): Promise<jest.Mock> {
+    const setIsLoading = jest.fn();
+    const run = new Function(
+      'getSavedLanguage',
+      'i18n',
+      'I18nManager',
+      'getStableId',
+      'setFlagStableId',
+      'initializeAuth',
+      'setStableUserId',
+      'setUser',
+      'setIsAuthenticated',
+      'setNeedsPreferences',
+      'tryRegisterPushToken',
+      'setIsLoading',
+      '__DEV__',
+      extractBootBlock(),
+    );
+    run(
+      getSavedLanguage,
+      { changeLanguage: jest.fn().mockResolvedValue(undefined) },
+      { isRTL: false, allowRTL: jest.fn(), forceRTL: jest.fn() },
+      jest.fn().mockResolvedValue('device-abc'),
+      jest.fn(),
+      jest.fn().mockResolvedValue(null),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+      jest.fn(() => Promise.resolve()),
+      setIsLoading,
+      false,
+    );
+    await settle();
+    return setIsLoading;
+  }
+
+  it('the boot block still ends in a .finally() that clears isLoading', () => {
+    const block = extractBootBlock();
+    expect(block).toContain('.finally(');
+    expect(block).toContain('setIsLoading(false)');
+  });
+
+  it('a SYNCHRONOUSLY throwing language read still releases the splash', async () => {
+    // The report's "a throwing getLocales" case: getSavedLanguage is the
+    // boot step that reads the device locale, and it is the FIRST await in
+    // the chain — the furthest-upstream strand.
+    const setIsLoading = await runBootBlock(
+      jest.fn(() => {
+        throw new Error('getLocales blew up');
+      }),
+    );
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+  });
+
+  it('a REJECTING language read still releases the splash', async () => {
+    const setIsLoading = await runBootBlock(
+      jest.fn().mockRejectedValue(new Error('storage down')),
+    );
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) ALREADY GREEN, REGRESSION PIN — the pinning catch still fires.
+// ---------------------------------------------------------------------------
+describe('W3-12 pin (c) [ALREADY GREEN, REGRESSION PIN] — cert-pinning catch on a sync throw', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockInitializeSslPinning.mockReset();
+  });
+
+  it('a synchronously-throwing initializeSslPinning still produces a captureMessage', async () => {
+    mockInitializeSslPinning.mockImplementation(() => {
+      throw new TypeError('native module unavailable');
+    });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require('@sentry/react-native');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { setupCertificatePinning } = require('../src/services/certificatePinning');
+
+    await setupCertificatePinning();
+
+    // __DEV__ is false in __tests__/setup.ts, so the release branch runs.
+    expect(mockInitializeSslPinning).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(Sentry.captureMessage.mock.calls[0][0])).toContain(
+      '[SECURITY] Certificate pinning init failed',
+    );
+  });
+
+  it('a REJECTING initializeSslPinning is caught identically', async () => {
+    mockInitializeSslPinning.mockRejectedValue(new Error('handshake failed'));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require('@sentry/react-native');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { setupCertificatePinning } = require('../src/services/certificatePinning');
+
+    await setupCertificatePinning();
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(Sentry.captureMessage.mock.calls[0][0])).toContain(
+      '[SECURITY] Certificate pinning init failed',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (idempotence) ALREADY GREEN, REGRESSION PIN — initSentry initialises once.
+// ---------------------------------------------------------------------------
+describe('W3-12 pin [ALREADY GREEN, REGRESSION PIN] — initSentry() is idempotent', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('calling initSentry() twice initialises Sentry exactly once', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require('@sentry/react-native');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { initSentry } = require('../src/services/sentry');
+
+    initSentry();
+    initSentry();
+
+    expect(Sentry.init).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the committed fallback DSN and still initialises exactly once', () => {
+    // The unit spec says "initSentry already no-ops without a DSN; preserve
+    // that". At this base that branch (`if (!resolved) return`) is
+    // UNREACHABLE: `resolved` falls through `dsn || EXPO_PUBLIC_SENTRY_DSN ||
+    // FALLBACK_DSN`, and FALLBACK_DSN is a non-empty committed literal. So
+    // the honest pin is the one that can actually fire — the resolution
+    // order, and the single-init guard on top of it.
+    const previous = process.env.EXPO_PUBLIC_SENTRY_DSN;
+    delete process.env.EXPO_PUBLIC_SENTRY_DSN;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require('@sentry/react-native');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { initSentry } = require('../src/services/sentry');
+
+      initSentry('');
+      initSentry('');
+
+      expect(Sentry.init).toHaveBeenCalledTimes(1);
+      expect(String(Sentry.init.mock.calls[0][0].dsn)).toMatch(/^https:\/\/.+@.+\/\d+$/);
+    } finally {
+      if (previous === undefined) delete process.env.EXPO_PUBLIC_SENTRY_DSN;
+      else process.env.EXPO_PUBLIC_SENTRY_DSN = previous;
+    }
+  });
+});

--- a/SmartCompareApp/__tests__/bootSentryAlarm.w312.test.ts
+++ b/SmartCompareApp/__tests__/bootSentryAlarm.w312.test.ts
@@ -1,0 +1,119 @@
+/**
+ * W3-12 — the "running unpinned" alarm must survive boot.
+ *
+ * `certificatePinning.ts:79-80` raises
+ *
+ *   Sentry.captureMessage('[SECURITY] Certificate pinning init failed -
+ *                          session is running unpinned', ...)
+ *
+ * from the release branch of `setupCertificatePinning`'s catch. That call is
+ * the ONLY channel that makes an unpinned release fleet visible (console.* is
+ * babel-stripped in production, see babel.config.js).
+ *
+ * It is reached from `api.ts:22`, which runs in api.ts's MODULE BODY, which
+ * the module graph evaluates before App.tsx's body statement `initSentry()`
+ * (App.tsx:10) ever executes. So the alarm is raised into a Sentry that has
+ * not been initialised and is dropped.
+ *
+ * This suite runs the real boot chain under the SHIPPED Babel/Metro
+ * transform (see `helpers/w312BootSandbox.ts` for why ts-jest's own TS->CJS
+ * emit cannot reproduce the ordering), executes the real `api.ts`,
+ * `certificatePinning.ts` and `sentry.ts` bodies, and forces
+ * `initializeSslPinning` to throw. `initializeSslPinning` is stubbed to throw
+ * SYNCHRONOUSLY — a missing / undefined native binding, which is the realistic
+ * release-build failure — so the catch (and the captureMessage) run inside
+ * api.ts's module body rather than a microtask later, which is exactly where
+ * production would raise it.
+ *
+ * The assertion is on whether Sentry was ALREADY INITIALISED at the moment
+ * captureMessage was called — not on whether captureMessage was called at all.
+ * The latter is green today (see `bootRegressionPins.w312.test.ts`) and is
+ * not the defect.
+ */
+
+import {
+  API_FILE,
+  APP_FILE,
+  AUTH_FILE,
+  BOOTSTRAP_FILE,
+  ENTRY,
+  PINNING_FILE,
+  SENTRY_FILE,
+  makeStub,
+  runBoot,
+} from './helpers/w312BootSandbox';
+
+const UNPINNED_MESSAGE = '[SECURITY] Certificate pinning init failed';
+
+type Capture = { message: string; sentryWasInitialized: boolean };
+
+describe('W3-12 — the unpinned alarm reaches an initialised Sentry', () => {
+  let captures: Capture[];
+  let initCalls: number;
+  let pinningAttempts: number;
+
+  beforeAll(() => {
+    captures = [];
+    initCalls = 0;
+    pinningAttempts = 0;
+    let sentryInitialized = false;
+
+    const sentryNative: any = {
+      __esModule: true,
+      init: () => {
+        initCalls += 1;
+        sentryInitialized = true;
+      },
+      captureMessage: (message: unknown) => {
+        captures.push({ message: String(message), sentryWasInitialized: sentryInitialized });
+      },
+      captureException: () => undefined,
+      addBreadcrumb: () => undefined,
+      setTag: () => undefined,
+      setUser: () => undefined,
+      setContext: () => undefined,
+      setExtra: () => undefined,
+      withScope: (cb: (s: any) => void) => cb({}),
+      getCurrentScope: () => ({ setTag: () => undefined, clear: () => undefined }),
+    };
+
+    runBoot({
+      executable: [ENTRY, APP_FILE, AUTH_FILE, API_FILE, PINNING_FILE, SENTRY_FILE, BOOTSTRAP_FILE],
+      bareOverrides: {
+        '@sentry/react-native': () => sentryNative,
+        'react-native-ssl-public-key-pinning': () => ({
+          __esModule: true,
+          initializeSslPinning: () => {
+            pinningAttempts += 1;
+            // Synchronous throw — the undefined-native-binding shape.
+            throw new TypeError('native module unavailable');
+          },
+        }),
+        axios: () => {
+          const client: any = makeStub();
+          return { __esModule: true, default: { create: () => client }, create: () => client };
+        },
+      },
+    });
+  });
+
+  it('the boot chain really reached the alarm (guards against a mock/path mistake)', () => {
+    // Falsifier: if api.ts never ran, or the pinning stub never got called,
+    // or the message text changed, this fails FIRST — so the assertion below
+    // is known to be about ordering and not about wiring.
+    expect(pinningAttempts).toBeGreaterThan(0);
+    expect(captures.map((c) => c.message).join('\n')).toContain(UNPINNED_MESSAGE);
+    expect(initCalls).toBeGreaterThan(0);
+  });
+
+  it('raises the unpinned alarm while Sentry is initialised', () => {
+    // RED today: Sentry.init has not run yet when the alarm fires, so the
+    // one signal that a release fleet is unpinned is dropped on the floor.
+    const alarm = captures.find((c) => c.message.includes(UNPINNED_MESSAGE));
+    expect(alarm).toBeDefined();
+    expect(alarm).toEqual({
+      message: expect.stringContaining(UNPINNED_MESSAGE),
+      sentryWasInitialized: true,
+    });
+  });
+});

--- a/SmartCompareApp/__tests__/bootSentryOrder.w312.test.ts
+++ b/SmartCompareApp/__tests__/bootSentryOrder.w312.test.ts
@@ -1,0 +1,192 @@
+/**
+ * W3-12 — Sentry must be armed BEFORE the module graph, not from inside
+ * App.tsx's module body.
+ *
+ * THE DEFECT. `App.tsx:9-10` reads:
+ *
+ *     import { initSentry } from './src/services/sentry';
+ *     initSentry();
+ *
+ * which LOOKS like the first thing the app does. It is not. `initSentry()`
+ * is a statement in App.tsx's module BODY, and a module body only runs after
+ * its whole import graph has been evaluated — true under ES module semantics
+ * (dependencies evaluated depth-first in source order) and equally true after
+ * Babel's ESM->CJS transform, which hoists every `require()` above the body.
+ * App.tsx imports `authService` (`:74`), which imports `src/services/api.ts`
+ * (`authService.ts:52`), whose module body at `:22` calls
+ * `setupCertificatePinning()`. On failure that path raises
+ * `Sentry.captureMessage('[SECURITY] Certificate pinning init failed …')`
+ * (`certificatePinning.ts:79-80`) — the one alarm that says a release fleet
+ * is running unpinned — into a Sentry that does not exist yet. The same
+ * window swallows any boot crash in any module App.tsx imports.
+ *
+ * The harness compiles the real entry point with the SHIPPED TWO-STAGE
+ * pipeline — babel-preset-expo under Metro's caller flags with
+ * `supportsStaticESM: true` (Expo sets `experimentalImportSupport: true`),
+ * then Metro's own `importExportPlugin` for the CommonJS lowering — and
+ * records module-evaluation order; see `helpers/w312BootSandbox.ts` for why a
+ * plain `require('../index')` under ts-jest would be green and prove nothing.
+ *
+ * Assertions are on RECORDED ORDER, never on call counts: both things do
+ * happen today, so counts are green — the defect is purely ordinal.
+ *
+ * HONEST LIMIT (inherited from the unit spec, narrowed by measurement): this
+ * verifies module-evaluation order under the same Babel transform Metro uses,
+ * driven by a sandbox `require` rather than by Metro's own runtime. It is not
+ * a device boot. The on-device check belongs in the post-OTA walkthrough:
+ * force a pinning failure on a release build and confirm the "running
+ * unpinned" event arrives in Sentry.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  APP_ROOT,
+  API_FILE,
+  APP_FILE,
+  AUTH_FILE,
+  BOOTSTRAP_FILE,
+  ENTRY,
+  SENTRY_FILE,
+  makeStub,
+  resolveLocal,
+  runBoot,
+} from './helpers/w312BootSandbox';
+
+const MARK_SENTRY = 'initSentry()';
+const MARK_API = 'api.ts module body';
+
+describe('W3-12 — Sentry is armed before the module graph (shipped Metro pipeline)', () => {
+  const order: string[] = [];
+  let emitted: Record<string, string>;
+
+  beforeAll(() => {
+    emitted = runBoot({
+      executable: [ENTRY, APP_FILE, AUTH_FILE, BOOTSTRAP_FILE],
+      localOverrides: {
+        // Reaching this require IS the moment api.ts's module body would
+        // run, so the marker is recorded here; the body itself is stubbed
+        // (nothing in it is needed to establish ordering).
+        [API_FILE]: () => {
+          order.push(MARK_API);
+          return makeStub();
+        },
+        [SENTRY_FILE]: () =>
+          new Proxy(
+            {},
+            {
+              get(_t, prop) {
+                if (prop === '__esModule') return true;
+                if (prop === 'initSentry') {
+                  return () => {
+                    order.push(MARK_SENTRY);
+                  };
+                }
+                if (typeof prop === 'symbol') return undefined;
+                return makeStub();
+              },
+            },
+          ),
+      },
+    }).emitted;
+  });
+
+  it('the harness compiles CJS and the entry point reaches BOTH markers', () => {
+    // Falsifier for the ordering tests below. If the transform silently
+    // stayed ESM, or a stub / renamed path dropped either module out of the
+    // boot chain, this fails FIRST — so an ordering failure below is known
+    // not to be a wiring artifact.
+    //
+    // GREEN-PHASE RE-ANCHOR (W3-12): the arming side was originally anchored
+    // on `App.tsx` requiring `./src/services/sentry`, because that is where
+    // the RED-phase code armed Sentry. Removing that call from App.tsx is the
+    // fix, so that exact string is gone by construction and the assertion had
+    // to move to where the arming now happens — the entry point's own emitted
+    // CJS. The falsifier is not weakened: it still proves (i) index.ts was
+    // compiled to CJS and really requires the bootstrap, (ii) App.tsx was
+    // compiled to CJS and really requires authService (the path to api.ts),
+    // and (iii) both order markers were actually recorded.
+    // Quote-agnostic: Metro's importExportPlugin emits single-quoted requires,
+    // Babel's own commonjs transform emits double-quoted ones. The claim is
+    // "the emitted CJS really requires this module", not "in these quotes".
+    expect(emitted['index.ts']).toMatch(/require\(['"]\.\/src\/services\/sentryBootstrap['"]\)/);
+    expect(emitted['App.tsx']).toMatch(/require\(['"]\.\/src\/services\/authService['"]\)/);
+    expect(order).toContain(MARK_SENTRY);
+    expect(order).toContain(MARK_API);
+  });
+
+  it('runs initSentry() BEFORE api.ts module body (RECORDED ORDER, not counts)', () => {
+    // RED today: the recorded order is ['api.ts module body', 'initSentry()'].
+    const sentryAt = order.indexOf(MARK_SENTRY);
+    const apiAt = order.indexOf(MARK_API);
+    expect(sentryAt).toBeGreaterThanOrEqual(0);
+    expect(apiAt).toBeGreaterThanOrEqual(0);
+    expect(sentryAt).toBeLessThan(apiAt);
+  });
+
+  it('arms Sentry as the FIRST recorded boot side effect', () => {
+    // Same claim stated as the whole recorded sequence, so a failure names
+    // the actual boot order instead of two integers. Stated positionally so
+    // that merely moving api.ts later in App.tsx's import list — rather than
+    // arming Sentry ahead of the graph — does not satisfy the unit.
+    expect(order).toEqual([MARK_SENTRY, MARK_API]);
+  });
+});
+
+describe('W3-12 — sentryBootstrap import-graph pin', () => {
+  // Static assertion over the bootstrap module's own import list. This is
+  // what stops a future edit from silently re-breaking the order: if
+  // sentryBootstrap.ts ever reaches services/api — directly or transitively —
+  // it recreates the exact problem it exists to solve.
+  //
+  // RED today: the module does not exist yet.
+  const SRC_ROOT = path.join(APP_ROOT, 'src');
+
+  function localImportsOf(file: string): string[] {
+    const src = fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+    const specs: string[] = [];
+    const re = /(?:\bfrom|\brequire\(|\bimport)\s*['"](\.[^'"]+)['"]/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) specs.push(m[1]);
+    return specs;
+  }
+
+  function transitiveLocalGraph(entry: string): string[] {
+    const seen = new Set<string>();
+    const stack = [entry];
+    while (stack.length) {
+      const file = stack.pop() as string;
+      if (seen.has(file)) continue;
+      seen.add(file);
+      for (const spec of localImportsOf(file)) {
+        const resolved = resolveLocal(file, spec);
+        if (resolved && !seen.has(resolved)) stack.push(resolved);
+      }
+    }
+    seen.delete(entry);
+    return [...seen];
+  }
+
+  it('src/services/sentryBootstrap.ts exists', () => {
+    expect(fs.existsSync(BOOTSTRAP_FILE)).toBe(true);
+  });
+
+  it('sentryBootstrap.ts never reaches services/api, even transitively', () => {
+    expect(fs.existsSync(BOOTSTRAP_FILE)).toBe(true);
+    const graph = transitiveLocalGraph(BOOTSTRAP_FILE).map((f) =>
+      path.relative(SRC_ROOT, f).replace(/\\/g, '/'),
+    );
+    expect(graph).not.toContain('services/api.ts');
+    expect(graph.filter((f) => /(^|\/)api\.tsx?$/.test(f))).toEqual([]);
+  });
+
+  it('index.ts imports the bootstrap ahead of ./App', () => {
+    const src = fs.readFileSync(ENTRY, 'utf8').replace(/\r\n/g, '\n');
+    const bootstrapAt = src.search(/['"][^'"]*sentryBootstrap['"]/);
+    const appAt = src.search(/['"]\.\/App['"]/);
+    expect(bootstrapAt).toBeGreaterThanOrEqual(0);
+    expect(appAt).toBeGreaterThanOrEqual(0);
+    expect(bootstrapAt).toBeLessThan(appAt);
+  });
+});

--- a/SmartCompareApp/__tests__/helpers/w312BootSandbox.ts
+++ b/SmartCompareApp/__tests__/helpers/w312BootSandbox.ts
@@ -1,0 +1,235 @@
+/**
+ * W3-12 boot sandbox — shared harness for the two red tests.
+ *
+ * NOT a test file (jest's `testMatch` only collects `*.test.ts(x)`).
+ *
+ * WHY THIS EXISTS. This repo's jest runs ts-jest, and TypeScript's CommonJS
+ * emit does NOT hoist requires — it emits each `require()` in place, in
+ * source order. Under that transform `initSentry()` at App.tsx:10 runs
+ * BEFORE the line-74 import of authService, so a plain `require('../index')`
+ * test is GREEN today and proves nothing. Metro bundles the app with
+ * `babel-preset-expo`, whose CJS transform hoists every require above the
+ * module body (babel.config.js's own header notes "jest never loads this
+ * file (the test runner is ts-jest, not babel)").
+ *
+ * So this harness compiles the REAL entry point and the real modules on the
+ * boot chain with the SHIPPED TWO-STAGE pipeline (babel-preset-expo under
+ * Metro's caller
+ * flags) and executes them in a sandbox whose `require` records what happens
+ * in what order. Modules outside the chain under test are stubbed; each
+ * suite asserts first that the markers it cares about were actually reached,
+ * so a stub or a renamed path can never be mistaken for an ordering failure.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const babel = require('@babel/core');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const importExportPlugin = require('metro-transform-plugins').importExportPlugin;
+
+export const APP_ROOT = path.resolve(__dirname, '../..');
+export const ENTRY = path.join(APP_ROOT, 'index.ts');
+export const APP_FILE = path.join(APP_ROOT, 'App.tsx');
+export const AUTH_FILE = path.join(APP_ROOT, 'src', 'services', 'authService.ts');
+export const API_FILE = path.join(APP_ROOT, 'src', 'services', 'api.ts');
+export const SENTRY_FILE = path.join(APP_ROOT, 'src', 'services', 'sentry.ts');
+export const PINNING_FILE = path.join(APP_ROOT, 'src', 'services', 'certificatePinning.ts');
+export const BOOTSTRAP_FILE = path.join(APP_ROOT, 'src', 'services', 'sentryBootstrap.ts');
+
+/**
+ * THE REAL TWO-STAGE METRO PIPELINE (Fable review, W3-12).
+ *
+ * An earlier version of this harness ran babel-preset-expo with
+ * `supportsStaticESM: false` and called that "the shipped transform". It is
+ * not. `@expo/metro-config` sets `experimentalImportSupport: true`
+ * (ExpoMetroConfig.js:321) and its babel-transformer derives
+ * `supportsStaticESM: options.experimentalImportSupport`
+ * (babel-transformer.js:78) — so on device Babel is asked to LEAVE the module
+ * as ESM, and Metro's own `importExportPlugin` does the CommonJS lowering.
+ *
+ * Measuring a different transform and claiming it is the shipped one is the
+ * exact mistake that produced this unit's original (green, worthless) test, so
+ * it is not repeated here: both stages are run, in order, as Metro runs them.
+ *
+ * `configFile: false` is deliberate — the project's own babel.config.js
+ * plugins (lucide splitter, production console-strip, reanimated) rewrite
+ * bodies and imports but cannot MOVE a module-level require, so they cannot
+ * affect evaluation order. That is an argument, not a measurement, and it is
+ * recorded here as such.
+ */
+export function emitCjs(file: string): string {
+  // Stage 1 — what Metro actually asks babel-preset-expo for. ESM is preserved.
+  const stage1 = babel.transformFileSync(file, {
+    cwd: APP_ROOT,
+    filename: file,
+    configFile: false,
+    babelrc: false,
+    presets: ['babel-preset-expo'],
+    caller: {
+      name: 'metro',
+      supportsStaticESM: true,
+      supportsDynamicImport: true,
+      platform: 'ios',
+      isDev: false,
+    },
+  });
+
+  // Stage 2 — Metro's own ESM -> CJS lowering, the step that decides order.
+  const stage2 = babel.transform(stage1.code as string, {
+    cwd: APP_ROOT,
+    filename: file,
+    configFile: false,
+    babelrc: false,
+    // The same options metro-transform-worker passes when
+    // experimentalImportSupport is on (metro-transform-worker/src/index.js:150-157).
+    // The two identifier names are only helper bindings; they cannot affect the
+    // require ORDER these suites measure, but they are required or the plugin throws.
+    plugins: [[importExportPlugin, { importAll: '_$$_IMPORT_ALL', importDefault: '_$$_IMPORT_DEFAULT', resolve: false }]],
+  });
+
+  return stage2.code as string;
+}
+
+/** A lazily-deep, callable stub standing in for modules outside the chain. */
+export function makeStub(): any {
+  const fn: any = function stub() {
+    return makeStub();
+  };
+  return new Proxy(fn, {
+    get(_target, prop) {
+      if (prop === '__esModule') return true;
+      if (typeof prop === 'symbol') return undefined;
+      return makeStub();
+    },
+    apply() {
+      return makeStub();
+    },
+    construct() {
+      return makeStub();
+    },
+  });
+}
+
+export function resolveLocal(fromFile: string, spec: string): string | null {
+  const base = path.resolve(path.dirname(fromFile), spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.js`,
+    path.join(base, 'index.ts'),
+    path.join(base, 'index.tsx'),
+    path.join(base, 'index.js'),
+  ];
+  for (const cand of candidates) {
+    if (fs.existsSync(cand) && fs.statSync(cand).isFile()) return cand;
+  }
+  return null;
+}
+
+export interface BootOptions {
+  /** Local files whose real module body should be EXECUTED, not stubbed. */
+  executable: string[];
+  /** Local files whose require should be intercepted (body never executed). */
+  localOverrides?: Record<string, () => any>;
+  /** Bare package specifiers to intercept. Anything else is stubbed. */
+  bareOverrides?: Record<string, () => any>;
+}
+
+export interface BootRun {
+  /** Emitted CJS keyed by app-root-relative path — evidence the transform ran. */
+  emitted: Record<string, string>;
+}
+
+/**
+ * Compiles + executes the real `index.ts` boot chain under the shipped two-stage
+ * pipeline. HONEST LIMIT: this is Metro's TRANSFORM, driven by a sandbox
+ * `require` — Metro's own runtime (module registry, `__d`/`__r`, inline
+ * requires) is NOT exercised, so this is still not a device boot. The post-OTA
+ * on-device check remains a hard gate.
+ */
+export function runBoot(options: BootOptions): BootRun {
+  const emitted: Record<string, string> = {};
+  const registry = new Map<string, any>();
+  const executable = new Set(options.executable.filter((f) => fs.existsSync(f)));
+  const localOverrides = options.localOverrides ?? {};
+  const bareOverrides = options.bareOverrides ?? {};
+
+  function load(file: string): any {
+    if (registry.has(file)) return registry.get(file);
+    const moduleObj = { exports: {} as any };
+    registry.set(file, moduleObj.exports);
+
+    const code = emitCjs(file);
+    emitted[path.relative(APP_ROOT, file).replace(/\\/g, '/')] = code;
+
+    const sandboxRequire = (spec: string): any => {
+      if (spec.startsWith('.')) {
+        const resolved = resolveLocal(file, spec);
+        if (resolved && localOverrides[resolved]) {
+          // CACHE the override, exactly as a real module registry does
+          // (Fable review, W3-12). A module body runs ONCE on device — Metro
+          // caches by module id — so an override standing in for one must
+          // fire once too. Uncached, a module required from two places
+          // recorded its marker twice and the recorded boot sequence gained a
+          // phantom entry that had nothing to do with ordering.
+          if (!registry.has(resolved)) registry.set(resolved, localOverrides[resolved]());
+          return registry.get(resolved);
+        }
+        if (resolved && executable.has(resolved)) return load(resolved);
+        return makeStub();
+      }
+      if (bareOverrides[spec]) return bareOverrides[spec]();
+      // Babel's own runtime helpers must be REAL or the emitted interop
+      // wrappers misbehave. Every other package is stubbed.
+      if (spec.startsWith('@babel/runtime')) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        return require(spec);
+      }
+      return makeStub();
+    };
+
+    // Metro's ESM interop helpers. `importExportPlugin` emits calls to these
+    // two globals (they are named by the `importAll` / `importDefault` options
+    // metro-transform-worker passes it), and on device Metro's own require
+    // polyfill provides them. The sandbox has to supply them or every emitted
+    // module throws ReferenceError before it can record anything.
+    const importDefault = (spec: string) => {
+      const m: any = sandboxRequire(spec);
+      return m && m.__esModule ? m.default : m;
+    };
+    const importAll = (spec: string) => {
+      const m: any = sandboxRequire(spec);
+      if (m && m.__esModule) return m;
+      return { ...(m as object), default: m };
+    };
+
+    const factory = new Function(
+      'require',
+      'module',
+      'exports',
+      '__filename',
+      '__dirname',
+      '__DEV__',
+      '_$$_IMPORT_DEFAULT',
+      '_$$_IMPORT_ALL',
+      code,
+    );
+    factory(
+      sandboxRequire,
+      moduleObj,
+      moduleObj.exports,
+      file,
+      path.dirname(file),
+      false,
+      importDefault,
+      importAll,
+    );
+    registry.set(file, moduleObj.exports);
+    return moduleObj.exports;
+  }
+
+  load(ENTRY);
+  return { emitted };
+}

--- a/SmartCompareApp/index.ts
+++ b/SmartCompareApp/index.ts
@@ -1,3 +1,10 @@
+// W3-12 — MUST stay the FIRST import: its module body arms Sentry before any
+// other module body runs, so a boot-time failure anywhere in App's import
+// graph (notably the "running unpinned" certificate-pinning alarm raised from
+// api.ts's module body) reaches an initialised Sentry instead of being
+// dropped. Do not reorder, and do not let it reach services/api.
+import './src/services/sentryBootstrap';
+
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/SmartCompareApp/src/services/sentryBootstrap.ts
+++ b/SmartCompareApp/src/services/sentryBootstrap.ts
@@ -1,0 +1,25 @@
+/**
+ * W3-12 — side-effect-only Sentry bootstrap.
+ *
+ * WHY THIS MODULE EXISTS. `initSentry()` used to be a statement in App.tsx's
+ * module BODY, which reads like the first thing the app does but is not: a
+ * module body runs only after its entire import graph has been evaluated.
+ * App.tsx imports `authService`, which imports `services/api`, whose module
+ * body calls `setupCertificatePinning()` — and on failure that path raises
+ * `Sentry.captureMessage('[SECURITY] Certificate pinning init failed …')`,
+ * the one alarm that says a release fleet is running unpinned, into a Sentry
+ * that did not exist yet. The same window swallowed any boot crash in any
+ * module App.tsx imports.
+ *
+ * Both module systems evaluate dependencies in source order, so importing
+ * this module FIRST in `index.ts` — ahead of `./App` — runs this body before
+ * App's graph is touched.
+ *
+ * INVARIANT (pinned by `__tests__/bootSentryOrder.w312.test.ts`): this module
+ * imports ONLY `./sentry`. If it ever reaches `services/api`, even
+ * transitively, it recreates the exact problem it exists to solve. Do not add
+ * imports here.
+ */
+import { initSentry } from './sentry';
+
+initSentry();


### PR DESCRIPTION
## W3-12 — arm Sentry before the module graph is evaluated

`MB-STARTUP-BUNDLE-07` (= `MB-TWO-LEVER-RELEASE-03`). Client-only, unflagged, OTA-safe. **This is the third and last OTA precondition** — (1) the `/auth/refresh` 503 fix is live, (2) the textAlign revert merged in #141.

### The defect

`App.tsx:9-10` looked like the first thing the app does:

```ts
import { initSentry } from './src/services/sentry';
initSentry();
```

It is not. That call is a statement in App.tsx's module *body*, and a module body runs only after its entire import graph has been evaluated. App.tsx imports `authService` → `services/api`, whose module body calls `setupCertificatePinning()`. On failure that path raises `Sentry.captureMessage('[SECURITY] Certificate pinning init failed - session is running unpinned')` — **into a Sentry that does not exist yet.**

The same window swallowed any boot crash in any module App.tsx imports. That is exactly the class of failure an OTA can introduce, which is why this belongs *with* the OTA rather than after it.

### The fix

A side-effect-only `src/services/sentryBootstrap.ts`, imported **first** in `index.ts` ahead of `./App`. It imports **only** `./sentry` — if it ever reached `services/api`, even transitively, it would recreate the problem it exists to solve, and a static import-graph test pins that. The redundant call is removed from App.tsx.

### Two of the three reported defects were already green

Verified behaviourally at this base, not by reading:

- *"a throwing `getLocales` strands the splash"* — already fixed; the boot block ends in `.catch(...).finally(() => setIsLoading(false))` (the other session's B5). Re-tested with the language read throwing synchronously **and** rejecting: the gate releases both ways.
- *"a synchronously-throwing `initializeSslPinning` still produces a `captureMessage`"* — already true, and not a defect as worded: the `await` sits inside the `try`, so a sync throw, a rejected promise and an undefined native binding are caught identically.

Both are kept as clearly-labelled **regression pins**, because this unit reorders boot and must not regress that work. Neither was rebuilt as a "red" test — that would have produced green tests proving nothing.

### The harness — and why the obvious test is worthless here

**The specified test passes on the unfixed code.** This repo's jest uses `ts-jest`, and TypeScript's CommonJS emit does *not* hoist requires — it emits each `require()` in source order, so under the test runner `initSentry()` at line 10 genuinely runs first and the defect does not exist. (`babel.config.js`'s own header says jest never loads it.) That test was built, measured green, and discarded rather than shipped.

What ships instead compiles the real modules with the **shipped two-stage Metro pipeline** and executes the emitted CJS in an order-recording sandbox:

1. `babel-preset-expo` under Metro's caller flags with **`supportsStaticESM: true`** — Expo sets `experimentalImportSupport: true` (`ExpoMetroConfig.js:321`) and its transformer derives `supportsStaticESM` from it (`babel-transformer.js:78`);
2. Metro's own `importExportPlugin` for the CommonJS lowering, with the same options `metro-transform-worker` passes it.

An earlier revision used `supportsStaticESM: false` and called that "the shipped transform". It is not — and repeating that exact mistake inside the fix for it would have been absurd. The sandbox also caches module overrides as a real registry does, so a module required from two places records its body once.

**Honest limit:** this measures Metro's *transform*, driven by a sandbox `require`. Metro's own runtime (module registry, `__d`/`__r`, inline requires) is not exercised, so it is still not a device boot. The post-OTA on-device check stands: force a pinning failure on a release build and confirm the alarm arrives in Sentry.

### One correction to the finding's blast radius

The alarm is dropped for the **synchronous-throw** shape — an unlinked native module, where the library's Proxy throws before the `await` suspends. When the native module is present and `initialize()` returns a **rejected promise** (a genuine native-side failure), the catch runs in a microtask, after the synchronous boot chain, so pre-fix that alarm may have arrived anyway. The fix is strictly better and also covers the broader "any boot crash in any imported module" case — but the pre-fix damage was narrower than the report implies, and the on-device check should force the *synchronous* shape to be meaningful.

### Gates

- Red-first: 6 right-reason failures, with a passing falsifier in each suite proving the boot chain really reached both markers (so an ordering failure is not a mock artifact).
- **Mutations, all verified:** removing the bootstrap import → 6 failures; keeping the bootstrap *and* restoring `initSentry()` to App.tsx → the whole-sequence test fails; inserting an `api` side-effect import above the bootstrap → both ordering tests fail.
- `npx --no-install tsc --noEmit` exit 0; eslint clean.
- Full suite: **281 suites, 2,752 tests, 44 snapshots, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
