### PR TITLE
feat(cost): an OpenAI preflight breaker so a dead LLM stops paying the scrape cascade (W1-3)

### DIFF
--- a/app/api/text_routes.py
+++ b/app/api/text_routes.py
@@ -166,13 +166,21 @@ def _surface_comparison_failure(result: Dict):
         # Preserve the structured body (FE matches the spec contract). Wrapping
         # in HTTPException would drop the layer/extra keys via str(detail).
         return result
-    if code == "TIMEOUT":
+    if code in ("TIMEOUT", "LLM_UNAVAILABLE"):
         # D2 — transient timeout. Structured detail so the envelope keeps
         # code:"TIMEOUT" (error_handler overrides the 503→FEATURE_DISABLED
         # default when a code is supplied). 503, NOT 400.
+        #
+        # W1-3 (adversarial review MAJOR 4): LLM_UNAVAILABLE joins it. Without
+        # this it fell through to the generic arm below and a SERVER-side LLM
+        # outage was reported to the client as a 400 client error. It belongs
+        # with the other upstream-unavailable surfaces. NOTE: the mobile client
+        # has no i18n key for this code yet, so it renders the raw `error`
+        # string — which is why that copy is written to the no-scary-copy
+        # contract.
         raise HTTPException(
             status_code=503,
-            detail={"code": "TIMEOUT", "error": error_msg},
+            detail={"code": code, "error": error_msg},
         )
     # INSUFFICIENT_DATA + parser-failure + anything unrecognized → 400. Keep
     # the structured code where present so the FE can branch (e.g. show the

--- a/app/services/api_budget_service.py
+++ b/app/services/api_budget_service.py
@@ -3,6 +3,7 @@
 Uses cache_service helpers (_redis_get, _redis_set, _redis_incr, _redis_expire)
 for Redis access. Gracefully degrades if Redis is unavailable.
 """
+import asyncio
 import json
 import os
 import time
@@ -55,6 +56,24 @@ PROVIDER_CONFIGS = {
         "monthly_limit": 2200,      # 2,500 credits, save 300 buffer
         "warn_at": 2000,
         "is_lifetime": True,
+    },
+    # W1-3 (LS-FAILURE-MODES-COST-02) — OpenAI was the ONE provider with no
+    # budget row at all, despite gating whether any compare is worth anything.
+    # This is a BUDGET ROW FOR FUTURE METERING, NOT PART OF THE BREAKER.
+    # It is INERT today, and more inert than the `brightdata` entry above:
+    # nothing calls has_budget("openai") or record_usage("openai"), and the
+    # circuit-breaker path this unit wires up does NOT read it either — the
+    # breaker keys off `circuit:openai` via _circuit_key(), which never
+    # consults PROVIDER_CONFIGS (renaming this key leaves every breaker test
+    # green; adversarial review MINOR 7). The only live effect of the row's
+    # presence is cosmetic: PROVIDER_CONFIGS-iterating admin surfaces
+    # (get_usage_summary, get_provider_burn) now list an `openai` line reading
+    # 0/100000. The limit is a REQUEST count, not tokens or dollars; the real
+    # spend ceilings are OPENAI_MAX_RETRIES (#117) and the OpenAI account cap.
+    "openai": {
+        "monthly_limit": 100000,    # request-count ceiling, monthly reset
+        "warn_at": 90000,
+        "is_lifetime": False,       # Monthly reset (budget:openai:<YYYY-MM>)
     },
     # Bundle B S3 L2 — YouTube Data API v3. Free quota is 10,000 units/DAY
     # (NOT lifetime, NOT monthly): search.list costs 100 units, videos.list 1.
@@ -602,6 +621,330 @@ def record_success(provider: str) -> None:
         _redis_set(key, json.dumps(state), ex=_CB_TTL)
     except Exception as e:
         logger.warning(f"[CIRCUIT] Error recording success for {provider}: {e}")
+
+
+# ============================================================================
+# W1-3 — OPENAI PREFLIGHT BREAKER (ENABLE_LLM_PREFLIGHT_BREAKER, default OFF)
+# ============================================================================
+# Findings LS-FAILURE-MODES-COST-02/-03. Serper is dead by configuration on the
+# `web` service (SERPER_LIFETIME_LIMIT=0), so every search leg routes to Bright
+# Data, which is armed with no budget gate. Meanwhile OpenAI answers 429. The
+# app's only compare shape (explicit_pair) never checked LLM health before
+# dispatching, so every compare paid the full scrape/render cascade and THEN
+# failed at the LLM. Money out, nothing back.
+#
+# This mirrors serper_service.py:284-320 (ENABLE_SERPER_BREAKER) — the template
+# that already solved the two hard parts — and reuses THIS module's existing
+# breaker (is_circuit_closed / record_failure / record_success). No new breaker
+# abstraction is introduced.
+#
+#   * MEMOISE the breaker state (LLM_BREAKER_CACHE_TTL, default 60s) so the
+#     check adds no per-call blocking Redis round trip to an async hot path —
+#     the event-loop hazard W0 spent four units removing.
+#   * FAIL-OPEN on any error. If the breaker state cannot be read, DISPATCH. A
+#     Redis blip must never become "the app refuses every compare".
+#   * Flag OFF -> nothing here runs: no breaker read, no record, every call
+#     dispatches (byte-identical to the pre-unit code path).
+#
+# TWO DIFFERENT QUESTIONS, TWO DIFFERENT FUNCTIONS (adversarial review, BLOCKING
+# 2 — this is the defect that would have fired the first time anyone flipped the
+# flag). `is_circuit_closed` is NOT read-only: its CB_HALF_OPEN branch does a
+# `_redis_incr(probe_key)` and CB_HALF_OPEN_MAX_CALLS is 1. Using it for the
+# compare-entry preflight SPENDS that single probe on a compare that may never
+# dispatch an LLM call at all (blocked by the L1 content-safety prefilter, or
+# short-circuited earlier), after which nothing records an outcome, the breaker
+# stays half-open with its budget spent, and every later compare is denied
+# forever. So:
+#
+#   * PREFLIGHT — "should I even start?" — openai_preflight_allows_compare().
+#     Strictly read-only (one GET, memoised, never an INCR, never a SET). It
+#     denies ONLY a breaker that is OPEN and still inside its cooldown. A
+#     half-open (or cooldown-expired) breaker PROCEEDS, precisely so the probe
+#     is spent at a real dispatch that records an outcome.
+#   * ADMISSION — "may I make this probe call?" — the dispatch chokepoint
+#     guarded_llm_create(), which keeps is_circuit_closed and where a success or
+#     failure is actually recorded.
+#
+# WHY THE PREFLIGHT IS RECOVERY-AWARE (a correction to the ruling's letter, kept
+# faithful to its intent). get_breaker_state() returns the PERSISTED state
+# string; it does not apply the CB_RECOVERY_TIMEOUT transition, because only
+# is_circuit_closed writes that transition. A preflight that denied on a bare
+# `state == CB_OPEN` would therefore deny forever: it blocks the compare, so
+# nothing on the compare path ever calls is_circuit_closed, so the blob is never
+# transitioned to half-open, so the preflight keeps reading "open" — the same
+# permanent lockout in a new place (verified: get_breaker_state returns "open"
+# indefinitely for a blob tripped long past CB_RECOVERY_TIMEOUT). Treating a
+# cooldown-expired OPEN as "proceed" is what hands the probe to the dispatch
+# chokepoint, which transitions and counts it correctly.
+#
+# THE SUCCESS PATH COSTS NOTHING ON THE HOT PATH (adversarial review, MAJOR 3).
+# Measured before the fix: an identical compare went 12 -> 24 blocking Redis
+# GETs with the flag ON, eleven of them from an un-memoised record_success on
+# every successful dispatch. A closed breaker learning it is still closed is not
+# information. The memo therefore caches the STATE (not just a boolean), and a
+# dispatch whose snapshot says CLOSED with a zero failure count neither calls
+# is_circuit_closed nor records a success: zero Redis round trips per call, one
+# GET per memo window. An outcome is recorded only when it can change something
+# — a standing failure streak, a half-open probe, or any failure.
+_LLM_PREFLIGHT_FLAG = "ENABLE_LLM_PREFLIGHT_BREAKER"
+_LLM_BREAKER_CACHE_TTL_ENV = "LLM_BREAKER_CACHE_TTL"
+_DEFAULT_LLM_BREAKER_CACHE_TTL = 60.0
+
+OPENAI_PROVIDER = "openai"
+
+# (expires_at_monotonic, state, tripped_at, failure_count)
+_openai_breaker_cache: Optional[tuple] = None
+
+
+class LLMUnavailableError(RuntimeError):
+    """Raised INSTEAD of dispatching when the `openai` breaker denies admission.
+
+    The message deliberately avoids the substrings
+    `extraction_service.generate_comparison` matches on to decide whether to run
+    its rate-limited verdict fallback ("429" / "rate" / "quota"), so a suppressed
+    primary call cannot trigger a second dispatch attempt.
+    """
+
+
+def llm_preflight_breaker_enabled() -> bool:
+    """Read PER CALL (the price_service.exact_gate_enabled idiom) so a Railway
+    flip takes effect without a restart. Default OFF."""
+    return os.getenv(_LLM_PREFLIGHT_FLAG, "").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+
+
+def _llm_breaker_cache_ttl() -> float:
+    """Seconds a breaker snapshot is reused. <=0 disables memoisation entirely
+    (every call re-reads Redis) — the escape hatch if a decision must be
+    instant."""
+    raw = (os.environ.get(_LLM_BREAKER_CACHE_TTL_ENV) or "").strip()
+    if not raw:
+        return _DEFAULT_LLM_BREAKER_CACHE_TTL
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_LLM_BREAKER_CACHE_TTL
+
+
+def _reset_openai_breaker_cache() -> None:
+    """Drop the memoised breaker snapshot so the next call re-reads. Used by
+    openai_record_failure and by tests."""
+    global _openai_breaker_cache
+    _openai_breaker_cache = None
+
+
+def _store_openai_breaker_snapshot(state: str, tripped_at: float, failures: int) -> None:
+    """Seed the memo from a state we just wrote ourselves, so a recorded outcome
+    does not force the next call to re-read Redis."""
+    global _openai_breaker_cache
+    ttl = _llm_breaker_cache_ttl()
+    _openai_breaker_cache = (
+        (time.monotonic() + ttl, state, tripped_at, failures) if ttl > 0 else None
+    )
+
+
+def _openai_breaker_snapshot() -> tuple:
+    """(state, tripped_at, failure_count) for the `openai` breaker.
+
+    READ-ONLY — exactly one Redis GET per memo window and never a write, so it
+    can never spend the half-open probe. FAIL-OPEN: an absent, malformed or
+    unreadable blob reads as a clean CLOSED breaker, which dispatches."""
+    global _openai_breaker_cache
+    now = time.monotonic()
+    cached = _openai_breaker_cache
+    if cached is not None and now < cached[0]:
+        return cached[1], cached[2], cached[3]
+    state, tripped_at, failures = CB_CLOSED, 0.0, 0
+    try:
+        raw = _redis_get(_circuit_key(OPENAI_PROVIDER))
+        if raw:
+            blob = json.loads(raw)
+            state = blob.get("state") or CB_CLOSED
+            tripped_at = float(blob.get("tripped_at") or 0)
+            failures = int(blob.get("failure_count") or 0)
+    except Exception as e:  # noqa: BLE001 — a monitoring failure must not block calls
+        logger.warning("[CIRCUIT] openai breaker read failed (%s) — failing open", e)
+        state, tripped_at, failures = CB_CLOSED, 0.0, 0
+    _store_openai_breaker_snapshot(state, tripped_at, failures)
+    return state, tripped_at, failures
+
+
+def openai_preflight_allows_compare() -> bool:
+    """READ-ONLY compare-entry preflight: "should I even start?".
+
+    False ONLY for a breaker that is OPEN and still inside CB_RECOVERY_TIMEOUT.
+    Everything else proceeds — closed, half-open, a cooldown-expired OPEN, and
+    any state that could not be read (fail-open). Never increments the half-open
+    probe counter; that budget belongs to guarded_llm_create, which records an
+    outcome for it."""
+    state, tripped_at, _failures = _openai_breaker_snapshot()
+    if state != CB_OPEN:
+        return True
+    if time.time() - tripped_at >= CB_RECOVERY_TIMEOUT:
+        # Cooldown expired: this compare is the recovery probe's carrier. Let it
+        # through so is_circuit_closed can transition + count the probe at a
+        # dispatch that will actually record success or failure.
+        return True
+    return False
+
+
+def _openai_dispatch_admission() -> tuple:
+    """(admitted, outcome_matters) for ONE OpenAI dispatch.
+
+    `outcome_matters` is False on the overwhelmingly common path — a breaker
+    that is closed with no standing failure streak — because record_success
+    would then write a state Redis already holds (MAJOR 3: eleven such writes
+    per compare). Whenever the breaker is anything else, is_circuit_closed does
+    the real admission (including the atomic half-open probe INCR) and the
+    outcome is recorded."""
+    state, tripped_at, failures = _openai_breaker_snapshot()
+    if state == CB_CLOSED:
+        # A closed breaker admits; is_circuit_closed would spend a Redis GET to
+        # say the same thing. A success still matters while a partial failure
+        # streak stands, because recording it resets the streak.
+        return True, failures > 0
+    if state == CB_OPEN and (time.time() - tripped_at) < CB_RECOVERY_TIMEOUT:
+        # Denied without touching Redis; the probe budget is untouched.
+        return False, False
+    try:
+        admitted = is_circuit_closed(OPENAI_PROVIDER)
+    except Exception as e:  # noqa: BLE001 — a monitoring failure must not block calls
+        logger.warning("[CIRCUIT] openai breaker check failed (%s) — failing open", e)
+        admitted = True
+    return admitted, True
+
+
+def openai_record_failure() -> None:
+    """Record an OpenAI transport failure (429 / 5xx / timeout / cancellation)
+    and drop the breaker memo so a resulting trip engages immediately. No-op
+    unless the preflight flag is ON."""
+    if not llm_preflight_breaker_enabled():
+        return
+    try:
+        record_failure(OPENAI_PROVIDER)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[CIRCUIT] openai record_failure failed: %s", e)
+    finally:
+        _reset_openai_breaker_cache()
+
+
+def openai_record_success() -> None:
+    """Record an OpenAI 200 so a half-open probe closes the breaker, or a
+    standing failure streak resets. No-op unless the preflight flag is ON.
+
+    Callers gate this on `outcome_matters` from _openai_dispatch_admission — a
+    closed, clean breaker learning it is still closed is not information, and
+    paying two Redis round trips per successful dispatch to write it is the
+    hot-path tax MAJOR 3 measured."""
+    if not llm_preflight_breaker_enabled():
+        return
+    try:
+        record_success(OPENAI_PROVIDER)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[CIRCUIT] openai record_success failed: %s", e)
+        _reset_openai_breaker_cache()
+        return
+    # We just wrote CLOSED / failure_count 0; model it locally instead of paying
+    # a GET on the next call to rediscover it.
+    _store_openai_breaker_snapshot(CB_CLOSED, 0.0, 0)
+
+
+def _openai_failure_is_transient(exc: BaseException) -> bool:
+    """True only for the failure classes record_failure's own docstring names:
+    429, 5xx, timeout, connection error. A 400/401/403/404/422 is a REQUEST
+    defect (a bad prompt, a wrong model id, a dead key) and must never trip a
+    breaker that gates every compare. `openai` is imported lazily so this module
+    keeps importing without the SDK present."""
+    if isinstance(exc, TimeoutError):  # asyncio.TimeoutError is TimeoutError on 3.11+
+        return True
+    try:
+        import openai as _openai_sdk
+    except Exception:  # noqa: BLE001 — no SDK -> nothing to classify
+        return False
+    if isinstance(
+        exc,
+        (
+            _openai_sdk.RateLimitError,
+            _openai_sdk.APIConnectionError,  # APITimeoutError subclasses this
+            _openai_sdk.InternalServerError,
+        ),
+    ):
+        return True
+    if isinstance(exc, _openai_sdk.APIStatusError):
+        status = getattr(exc, "status_code", None)
+        return isinstance(status, int) and status >= 500
+    return False
+
+
+# WHICH OpenAI CALLERS FEED THIS BREAKER — the full census, so nobody later
+# assumes it sees traffic it does not (ruling #2; adversarial review MINOR 6).
+# WIRED (14 dispatches, all reachable from a compare):
+#   extraction_service      classify_category_llm, parse_product_query,
+#                           extract_specs, extract_price_*(2), extract_reviews,
+#                           generate_comparison (primary + rate-limit fallback)
+#   openai_service          identify_products (vision), extract_specs_targeted,
+#                           generate_comparison, disambiguate_variant_line
+#   url_extraction_service  extract_with_ai
+#   verdict_critique_service critique_verdict   (wired by this rework)
+# NOT WIRED, deliberately:
+#   content_safety_service:152 — `moderations.create`, a DIFFERENT API surface
+#     with its own fail-open contract. A moderation blip is not an "LLM is down"
+#     signal and must not gate every compare.
+#   image_service:173 — the Tier-3 product-image GPT fallback. It IS reachable
+#     from a compare (structured_comparison_service awaits get_product_image_url
+#     in the product fetch), so this is a scope decision, not a reachability
+#     one: it is optional enrichment whose own failure is already swallowed into
+#     "no image", and letting it trip the breaker that gates every compare would
+#     let a cosmetic tier take the whole product down. Revisit deliberately.
+async def guarded_llm_create(client, **kwargs):
+    """The ONE OpenAI chat-completion dispatch chokepoint the preflight breaker
+    reads and records at.
+
+    Flag OFF: a bare ``await client.chat.completions.create(**kwargs)`` — no
+    breaker read, no record, every call dispatches.
+
+    Flag ON: a denied admission raises LLMUnavailableError WITHOUT dispatching;
+    otherwise the call runs and its outcome is recorded WHEN THE OUTCOME CAN
+    CHANGE SOMETHING. This call-site guard is the backstop, NOT the saving — the
+    saving is the preflight at the two compare entries
+    (structured_comparison_service.compare_from_text and
+    compare_from_text_streaming), because a check here alone saves the LLM call
+    and still pays for all the scraping, which is the entire cost being attacked.
+    """
+    if not llm_preflight_breaker_enabled():
+        return await client.chat.completions.create(**kwargs)
+    admitted, outcome_matters = _openai_dispatch_admission()
+    if not admitted:
+        raise LLMUnavailableError(
+            "openai circuit breaker denied admission — dispatch suppressed"
+        )
+    try:
+        response = await client.chat.completions.create(**kwargs)
+    except asyncio.CancelledError:
+        # MINOR 5 — CancelledError is a BaseException, so an `except Exception`
+        # never saw it and an asyncio.wait_for timeout around this call was
+        # never recorded (measured: {'fail': 0, 'succ': 0}). Almost every
+        # wait_for in the compare path wraps THIS coroutine, so the timeout the
+        # breaker most needs to see arrived here as a cancellation.
+        #
+        # ACCEPTED RESIDUAL, disclosed rather than hidden: a cancellation from
+        # an outer cause (process shutdown, or ENABLE_PREVERDICT_DISCONNECT_ABORT
+        # closing the stream) is indistinguishable from a deadline here — the
+        # task is cancelled identically in both cases — so it also records a
+        # failure. It takes CB_FAILURE_THRESHOLD *consecutive* such records to
+        # trip, and any successful dispatch in between resets the streak (that
+        # is exactly the case `outcome_matters` keeps recording for).
+        # The cancellation is re-raised untouched, never swallowed.
+        openai_record_failure()
+        raise
+    except Exception as e:  # noqa: BLE001 — classify, record, re-raise unchanged
+        if _openai_failure_is_transient(e):
+            openai_record_failure()
+        raise
+    if outcome_matters:
+        openai_record_success()
+    return response
 
 
 def get_remaining(provider: str) -> int:

--- a/app/services/extraction_service.py
+++ b/app/services/extraction_service.py
@@ -22,6 +22,7 @@ from app.utils.prompt_sanitizer import (
     sanitize_untrusted_block,
     check_injection_patterns,
 )
+from app.services import api_budget_service as _llm_breaker
 
 logger = logging.getLogger(__name__)
 
@@ -1220,7 +1221,7 @@ async def classify_category_llm(texts: list) -> str:
         user_content = sanitize_prompt_input(" | ".join(names), max_length=300)
         client = get_client()
         response = await asyncio.wait_for(
-            client.chat.completions.create(
+            _llm_breaker.guarded_llm_create(client,
                 model=standard_model(),
                 messages=[
                     {"role": "system", "content": _CLASSIFY_CATEGORY_LLM_PROMPT},
@@ -1360,7 +1361,7 @@ async def parse_product_query(query: str) -> Tuple[Dict[str, Any], Dict[str, int
         sanitized_query = sanitize_prompt_input(query, max_length=500)
         if check_injection_patterns(query):
             logger.warning(f"Injection pattern detected in query: {query[:100]}")
-        response = await client.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client,
             model=standard_model(),
             messages=[
                 {"role": "system", "content": PRODUCT_PARSER_PROMPT},
@@ -1418,7 +1419,7 @@ async def extract_specs(
             skip_fields=skip_fields,
         )
 
-        response = await client.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client,
             model=standard_model(),
             messages=[
                 {"role": "system", "content": prompt_parts["system"]},
@@ -1577,7 +1578,7 @@ Region: {region} ({region_info["currency"]})
 SEARCH CONTEXT:
 {_wrap_search_context(search_context[:2000])}"""
 
-        response = await client.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client,
             model=standard_model(),
             messages=[
                 {"role": "system", "content": PRICE_EXTRACTION_SYSTEM},
@@ -1623,7 +1624,7 @@ async def extract_price_from_training_data(
 Product: {s_brand} {s_name} {s_variant}
 Region: {region} ({region_info["currency"]})
 </USER_INPUT>"""
-        response = await client.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client,
             model=standard_model(),
             messages=[
                 {"role": "system", "content": PRICE_FALLBACK_SYSTEM},
@@ -1670,7 +1671,7 @@ Category: {category}
 SEARCH CONTEXT:
 {_wrap_search_context(search_context[:2500])}"""
 
-        response = await client.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client,
             model=standard_model(),
             messages=[
                 {"role": "system", "content": REVIEWS_EXTRACTION_SYSTEM},
@@ -2438,7 +2439,7 @@ Primary concern: {concern}
         # COMPARISON_SYSTEM already contains "Return ONLY valid JSON" so
         # OpenAI's prompt-validation contract is satisfied.
         try:
-            response = await client.chat.completions.create(
+            response = await _llm_breaker.guarded_llm_create(client,
                 model=verdict_model,
                 messages=[
                     {"role": "system", "content": system_msg},
@@ -2480,9 +2481,10 @@ Primary concern: {concern}
                 # already-saturated mini TPM budget. Worst-case chain total is
                 # model_config.verdict_chain_max_attempts(), read per call.
                 from app.services.model_config import openai_fallback_max_retries
-                response = await client.with_options(
-                    max_retries=openai_fallback_max_retries()
-                ).chat.completions.create(
+                response = await _llm_breaker.guarded_llm_create(
+                    client.with_options(
+                        max_retries=openai_fallback_max_retries()
+                    ),
                     model=verdict_model,
                     messages=[
                         {"role": "system", "content": system_msg},

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -19,6 +19,7 @@ from app.services.model_config import (
     verdict_model,
     vision_model,
 )
+from app.services import api_budget_service as _llm_breaker
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +213,7 @@ EXAMPLES:
     
     # Call OpenAI Vision API
     _vision_model = vision_model()
-    response = await client.chat.completions.create(
+    response = await _llm_breaker.guarded_llm_create(client,
         model=_vision_model,
         messages=[{"role": "user", "content": content}],
         **token_limit_kwargs(_vision_model, 500),
@@ -299,7 +300,7 @@ Rules:
     try:
         client_local = get_client()
         _model = standard_model()
-        response = await client_local.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client_local,
             model=_model,
             messages=[
                 {"role": "system", "content": system},
@@ -374,7 +375,7 @@ Rules:
         # explicit id (structured_comparison_service routes one in from
         # model_router) are unaffected.
         _model = model or verdict_model()
-        response = await client_local.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client_local,
             model=_model,
             messages=[
                 {"role": "system", "content": system},
@@ -436,7 +437,7 @@ async def disambiguate_variant_line(
     try:
         client_local = get_client()
         _model = standard_model()
-        response = await client_local.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client_local,
             model=_model,
             messages=[
                 {"role": "system", "content": system},

--- a/app/services/structured_comparison_service.py
+++ b/app/services/structured_comparison_service.py
@@ -61,6 +61,10 @@ from app.services.scoring_service import get_scoring_service, MISSING_SCORE
 from app.services.api_budget_service import (
     has_budget, record_usage, record_failure, record_success,
     is_circuit_closed,
+    # W1-3 — the OpenAI preflight breaker (ENABLE_LLM_PREFLIGHT_BREAKER).
+    # openai_preflight_allows_compare is the READ-ONLY half deliberately: the
+    # half-open probe budget belongs to the dispatch chokepoint, never here.
+    llm_preflight_breaker_enabled, openai_preflight_allows_compare,
 )
 from app.services import firecrawl_service, scrapedo_service
 
@@ -1504,6 +1508,29 @@ _PRICE_RACE_TIMEOUT = float(os.getenv("PRICE_RACE_TIMEOUT", "15.0"))
 # "couldn't" / "try again" / "Failed to". The FE i18n-substitutes by CODE
 # ("TIMEOUT"), so this string is the API-level fallback, not the rendered copy.
 TIMEOUT_FRIENDLY_MESSAGE = "Still gathering prices — give it another tap in a moment."
+
+# W1-3 — copy for the LLM-preflight short-circuit. Same friendly register as
+# TIMEOUT_FRIENDLY_MESSAGE and inside the Build-Principle-#4 copy contract (no
+# "couldn't", no "try again", no "Failed to").
+LLM_UNAVAILABLE_FRIENDLY_MESSAGE = (
+    "Still warming up the comparison engine — give it another tap in a moment."
+)
+
+
+def _llm_preflight_short_circuits() -> bool:
+    """W1-3 — True when the compare must NOT start because the `openai` breaker
+    is OPEN and still inside its cooldown.
+
+    Deliberately calls the READ-ONLY preflight, never `is_circuit_closed`: the
+    latter increments the half-open probe counter (CB_HALF_OPEN_MAX_CALLS == 1),
+    so using it here would spend the single recovery probe on a compare that may
+    never reach an LLM dispatch at all — and, since nothing would then record an
+    outcome, the breaker would stay half-open with its budget spent and deny
+    every later compare indefinitely. A half-open (or cooldown-expired) breaker
+    PROCEEDS from here, so the probe is spent at a real dispatch inside
+    api_budget_service.guarded_llm_create, which records success or failure.
+    Flag OFF short-circuits the check itself, so nothing is read at all."""
+    return llm_preflight_breaker_enabled() and not openai_preflight_allows_compare()
 
 
 def _fan_out_budget_seconds() -> float:
@@ -3236,6 +3263,26 @@ class StructuredComparisonService:
         # M18 PO-fact-check-10 — Decision 7 notice (additive metadata key).
         return attach_data_freshness_notice(result)
 
+    def _llm_unavailable_envelope(self) -> Dict[str, Any]:
+        """W1-3 — the ONE body both compare entries return when the `openai`
+        breaker short-circuits, so the SSE path and the POST path cannot drift.
+
+        Shape: the existing failure envelope this route already emits (the same
+        keys as the TIMEOUT / STREAM_TIMEOUT bodies built a few lines above), so
+        the client's existing `parseApiError` handling applies unchanged. The
+        `code` is new — text_routes maps it to 503 alongside TIMEOUT — and the
+        client has no i18n key for it yet, so it renders `error` verbatim; that
+        is why the copy is written to the Build-Principle-#4 contract (no
+        "couldn't", no "try again", no "Failed to")."""
+        return {
+            "success": False,
+            "error": LLM_UNAVAILABLE_FRIENDLY_MESSAGE,
+            "code": "LLM_UNAVAILABLE",
+            "elapsed_seconds": 0.0,
+            "total_cost": self.total_cost,
+            "api_calls": self.api_calls,
+        }
+
     async def compare_from_text(
         self,
         query: str,
@@ -3262,7 +3309,26 @@ class StructuredComparisonService:
           - else → the existing INSUFFICIENT_DATA body (both products empty).
         A true `code:TIMEOUT` is reserved for the no-data case if even the
         partial build fails; the route maps it to HTTP 503 (D2), never 400.
+
+        W1-3 (ENABLE_LLM_PREFLIGHT_BREAKER, default OFF) — the LLM preflight
+        sits HERE, at the compare entry, and not at the OpenAI call sites: a
+        check at the call sites saves the LLM call and still pays for the whole
+        Serper / Bright Data / Firecrawl fan-out, which is the entire cost being
+        attacked. With the `openai` breaker OPEN this returns the error envelope
+        before a single paid provider is touched. The read is memoised, READ-ONLY
+        and FAILS OPEN (see _llm_preflight_short_circuits), so a Redis blip can
+        never become "the app refuses every compare". The SSE entry
+        (compare_from_text_streaming) carries the same guard — it is the route
+        the mobile client actually drives. Flag OFF: no breaker read, no record,
+        the method is byte-identical.
         """
+        if _llm_preflight_short_circuits():
+            logger.warning(
+                "[CIRCUIT] openai breaker OPEN — short-circuiting compare for "
+                "query=%r BEFORE the provider fan-out",
+                query,
+            )
+            return self._llm_unavailable_envelope()
         _t0 = time.time()
         try:
             return await asyncio.wait_for(
@@ -3881,6 +3947,28 @@ class StructuredComparisonService:
         self.gpt_calls = 0
         self.serper_calls = 0
         self._shopping_items_cache = {}
+
+        # W1-3 (ENABLE_LLM_PREFLIGHT_BREAKER, default OFF) — the SAME preflight
+        # the non-streaming entry runs, mirrored here because THIS is the entry
+        # the app actually uses: the client calls SSE streamComparison() and only
+        # falls back to POST /compare. Guarding one of the two entries would
+        # leave the primary user path paying the full Serper / Bright Data /
+        # Firecrawl cascade (measured on the non-streaming path: 22 search_web +
+        # 2 bd_search_web calls) before failing at the LLM — i.e. the unit's
+        # headline saving would not reach most real traffic. Emitted as an
+        # `error` event, which is what the route's `had_error` branch already
+        # keys the credit refund off. Placed before the L1 content-safety
+        # prefilter for exact parity with the sync path, where the preflight sits
+        # in compare_from_text and L1 lives inside _compare_from_text_impl.
+        # Flag OFF: no breaker read, no record, byte-identical.
+        if _llm_preflight_short_circuits():
+            logger.warning(
+                "[CIRCUIT] openai breaker OPEN — short-circuiting streaming "
+                "compare for query=%r BEFORE the provider fan-out",
+                query,
+            )
+            yield ("error", self._llm_unavailable_envelope())
+            return
 
         # M13-04 — deadline for the FULL stream (Phase 1 + the verdict/critique/
         # moderation tail). Computed at entry; the tail awaits are wrapped in

--- a/app/services/url_extraction_service.py
+++ b/app/services/url_extraction_service.py
@@ -19,6 +19,7 @@ from app.services.llm_provider import provider_base_url
 from app.services.model_config import standard_model, token_limit_kwargs
 
 from app.services.extraction_service import canonicalize_category
+from app.services import api_budget_service as _llm_breaker
 
 logger = logging.getLogger(__name__)
 
@@ -392,7 +393,7 @@ async def extract_with_ai(url: str, html: str, retailer: Dict) -> Dict[str, Any]
     try:
         client = get_client()
         _model = standard_model()
-        response = await client.chat.completions.create(
+        response = await _llm_breaker.guarded_llm_create(client,
             model=_model,
             messages=[{
                 "role": "user",

--- a/app/services/verdict_critique_service.py
+++ b/app/services/verdict_critique_service.py
@@ -33,6 +33,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from app.services import api_budget_service as _llm_breaker
 from app.services.database_service import get_admin_supabase_client
 from app.services.model_config import critic_model, token_limit_kwargs
 from app.services.openai_service import get_client
@@ -164,7 +165,14 @@ async def critique_verdict(
             comparison, product_names, pain_workflow_context
         )
         _model = critic_model()
-        response = await client.chat.completions.create(
+        # W1-3 (adversarial review MINOR 6) — this dispatch IS on the compare
+        # path (_apply_self_critique, gated by ENABLE_SELF_CRITIQUE), so it feeds
+        # the breaker like the other compare-path callers. Flag OFF this is a
+        # bare create(). A denied admission raises LLMUnavailableError, which the
+        # enclosing `except Exception` already turns into "serve the original
+        # verdict" — the documented contract of this function.
+        response = await _llm_breaker.guarded_llm_create(
+            client,
             model=_model,
             messages=[
                 {"role": "system", "content": _CRITIQUE_SYSTEM},

--- a/tests/test_openai_breaker.py
+++ b/tests/test_openai_breaker.py
@@ -1,0 +1,911 @@
+"""W1-3 — an OpenAI preflight breaker, so a dead LLM stops costing money.
+
+Findings ``LS-FAILURE-MODES-COST-02`` / ``-03``. Flag
+``ENABLE_LLM_PREFLIGHT_BREAKER``, default OFF; flag OFF must be byte-identical.
+
+WHY THIS UNIT EXISTS (measured, not modelled)
+---------------------------------------------
+Serper is dead by configuration on ``web`` (``SERPER_LIFETIME_LIMIT=0``), so
+every search leg routes to Bright Data, which is armed with no budget gate and
+no breaker. Meanwhile OpenAI answers 429. The app's only compare shape
+(``explicit_pair``) never checks LLM health before dispatching, so every compare
+pays the full scrape/render cascade and then fails at the LLM. Money out,
+nothing back.
+
+THE CONTRACT THESE TESTS PIN
+----------------------------
+The template is the Serper breaker at ``serper_service.py:284-320``
+(``ENABLE_SERPER_BREAKER``), which already solved the two hard parts. The OpenAI
+breaker must mirror it exactly:
+
+  * ``api_budget_service.PROVIDER_CONFIGS`` gains an ``"openai"`` entry — a
+    budget row for FUTURE metering, explicitly not part of the breaker mechanism.
+  * The breaker state is MEMOISED and the success path costs NOTHING when the
+    breaker is closed and clean, so the hot path takes no blocking Redis round
+    trip — the event-loop hazard W0 spent four units removing.
+  * FAIL-OPEN on any error. If the breaker state cannot be read, DISPATCH. A
+    Redis blip must never become "the app refuses every compare".
+  * The short-circuit sits at BOTH COMPARE ENTRIES, before the provider fan-out
+    — ``compare_from_text`` AND ``compare_from_text_streaming``, which is the
+    entry the mobile client actually drives. Placing it at the OpenAI call sites
+    saves the LLM call and still pays for all the scraping, which is the entire
+    cost being attacked.
+  * The compare-entry preflight is READ-ONLY. ``is_circuit_closed`` is not: its
+    half-open branch spends the single ``CB_HALF_OPEN_MAX_CALLS`` probe, so
+    using it at an entry that may never dispatch an LLM call would leave the
+    breaker half-open with its budget spent and NOTHING to record an outcome —
+    denying every later compare forever. Pinned by
+    ``test_half_open_preflight_never_locks_the_breaker_open``.
+  * Flag OFF: no breaker read, no record, every call dispatches, both entries
+    reach the fan-out.
+
+The breaker uses the EXISTING abstraction (``api_budget_service.record_failure``
+/ ``record_success`` / ``is_circuit_closed``) under the provider key ``openai``.
+No new breaker is introduced.
+
+SURFACE ASSUMPTIONS (stated so a reviewer can move them deliberately)
+---------------------------------------------------------------------
+Behavioural tests go through real call paths (``openai_service`` for the record
+half, ``compare_from_text`` / ``compare_from_text_streaming`` for the preflight
+half) rather than private helpers, so a RED failure is "the behaviour is absent",
+never "the name is absent". The one exception is the MINOR-5 timeout pin, which
+drives ``guarded_llm_create`` directly because that IS the named chokepoint.
+Fail-open is exercised by making the underlying Redis GET raise, not by patching
+a named breaker helper, so the test cannot be satisfied by a rename. Two names
+ARE pinned outright because the spec names them: the flag
+``ENABLE_LLM_PREFLIGHT_BREAKER`` and the provider key ``"openai"``.
+
+Zero-network: the circuit-breaker Redis is dict-stubbed, every OpenAI client is
+a mock, and the Serper / Bright Data / Firecrawl entry points are counting stubs.
+"""
+import asyncio
+import json
+import time
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import openai as openai_sdk
+from fastapi import HTTPException
+
+from app.api import text_routes as text_routes_mod
+from app.services import api_budget_service as abs_mod
+from app.services import brightdata_service as bd_mod
+from app.services import extraction_service as extraction_mod
+from app.services import firecrawl_service as fc_mod
+from app.services import openai_service as oai
+from app.services import serper_service as ss
+from app.services import structured_comparison_service as scs
+from app.services import url_extraction_service as url_extraction_mod
+from app.services import verdict_critique_service as vc_mod
+
+
+FLAG = "ENABLE_LLM_PREFLIGHT_BREAKER"
+TTL_ENV = "LLM_BREAKER_CACHE_TTL"
+PROVIDER = "openai"
+
+# An L1-blocklisted query (app/data/content_blocklist.json, `weapons`). It makes
+# a compare return BEFORE any LLM call is dispatched, which is the exact shape
+# that turned the half-open probe into a permanent lockout.
+L1_BLOCKED_QUERY = "handgun holster vs rifle case"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+def _dict_breaker_redis(seed=None):
+    """A dict standing in for the circuit-breaker Redis. Returns the store, an
+    op counter, and the four cache_service helpers api_budget_service calls.
+
+    The counter is what makes the hot-path cost assertable: every entry in it is
+    one BLOCKING Upstash round trip on the async event loop."""
+    store = dict(seed or {})
+    ops = {"get": 0, "set": 0, "incr": 0, "expire": 0}
+
+    def _get(key):
+        ops["get"] += 1
+        return store.get(key)
+
+    def _set(key, value, ex=None):
+        ops["set"] += 1
+        store[key] = value
+        return True
+
+    def _incr(key):
+        ops["incr"] += 1
+        store[key] = str(int(store.get(key, "0")) + 1)
+        return int(store[key])
+
+    def _expire(key, ttl):
+        ops["expire"] += 1
+        return True
+
+    return store, ops, _get, _set, _incr, _expire
+
+
+def _patch_breaker_redis(get, set_, incr, expire):
+    """Context managers for the four api_budget_service Redis helpers."""
+    return (
+        patch.object(abs_mod, "_redis_get", side_effect=get),
+        patch.object(abs_mod, "_redis_set", side_effect=set_),
+        patch.object(abs_mod, "_redis_incr", side_effect=incr),
+        patch.object(abs_mod, "_redis_expire", side_effect=expire),
+    )
+
+
+def _open_breaker_seed(provider=PROVIDER, tripped_ago=0.0):
+    """A breaker blob that reads as OPEN. `tripped_ago=0` is inside the cooldown
+    (deny); anything past CB_RECOVERY_TIMEOUT is recovery-eligible."""
+    return {
+        abs_mod._circuit_key(provider): json.dumps({
+            "state": abs_mod.CB_OPEN,
+            "failure_count": abs_mod.CB_FAILURE_THRESHOLD,
+            "tripped_at": time.time() - tripped_ago,
+        })
+    }
+
+
+def _half_open_breaker_seed(provider=PROVIDER):
+    """A breaker blob already transitioned to half-open with its probe UNSPENT."""
+    return {
+        abs_mod._circuit_key(provider): json.dumps({
+            "state": abs_mod.CB_HALF_OPEN,
+            "failure_count": abs_mod.CB_FAILURE_THRESHOLD,
+            "tripped_at": time.time() - (abs_mod.CB_RECOVERY_TIMEOUT + 5),
+            "half_open_calls": 0,
+        })
+    }
+
+
+def _probe_key_for(store, provider=PROVIDER):
+    """The half-open probe counter key for the blob currently in `store`."""
+    state = json.loads(store[abs_mod._circuit_key(provider)])
+    return abs_mod._half_open_probe_key(provider, state)
+
+
+def _breaker_blob(store, provider=PROVIDER):
+    raw = store.get(abs_mod._circuit_key(provider))
+    return json.loads(raw) if raw else None
+
+
+def _rate_limit_error():
+    """A genuine SDK 429 — what a credit-exhausted OpenAI project returns."""
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    return openai_sdk.RateLimitError(
+        "rate limit / credit balance exhausted", response=response, body=None
+    )
+
+
+def _mock_openai_client(raises=None, content='{"f": "v"}'):
+    """A stand-in AsyncOpenAI whose chat.completions.create is countable."""
+    client = MagicMock()
+    if raises is not None:
+        client.chat.completions.create = AsyncMock(side_effect=raises)
+    else:
+        message = MagicMock()
+        message.content = content
+        choice = MagicMock()
+        choice.message = message
+        resp = MagicMock()
+        resp.choices = [choice]
+        resp.usage = None
+        client.chat.completions.create = AsyncMock(return_value=resp)
+    # content_safety L3 goes through client.moderations.create; give it an async
+    # stand-in so the compare path never falls back to its fail-open exception
+    # branch for a reason unrelated to this unit.
+    _flagged = MagicMock()
+    _flagged.flagged = False
+    _mod_resp = MagicMock()
+    _mod_resp.results = [_flagged]
+    client.moderations.create = AsyncMock(return_value=_mod_resp)
+    return client
+
+
+def _reset_breaker_memo():
+    """Drop the breaker memo between tests. Defensive: the hook does not exist in
+    the RED state, and its absence must not be what a behavioural test reports."""
+    for module in (oai, scs, abs_mod):
+        for name in (
+            "_reset_openai_breaker_cache",
+            "_reset_llm_breaker_cache",
+            "_reset_openai_gate_cache",
+        ):
+            hook = getattr(module, name, None)
+            if callable(hook):
+                hook()
+
+
+@pytest.fixture(autouse=True)
+def _clean_breaker_state(monkeypatch):
+    monkeypatch.delenv(FLAG, raising=False)
+    monkeypatch.delenv(TTL_ENV, raising=False)
+    _reset_breaker_memo()
+    yield
+    _reset_breaker_memo()
+
+
+def _arm_prod_search_config(monkeypatch):
+    """Reproduce the measured prod config from the finding: Serper dead by
+    configuration (``SERPER_LIFETIME_LIMIT=0``, no key) so every search leg routes
+    to the Bright Data fallback, which is armed with no budget gate. This is what
+    makes ``bd_search_web`` genuinely REACHABLE in this harness rather than a
+    counter that can only ever read zero."""
+    monkeypatch.delenv("SERPER_API_KEY", raising=False)
+    monkeypatch.delenv("SERPER_API_KEYS", raising=False)
+    monkeypatch.setenv("SERPER_LIFETIME_LIMIT", "0")
+    monkeypatch.setenv("ENABLE_BRIGHTDATA_FALLBACK", "true")
+    monkeypatch.setenv("BRIGHTDATA_API_KEY", "bd-test-dummy")
+    monkeypatch.setenv("BRIGHTDATA_ZONE", "serp_api1")
+    monkeypatch.delenv("ENABLE_BRIGHTDATA_BUDGET_GATE", raising=False)
+
+
+class _FanOutCounters:
+    """Counting stubs for every PAID provider entry point a compare can reach
+    before the LLM: Serper, the Bright Data fallback Serper's dead config routes
+    everything to, and Firecrawl."""
+
+    def __init__(self):
+        self.calls = {"search_web": 0, "bd_search_web": 0, "firecrawl": 0}
+
+    async def search_web(self, *args, **kwargs):
+        self.calls["search_web"] += 1
+        return {"organic": [], "shopping": []}
+
+    async def bd_search_web(self, *args, **kwargs):
+        self.calls["bd_search_web"] += 1
+        return {"organic": []}
+
+    async def firecrawl(self, *args, **kwargs):
+        self.calls["firecrawl"] += 1
+        return None
+
+    async def firecrawl_with_status(self, *args, **kwargs):
+        self.calls["firecrawl"] += 1
+        return None, 0
+
+    def patches(self, llm_client):
+        return (
+            patch.object(ss, "search_web", side_effect=self.search_web),
+            patch.object(scs, "search_web", side_effect=self.search_web),
+            patch.object(bd_mod, "bd_search_web", side_effect=self.bd_search_web),
+            patch.object(fc_mod, "scrape_page", side_effect=self.firecrawl),
+            patch.object(fc_mod, "scrape_page_with_status",
+                         side_effect=self.firecrawl_with_status),
+            patch.object(oai, "get_client", return_value=llm_client),
+            patch.object(extraction_mod, "get_client", return_value=llm_client),
+            patch.object(url_extraction_mod, "get_client", return_value=llm_client),
+        )
+
+    @property
+    def total(self):
+        return sum(self.calls.values())
+
+
+import contextlib  # noqa: E402 — used only by the helper below
+
+
+@contextlib.contextmanager
+def _all(*context_managers):
+    """Enter a flat tuple of context managers (keeps the `with` blocks readable
+    now that there are ten of them per test)."""
+    with contextlib.ExitStack() as stack:
+        for cm in context_managers:
+            stack.enter_context(cm)
+        yield
+
+
+async def _call_llm():
+    """One real LLM call path (``openai_service.extract_specs_targeted``). It
+    builds its client through ``get_client()`` and swallows exceptions, so the
+    observable is the dispatch count on the mocked client, not the return value."""
+    return await oai.extract_specs_targeted(
+        brand="Acme",
+        name="Widget",
+        variant=None,
+        category="electronics",
+        fields=["weight"],
+        context="snippets",
+    )
+
+
+async def _run_compare(query="Acme Widget vs Globex Gadget"):
+    service = scs.get_comparison_service()
+    return await service.compare_from_text(
+        query=query,
+        region="bahrain",
+        explicit_pair=("Acme Widget", "Globex Gadget"),
+    )
+
+
+async def _run_stream(query="Acme Widget vs Globex Gadget"):
+    """Drive the SSE entry the mobile client actually uses and collect its
+    events."""
+    service = scs.get_comparison_service()
+    events = []
+    async for event_type, data in service.compare_from_text_streaming(
+        query=query,
+        region="bahrain",
+        explicit_pair=("Acme Widget", "Globex Gadget"),
+    ):
+        events.append((event_type, data))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — the missing budget row (a CONFIGURATION pin, not a behavioural one)
+# ---------------------------------------------------------------------------
+def test_openai_has_a_provider_budget_row():
+    """CONFIGURATION PIN — deliberately labelled as such (adversarial review
+    MINOR 7). It asserts the row EXISTS and is well-formed; it asserts nothing
+    about behaviour, because the row has none: the breaker keys off
+    `circuit:openai` via `_circuit_key`, which never consults PROVIDER_CONFIGS.
+    The row is the budget row the finding asks for, for future metering."""
+    assert PROVIDER in abs_mod.PROVIDER_CONFIGS, (
+        "no 'openai' entry in PROVIDER_CONFIGS — the provider that gates every "
+        "compare's usefulness is the only one with no budget row"
+    )
+    entry = abs_mod.PROVIDER_CONFIGS[PROVIDER]
+    assert isinstance(entry.get("monthly_limit"), int) and entry["monthly_limit"] > 0
+    assert isinstance(entry.get("warn_at"), int) and entry["warn_at"] > 0
+    assert entry["warn_at"] < entry["monthly_limit"]
+    assert isinstance(entry.get("is_lifetime"), bool)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — three consecutive 429s ⇒ the 4th call short-circuits
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_three_429s_then_fourth_call_short_circuits(monkeypatch):
+    """RED: it dispatches. Today nothing records an OpenAI outcome and nothing
+    reads a breaker, so a 429 storm dispatches forever."""
+    monkeypatch.setenv(FLAG, "true")
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis()
+    client = _mock_openai_client(raises=_rate_limit_error())
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              patch.object(oai, "get_client", return_value=client)):
+        for _ in range(abs_mod.CB_FAILURE_THRESHOLD):
+            await _call_llm()
+        assert client.chat.completions.create.await_count == abs_mod.CB_FAILURE_THRESHOLD
+
+        await _call_llm()
+
+    assert client.chat.completions.create.await_count == abs_mod.CB_FAILURE_THRESHOLD, (
+        "the 4th call dispatched despite three consecutive 429s — no failure was "
+        "recorded against the 'openai' breaker, or the breaker is never read"
+    )
+    assert abs_mod._circuit_key(PROVIDER) in store, (
+        "no circuit state was ever written for 'openai'"
+    )
+    assert _breaker_blob(store)["state"] == abs_mod.CB_OPEN
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — THE LOAD-BEARING ONE: short-circuit BEFORE the provider fan-out
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_explicit_pair_compare_returns_before_provider_fanout(monkeypatch):
+    """The whole point of the unit. With the OpenAI breaker OPEN, an explicit-pair
+    compare must return the LLM_UNAVAILABLE-class envelope BEFORE any paid
+    provider is touched — Serper, the Bright Data fallback that Serper's dead
+    config routes everything to, and Firecrawl all record ZERO calls.
+
+    RED: > 0. Today the compare pays the full scrape/render cascade and only then
+    fails at the LLM. Flag OFF the identical harness reaches the fan-out 24 times
+    (see test_flag_off_compare_never_short_circuits), which is what makes the
+    zero here evidence rather than a tautology.
+    """
+    monkeypatch.setenv(FLAG, "true")
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(seed=_open_breaker_seed())
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        result = await _run_compare()
+
+    # THE assertion this unit exists for — asserted FIRST, because "the compare
+    # returned an error envelope" is worth nothing if it already paid for the
+    # scrape/render cascade to get there.
+    assert fan.calls == {"search_web": 0, "bd_search_web": 0, "firecrawl": 0}, (
+        f"the compare paid the provider fan-out before failing at the LLM: {fan.calls}"
+    )
+    assert llm_client.chat.completions.create.await_count == 0
+
+    # The envelope: the existing error SHAPE, carrying an LLM-unavailable code.
+    assert isinstance(result, dict)
+    assert result.get("success") is False, (
+        f"compare returned success={result.get('success')!r} with the OpenAI "
+        f"breaker OPEN (code={result.get('code')!r})"
+    )
+    assert result.get("code") == "LLM_UNAVAILABLE", (
+        f"expected an LLM_UNAVAILABLE-class envelope, got code={result.get('code')!r}"
+    )
+    assert isinstance(result.get("error"), str) and result["error"].strip()
+
+    # The preflight is READ-ONLY: one GET for the state, never a write, never an
+    # INCR of the half-open probe counter.
+    assert ops["set"] == 0 and ops["incr"] == 0, f"the preflight mutated Redis: {ops}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2b — BLOCKING 1: the SAME pin on the STREAMING entry the app actually uses
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_streaming_explicit_pair_returns_before_provider_fanout(monkeypatch):
+    """``GET /api/v1/text/compare/stream`` is the entry the mobile client drives
+    (``streamComparison()``); POST /compare is only its fallback. A preflight on
+    the non-streaming entry alone would leave the PRIMARY user path paying the
+    full Serper / Bright Data / Firecrawl cascade before failing at the LLM — the
+    unit's headline saving would not reach the traffic it was written for.
+
+    Same assertion as test 2, on the other entry: zeroed fan-out counters plus
+    the LLM_UNAVAILABLE-class error event.
+    """
+    monkeypatch.setenv(FLAG, "true")
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(seed=_open_breaker_seed())
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        events = await _run_stream()
+
+    assert fan.calls == {"search_web": 0, "bd_search_web": 0, "firecrawl": 0}, (
+        f"the STREAMING compare paid the provider fan-out before failing at the "
+        f"LLM: {fan.calls}"
+    )
+    assert llm_client.chat.completions.create.await_count == 0
+
+    assert [e for e, _ in events] == ["error"], (
+        f"expected exactly one error event before any work, got {[e for e, _ in events]}"
+    )
+    body = events[0][1]
+    assert body.get("success") is False
+    assert body.get("code") == "LLM_UNAVAILABLE", (
+        f"expected an LLM_UNAVAILABLE-class error event, got code={body.get('code')!r}"
+    )
+    assert isinstance(body.get("error"), str) and body["error"].strip()
+    assert ops["set"] == 0 and ops["incr"] == 0, f"the preflight mutated Redis: {ops}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2c — BLOCKING 2: the permanent-lockout pin
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_half_open_preflight_never_locks_the_breaker_open(monkeypatch):
+    """``is_circuit_closed`` is NOT read-only — its half-open branch INCRs the
+    probe counter and ``CB_HALF_OPEN_MAX_CALLS`` is 1. A compare-entry preflight
+    built on it SPENDS that single probe on a compare that may never dispatch an
+    LLM call at all (here: blocked by the L1 content-safety prefilter), after
+    which NOTHING records an outcome — so the breaker stays half-open with its
+    budget spent and denies every subsequent compare indefinitely. That is
+    strictly worse than the problem this unit exists to solve, and it would fire
+    the first time anyone flipped the flag.
+
+    The memo is disabled (``LLM_BREAKER_CACHE_TTL=0``) on purpose: with it on,
+    the second compare would reuse the first compare's cached verdict and the
+    defect would hide behind the cache rather than being pinned.
+    """
+    monkeypatch.setenv(FLAG, "true")
+    monkeypatch.setenv(TTL_ENV, "0")
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(
+        seed=_half_open_breaker_seed()
+    )
+    probe_key = _probe_key_for(store)
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        # 1. A compare that returns BEFORE any LLM dispatch.
+        blocked = await _run_compare(query=L1_BLOCKED_QUERY)
+        assert blocked.get("code") == "CONTENT_UNAVAILABLE", (
+            f"the harness did not produce a dispatch-free compare: {blocked!r}"
+        )
+        assert llm_client.chat.completions.create.await_count == 0
+        assert store.get(probe_key) is None, (
+            "the compare-entry preflight SPENT the single half-open probe on a "
+            f"compare that never dispatched an LLM call (probe={store.get(probe_key)!r})"
+        )
+
+        # 2. The very next compare must still be admitted.
+        result = await _run_compare()
+
+    assert result.get("code") != "LLM_UNAVAILABLE", (
+        "the breaker locked out every later compare after a half-open probe was "
+        "spent by a compare that recorded no outcome — permanent lockout"
+    )
+    assert fan.total > 0, "the second compare never reached the provider fan-out"
+    # And the probe was spent where an outcome IS recorded, closing the breaker.
+    assert llm_client.chat.completions.create.await_count > 0
+    assert store.get(probe_key) == "1", (
+        f"expected exactly one probe, spent at the dispatch chokepoint: "
+        f"{store.get(probe_key)!r}"
+    )
+    assert _breaker_blob(store)["state"] == abs_mod.CB_CLOSED, (
+        "the successful probe dispatch did not close the breaker"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_admits_once_the_open_cooldown_expires(monkeypatch):
+    """The other half of the same lockout, and a correction to the ruling's
+    letter: ``get_breaker_state`` returns the PERSISTED state and does NOT apply
+    the ``CB_RECOVERY_TIMEOUT`` transition — only ``is_circuit_closed`` writes
+    that. Verified: a blob tripped long past the cooldown still reads "open"
+    forever. So a preflight that denied on a bare ``state == CB_OPEN`` would deny
+    forever: it blocks the compare, nothing on the compare path then calls
+    ``is_circuit_closed``, the blob is never transitioned, and the preflight
+    keeps reading "open". A cooldown-expired OPEN must PROCEED, handing the probe
+    to the dispatch chokepoint that transitions and records it."""
+    monkeypatch.setenv(FLAG, "true")
+    monkeypatch.setenv(TTL_ENV, "0")
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(
+        seed=_open_breaker_seed(tripped_ago=abs_mod.CB_RECOVERY_TIMEOUT + 5)
+    )
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    # The state string alone still says OPEN — that is the trap being pinned.
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire)):
+        assert abs_mod.get_breaker_state(PROVIDER) == abs_mod.CB_OPEN
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        result = await _run_compare()
+
+    assert result.get("code") != "LLM_UNAVAILABLE", (
+        "a breaker whose cooldown has expired denied the compare — nothing else "
+        "on the compare path can transition it, so this denies forever"
+    )
+    assert fan.total > 0
+    assert _breaker_blob(store)["state"] == abs_mod.CB_CLOSED, (
+        "the recovery probe never reached a dispatch that could record an outcome"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — FAIL-OPEN pins (exercised through an unreadable Redis, not a
+# patched-out helper name)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_breaker_read_raising_still_dispatches(monkeypatch):
+    """A Redis blip must never become 'the app refuses every compare'. If the
+    breaker state cannot be read, DISPATCH."""
+    monkeypatch.setenv(FLAG, "true")
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis()
+    client = _mock_openai_client()
+
+    def _boom(key):
+        raise RuntimeError("upstash unreachable")
+
+    with _all(*_patch_breaker_redis(_boom, _set, _incr, _expire),
+              patch.object(oai, "get_client", return_value=client)):
+        await _call_llm()
+
+    assert client.chat.completions.create.await_count == 1, (
+        "an unreadable breaker blocked the call — the breaker must FAIL OPEN"
+    )
+    assert store == {}, f"an unreadable breaker still wrote state: {store}"
+
+
+@pytest.mark.asyncio
+async def test_breaker_read_raising_still_runs_the_compare(monkeypatch):
+    """Fail-open at the compare entry too. Asserts the compare actually SUCCEEDED
+    and actually reached the fan-out — `code != LLM_UNAVAILABLE` alone would pass
+    on a compare that failed for any unrelated reason (adversarial review)."""
+    monkeypatch.setenv(FLAG, "true")
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(seed=_open_breaker_seed())
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    def _boom(key):
+        raise RuntimeError("upstash unreachable")
+
+    with _all(*_patch_breaker_redis(_boom, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        result = await _run_compare()
+
+    assert result.get("success") is True, (
+        f"an unreadable breaker degraded the compare (code={result.get('code')!r}) "
+        "— it must FAIL OPEN and behave exactly as it does with no breaker at all"
+    )
+    assert result.get("code") != "LLM_UNAVAILABLE"
+    assert fan.total > 0, "the compare never reached the provider fan-out"
+    assert llm_client.chat.completions.create.await_count > 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_breaker_read_raising_still_runs_the_compare(monkeypatch):
+    """Same fail-open pin on the streaming entry: an unreadable breaker must not
+    turn the primary user path into an error event."""
+    monkeypatch.setenv(FLAG, "true")
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(seed=_open_breaker_seed())
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    def _boom(key):
+        raise RuntimeError("upstash unreachable")
+
+    with _all(*_patch_breaker_redis(_boom, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        events = await _run_stream()
+
+    codes = [d.get("code") for e, d in events if e == "error"]
+    assert "LLM_UNAVAILABLE" not in codes, (
+        "an unreadable breaker short-circuited the stream — it must FAIL OPEN"
+    )
+    assert fan.total > 0, "the stream never reached the provider fan-out"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — the hot path costs (almost) nothing: MEMOISED READ *and* no
+# un-memoised success writes
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_flag_on_hot_path_adds_no_per_call_redis_round_trips(monkeypatch):
+    """"No per-call blocking Redis round trip on the async hot path" was named
+    non-negotiable in the spec, and the first implementation only memoised the
+    READ: `record_success` still fired un-memoised on every successful dispatch,
+    which measured 12 -> 24 blocking GETs on one identical compare (adversarial
+    review MAJOR 3). This counts ALL FOUR Redis verbs, not just the read.
+
+    A closed breaker learning it is still closed is not information."""
+    monkeypatch.setenv(FLAG, "true")
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis()
+    ok_client = _mock_openai_client()
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              patch.object(oai, "get_client", return_value=ok_client)):
+        # A. Five successful dispatches in one memo window == ONE Redis op total.
+        for _ in range(5):
+            await _call_llm()
+        assert ops == {"get": 1, "set": 0, "incr": 0, "expire": 0}, (
+            f"5 successful dispatches cost {ops} blocking Redis round trips on "
+            "the event loop; the contract is one memoised read and no writes"
+        )
+
+        # B. A recorded FAILURE must both write and drop the memo.
+        failing_client = _mock_openai_client(raises=_rate_limit_error())
+        with patch.object(oai, "get_client", return_value=failing_client):
+            await _call_llm()
+        assert ops["set"] == 1, "the failure was not recorded"
+        after_failure = dict(ops)
+
+        # C. The next call re-reads (memo dropped) and, because a failure streak
+        #    now stands, its success IS recorded — that is what resets the streak.
+        await _call_llm()
+        assert ops["get"] == after_failure["get"] + 2, (
+            "a recorded failure did not invalidate the breaker memo — a trip "
+            f"would not engage until the memo window expired (ops={ops})"
+        )
+        assert ops["set"] == after_failure["set"] + 1, (
+            "the success that follows a failure streak was not recorded, so the "
+            "streak would never reset and unrelated failures would trip the breaker"
+        )
+        assert json.loads(store[abs_mod._circuit_key(PROVIDER)])["failure_count"] == 0
+        settled = dict(ops)
+
+        # D. Back on the quiet path: free again.
+        for _ in range(4):
+            await _call_llm()
+        assert ops == settled, (
+            f"the hot path started paying Redis again after recovery: {ops} vs {settled}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — flag OFF is byte-identical
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_flag_off_never_reads_or_records_and_always_dispatches(monkeypatch):
+    """Flag OFF: no breaker read, no record, every call dispatches."""
+    monkeypatch.delenv(FLAG, raising=False)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis()
+    client = _mock_openai_client(raises=_rate_limit_error())
+
+    seen = {"closed": 0, "fail": 0, "success": 0}
+
+    def _closed(provider):
+        if provider == PROVIDER:
+            seen["closed"] += 1
+        return True
+
+    def _fail(provider):
+        if provider == PROVIDER:
+            seen["fail"] += 1
+
+    def _success(provider):
+        if provider == PROVIDER:
+            seen["success"] += 1
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              patch.object(abs_mod, "is_circuit_closed", side_effect=_closed),
+              patch.object(abs_mod, "record_failure", side_effect=_fail),
+              patch.object(abs_mod, "record_success", side_effect=_success),
+              patch.object(oai, "get_client", return_value=client)):
+        for _ in range(5):
+            await _call_llm()
+
+    assert client.chat.completions.create.await_count == 5, (
+        "flag OFF must dispatch every call"
+    )
+    assert seen == {"closed": 0, "fail": 0, "success": 0}, (
+        f"flag OFF touched the breaker: {seen}"
+    )
+    assert ops == {"get": 0, "set": 0, "incr": 0, "expire": 0}, (
+        f"flag OFF made Redis round trips: {ops}"
+    )
+    assert store == {}, f"flag OFF wrote circuit state: {store}"
+
+
+@pytest.mark.asyncio
+async def test_flag_off_compare_never_short_circuits(monkeypatch):
+    """Flag OFF at the compare entry: an OPEN breaker is invisible and the
+    compare runs exactly as it does today — which means it REACHES THE FAN-OUT.
+    The counter is asserted, not merely built (adversarial review): without it
+    the docstring's claim was unchecked and the test would pass on a compare
+    that short-circuited for some other reason. Measured here: 22 Serper
+    `search_web` calls + 2 Bright Data `bd_search_web` calls, which is exactly
+    the spend test 2 proves the flag ON avoids."""
+    monkeypatch.delenv(FLAG, raising=False)
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(seed=_open_breaker_seed())
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        result = await _run_compare()
+
+    assert result.get("code") != "LLM_UNAVAILABLE", (
+        "flag OFF short-circuited the compare — flag OFF must be byte-identical"
+    )
+    assert fan.calls["search_web"] > 0 and fan.calls["bd_search_web"] > 0, (
+        f"flag OFF did not reach the paid provider fan-out: {fan.calls} — the "
+        "zero-fan-out assertion in test 2 would then prove nothing"
+    )
+    assert llm_client.chat.completions.create.await_count > 0
+
+
+@pytest.mark.asyncio
+async def test_flag_off_streaming_never_short_circuits(monkeypatch):
+    """Flag OFF on the streaming entry too: an OPEN breaker is invisible and the
+    stream reaches the fan-out."""
+    monkeypatch.delenv(FLAG, raising=False)
+    _arm_prod_search_config(monkeypatch)
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(seed=_open_breaker_seed())
+    fan = _FanOutCounters()
+    llm_client = _mock_openai_client()
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              *fan.patches(llm_client)):
+        events = await _run_stream()
+
+    codes = [d.get("code") for e, d in events if e == "error"]
+    assert "LLM_UNAVAILABLE" not in codes, (
+        "flag OFF short-circuited the stream — flag OFF must be byte-identical"
+    )
+    assert fan.calls["search_web"] > 0 and fan.calls["bd_search_web"] > 0, (
+        f"flag OFF did not reach the paid provider fan-out: {fan.calls}"
+    )
+    # NOTE deliberately NOT asserted here: `ops == 0`. A flag-OFF compare already
+    # makes 12 breaker GETs — the PRE-EXISTING firecrawl/scrapedo render-gate
+    # `is_circuit_closed` reads, which have nothing to do with this unit. The
+    # "flag OFF never touches the openai breaker" pin lives in
+    # test_flag_off_never_reads_or_records_and_always_dispatches, where the only
+    # breaker traffic possible is this unit's.
+    assert llm_client.chat.completions.create.await_count > 0
+
+
+# ---------------------------------------------------------------------------
+# MINOR 5 — a wait_for timeout must be RECORDED, and never swallowed
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_wait_for_timeout_around_the_guard_records_a_failure(monkeypatch):
+    """`asyncio.CancelledError` is a BaseException, so an `except Exception`
+    never saw it: an `asyncio.wait_for` deadline around a guarded dispatch
+    cancelled the call and the breaker recorded NOTHING (measured
+    {'fail': 0, 'succ': 0}). Most compare-path LLM calls are wrapped in exactly
+    such a wait_for, so this was the timeout class the breaker most needed to
+    see. The cancellation must still propagate — the guard records, it does not
+    swallow."""
+    monkeypatch.setenv(FLAG, "true")
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis()
+
+    client = MagicMock()
+
+    async def _never_returns(**kwargs):
+        await asyncio.sleep(30)
+
+    client.chat.completions.create = _never_returns
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire)):
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                abs_mod.guarded_llm_create(client, model="gpt-4o-mini"),
+                timeout=0.05,
+            )
+
+    blob = _breaker_blob(store)
+    assert blob is not None, (
+        "a wait_for timeout around the dispatch chokepoint recorded nothing — "
+        "the cancellation escaped the guard's `except Exception`"
+    )
+    assert blob["failure_count"] == 1, f"expected one recorded failure, got {blob}"
+
+
+# ---------------------------------------------------------------------------
+# MAJOR 4 — a server-side LLM outage is a 503, not a 400
+# ---------------------------------------------------------------------------
+def test_llm_unavailable_surfaces_as_503():
+    """`_surface_comparison_failure` fell through to the generic arm, so a
+    SERVER-side LLM outage was reported to the client as a client error."""
+    with pytest.raises(HTTPException) as excinfo:
+        text_routes_mod._surface_comparison_failure({
+            "success": False,
+            "code": "LLM_UNAVAILABLE",
+            "error": scs.LLM_UNAVAILABLE_FRIENDLY_MESSAGE,
+        })
+    assert excinfo.value.status_code == 503, (
+        f"LLM_UNAVAILABLE surfaced as HTTP {excinfo.value.status_code}; an "
+        "upstream outage belongs with the other 503s, not with BAD_REQUEST"
+    )
+    assert excinfo.value.detail["code"] == "LLM_UNAVAILABLE"
+    # The client has no i18n key for this code yet, so it renders `error`
+    # verbatim — it must therefore obey the no-scary-copy contract.
+    msg = excinfo.value.detail["error"].lower()
+    assert "failed" not in msg and "couldn't" not in msg and "try again" not in msg
+
+
+def test_timeout_still_surfaces_as_503():
+    """Guard the MAJOR-4 edit: widening the 503 arm must not move TIMEOUT."""
+    with pytest.raises(HTTPException) as excinfo:
+        text_routes_mod._surface_comparison_failure({"code": "TIMEOUT", "error": "x"})
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail["code"] == "TIMEOUT"
+
+
+def test_insufficient_data_still_surfaces_as_400():
+    """...and must not move anything else onto 503 either."""
+    with pytest.raises(HTTPException) as excinfo:
+        text_routes_mod._surface_comparison_failure(
+            {"code": "INSUFFICIENT_DATA", "error": "x"}
+        )
+    assert excinfo.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# MINOR 6 — the compare-path caller that was left unwired
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_verdict_critique_dispatch_feeds_the_breaker(monkeypatch):
+    """`verdict_critique_service.critique_verdict` IS on the compare path
+    (`_apply_self_critique`, gated by ENABLE_SELF_CRITIQUE) and was not wired to
+    the breaker. With the breaker OPEN it must not dispatch; the function's own
+    contract (serve the original verdict on any failure) is preserved."""
+    monkeypatch.setenv(FLAG, "true")
+    store, ops, _get, _set, _incr, _expire = _dict_breaker_redis(seed=_open_breaker_seed())
+    client = _mock_openai_client()
+
+    with _all(*_patch_breaker_redis(_get, _set, _incr, _expire),
+              patch.object(vc_mod, "get_client", return_value=client)):
+        result = await vc_mod.critique_verdict(
+            comparison={"winner_index": 0, "winner_reason": "cheaper"},
+            product_names=["Acme Widget", "Globex Gadget"],
+        )
+
+    assert client.chat.completions.create.await_count == 0, (
+        "the self-critique pass dispatched to OpenAI with the breaker OPEN — it "
+        "is on the compare path and must feed the breaker like the others"
+    )
+    assert result is None, "critique_verdict must degrade to the original verdict"


### PR DESCRIPTION
## W1-3 — an OpenAI preflight breaker, so a dead LLM stops paying the scrape cascade

`LS-FAILURE-MODES-COST-02` / `-03`. Flag **`ENABLE_LLM_PREFLIGHT_BREAKER`, default OFF**, flag-OFF byte-identical.

### Why — measured, on the production configuration

`ENABLE_BRIGHTDATA_FALLBACK=true` with no budget gate, `SERPER_LIFETIME_LIMIT=0`, and OpenAI at 429. Every compare paid the full cascade and then failed at the LLM. **Measured on one `explicit_pair` compare with the breaker OPEN and no preflight: 22 Serper `search_web` calls and 2 Bright Data `bd_search_web` calls before the LLM was ever consulted.** `PROVIDER_CONFIGS` had no `openai` row — the provider gating every compare's usefulness was the only one with no budget entry.

### The design: two different questions, two different primitives

| question | primitive | why |
|---|---|---|
| "should I even start this compare?" | `openai_preflight_allows_compare()` — strictly **read-only** | denies only an OPEN breaker still inside `CB_RECOVERY_TIMEOUT` |
| "may I make this one call?" | `is_circuit_closed` at the dispatch chokepoint | that is where an outcome is actually recorded |

**Getting this split wrong is not academic — it was caught twice, both times by measurement.**

**First cut:** used `is_circuit_closed` for the *preflight*. That function is **not read-only** — its `CB_HALF_OPEN` branch does `_redis_incr` on the probe key, and `CB_HALF_OPEN_MAX_CALLS` is 1. A compare admitted by that probe which never reached an LLM dispatch (content-safety prefilter, early return) recorded **no outcome**, leaving the breaker half-open with its budget spent and **denying every later compare forever** — strictly worse than the problem the unit exists to solve.

**The obvious fix was also wrong.** Routing the preflight through `get_breaker_state` (documented read-only) would have produced a *second* permanent lockout: it returns the persisted state and never applies the `OPEN → HALF_OPEN` recovery transition — only `is_circuit_closed` writes it — and a preflight that *blocks* the compare means nothing ever reaches the writer. Measured:

```
get_breaker_state("openai")  -> "open"   (stored: open)     x3
is_circuit_closed("openai")  -> True     (stored: half_open)
```

So the preflight reads the state blob directly (it needs `tripped_at`, which `get_breaker_state` does not expose), applies the recovery check read-only, and lets a **cooldown-expired OPEN through as the recovery probe's carrier** — so the transition happens at a dispatch that records an outcome. Pinned by `test_preflight_admits_once_the_open_cooldown_expires` and `test_half_open_preflight_never_locks_the_breaker_open`.

> *"Read-only" is a claim about a function's writes. It says nothing about whether the state machine it reads advances somewhere else.*

### Both entry points — because the app uses the one the first cut missed

`compare_from_text_streaming` is what `GET /api/v1/text/compare/stream` drives and what the mobile client actually uses. Guarding only `compare_from_text` would have left the primary user path paying the full fan-out while this PR claimed the saving. Both share one `_llm_unavailable_envelope()` so they cannot drift; the streaming side emits `("error", <envelope>)`, the event the route's `had_error` branch already keys the credit refund off.

### Hot path: the flag costs one Redis GET per compare

The memo caches breaker **state**, not a boolean, so a dispatch whose snapshot says CLOSED with no standing failure streak neither reads the breaker nor records a success — *a closed breaker learning it is still closed is not information*. Measured on the identical compare: **flag OFF 12 GETs → first cut ON 24 → now 13.** (The 12 are pre-existing render-gate reads, not this unit's.) A success is still recorded while a failure streak stands, because that is what resets it.

### Also fixed

`LLM_UNAVAILABLE` now surfaces as **503**, not 400 — a server-side outage is not a client error. A `wait_for` cancellation **records a failure and is re-raised**, never swallowed. `verdict_critique_service`'s dispatch feeds the breaker.

### Disclosed, not hidden

- `content_safety_service:152` and `image_service:173` do **not** feed the breaker. The second **is** on the compare path — that is a **scope** decision, not a reachability one: a cosmetic image-enrichment tier whose failure already degrades to "no image" should not trip the breaker that gates every compare.
- On Python 3.12 a `wait_for` deadline is indistinguishable from an external cancel, so the guard also records a failure on shutdown or a disconnect-abort. Bounded (three *consecutive* records trip it) and self-healing (the next success resets the streak).
- The `PROVIDER_CONFIGS['openai']` row is a budget entry for future metering, **not** part of the breaker mechanism — nothing in the breaker path reads it.
- The client has **no i18n key** for `LLM_UNAVAILABLE`, so it will render the raw `error` string until one ships.
- The memo means a cross-worker trip can be up to `LLM_BREAKER_CACHE_TTL` (60 s, env-tunable) stale. Bounded, and it fails toward dispatching.
- The credit refund on a short-circuit was verified **by reading** `text_routes`, not by a test.

### This does not stop the spend on merge

The flag ships **OFF**. Until it is flipped, `ENABLE_BRIGHTDATA_BUDGET_GATE=true` on both services (or unsetting the fallback) is still the thing that stops the money.

### Gates

- 18 unit tests. **14 of 14 mutations reddened** — every fix removed, its test confirmed red, restored.
- Four weak tests repaired, including one that built a counter and never asserted on it.
- **Flag-OFF byte-identity: `OVERALL SHA256 9504e5a9…` == the recorded base** (`n=414 skipped_no_html=6 distinct_queries=362 non_none=825 calls=1656`). Corpus manifest re-verified; `_proof/sweep2.py` not run.
- Ruff `E9,F63,F7,F82` + `py_compile` clean on all eight files.
- **Full CI-equivalent suite: 17,229 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
