### PR TITLE
fix(feedback): accept the chips the app actually sends (W3-1, MB-NETWORK-CONTRACT-01)

### DIFF
--- a/app/api/feedback_routes.py
+++ b/app/api/feedback_routes.py
@@ -34,8 +34,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["feedback"])
 
+# Allowlist of mattered_most values accepted by POST /feedback. This MUST be a
+# SUPERSET of every chip key the mobile app can send: FeedbackCard.tsx sends the
+# tapped chip as `mattered_most: [chipKey]`, and an unknown value 422-rejects the
+# WHOLE submission, which the client swallows (fire-and-forget), so the tap is
+# silently dropped server-side. tests/test_feedback_allowlist_superset.py greps
+# the FE chip definitions and fails if any is missing here. WIDEN this list only
+# — removing an accepted value breaks any client still sending it.
 VALID_MATTERED_MOST = [
-    "price", "specs", "reviews", "brand", "value", "warranty", "ratings"
+    "price", "specs", "reviews", "brand", "value", "warranty", "ratings",
+    # FeedbackCard.tsx chips (the MATTERED_OPTIONS array) — on phones today.
+    "accurate", "detailed", "fast",
 ]
 
 # Allowlist of event_type values accepted by POST /events. This MUST be a

--- a/tests/test_feedback_allowlist_superset.py
+++ b/tests/test_feedback_allowlist_superset.py
@@ -1,0 +1,184 @@
+"""Regression: VALID_MATTERED_MOST must be a superset of the FE feedback chips.
+
+W3-1 / MB-NETWORK-CONTRACT-01. The mobile app's FeedbackCard renders a row of
+pill chips and sends the tapped chip's key to POST /api/v1/feedback as
+`mattered_most: [chipKey]`. The route validates every item against
+feedback_routes.VALID_MATTERED_MOST and 422-rejects the WHOLE request on any
+unknown value — and FeedbackCard swallows that error (`catch {}`,
+fire-and-forget), so the tap silently records nothing server-side.
+
+Measured at eecd8bf9: the two sets have ZERO overlap. The client can send only
+`accurate` / `detailed` / `fast`; the allowlist holds only `price`, `specs`,
+`reviews`, `brand`, `value`, `warranty`, `ratings`. Every in-app feedback tap on
+the current build has been dropped. The fix is on the SERVER side (widen the
+allowlist), so it reaches users without an OTA.
+
+This mirrors tests/test_events_allowlist_superset.py, with ONE deliberate
+difference in what is grepped. The client sends `mattered_most: [chipKey]`
+DYNAMICALLY, so grepping for `mattered_most: [` finds no literal values and
+would pass vacuously. The literals that define the contract are the chip
+definitions themselves — the `{ key: '<x>' }` entries in the chip array in
+FeedbackCard.tsx — so those are what this test greps.
+
+This is a BACKEND test that scans SmartCompareApp/: per the gate rule in
+CLAUDE.md it belongs in the mobile comm set even when no client file changes
+(`grep -rl "SmartCompareApp" tests/` must find it).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FEEDBACK_CARD = REPO_ROOT / "SmartCompareApp" / "src" / "components" / "FeedbackCard.tsx"
+
+# The chip array entries, e.g. `{ key: 'accurate', i18nKey: '...' },`. These are
+# the ONLY literal mattered_most values in the client tree — the send site
+# (`mattered_most: [chipKey]`) is dynamic.
+# One brace-bounded object literal per match, DOTALL so a prettier-wrapped
+# multi-line chip and a reordered `{ i18nKey: ..., key: ... }` chip are BOTH
+# seen (adversary finding: the earlier same-line/key-first regex missed both,
+# so an unallowlisted chip in either shape shipped green).
+_CHIP_KEY_PATTERN = re.compile(
+    r"\{[^{}]*?\bkey:\s*['\"]([A-Za-z0-9_]+)['\"][^{}]*?\}", re.DOTALL
+)
+
+# The chips shipped on phones today (FeedbackCard.tsx:19-21). Pinned explicitly
+# so the contract survives a refactor that renames or moves the array.
+_SHIPPED_CHIP_KEYS = ("accurate", "detailed", "fast")
+
+
+def _collect_chip_keys() -> dict[str, list[str]]:
+    """Map chip key -> ["file:line"] for every literal chip definition."""
+    found: dict[str, list[str]] = {}
+    text = FEEDBACK_CARD.read_text(encoding="utf-8")
+    for m in _CHIP_KEY_PATTERN.finditer(text):
+        key = m.group(1)
+        lineno = text.count("\n", 0, m.start(1)) + 1
+        found.setdefault(key, []).append(
+            f"{FEEDBACK_CARD.relative_to(REPO_ROOT)}:{lineno}"
+        )
+    return found
+
+
+# ---- Static superset contract ----------------------------------------------
+
+def test_feedback_card_exists():
+    """Guard against a vacuous pass if the component moves or is renamed."""
+    assert FEEDBACK_CARD.is_file(), f"FeedbackCard not found at {FEEDBACK_CARD}"
+
+
+def test_chip_keys_are_the_values_sent_as_mattered_most():
+    """Anchor the grep target: the chip key IS what lands in mattered_most.
+
+    If this send site ever stops being `mattered_most: [chipKey]`, the chip
+    literals are no longer the contract and this whole file must be re-aimed.
+    """
+    text = FEEDBACK_CARD.read_text(encoding="utf-8")
+    assert "mattered_most: [chipKey]" in text, (
+        "FeedbackCard no longer sends the chip key as mattered_most — the grep "
+        "target of this test is stale"
+    )
+
+
+def test_some_chip_keys_discovered():
+    """The grep must actually find chip definitions — a regex that matched
+    nothing would make the superset assertion vacuously true."""
+    found = _collect_chip_keys()
+    assert len(found) >= 3, (
+        f"expected to discover the FeedbackCard chips, found {len(found)}: "
+        f"{sorted(found)} — the grep pattern may have drifted from the code"
+    )
+
+
+def test_valid_mattered_most_is_superset_of_feedback_chips():
+    """Every chip the client can send must be allowlisted server-side."""
+    from app.api.feedback_routes import VALID_MATTERED_MOST
+
+    allow = set(VALID_MATTERED_MOST)
+    found = _collect_chip_keys()
+    missing = {k: sites for k, sites in found.items() if k not in allow}
+    assert not missing, (
+        "VALID_MATTERED_MOST is missing FeedbackCard chip keys (a tap on these "
+        "422s and is silently dropped server-side):\n"
+        + "\n".join(f"  {k}  defined at {sites}" for k, sites in sorted(missing.items()))
+    )
+
+
+@pytest.mark.parametrize("chip", _SHIPPED_CHIP_KEYS)
+def test_shipped_chip_keys_are_allowlisted(chip):
+    """Explicit pins for the three chips on phones today — they must stay
+    allowlisted even if a future refactor removes their client definition
+    (builds already in the field keep sending them)."""
+    from app.api.feedback_routes import VALID_MATTERED_MOST
+
+    assert chip in set(VALID_MATTERED_MOST), (
+        f"{chip} must be allowlisted — the shipped client sends it and the "
+        f"route 422s the whole submission otherwise"
+    )
+
+
+def test_existing_seven_values_are_not_removed():
+    """This unit WIDENS the allowlist. Removing an accepted value is a breaking
+    change for any historical client or other caller that still sends it."""
+    from app.api.feedback_routes import VALID_MATTERED_MOST
+
+    allow = set(VALID_MATTERED_MOST)
+    for value in ("price", "specs", "reviews", "brand", "value", "warranty", "ratings"):
+        assert value in allow, f"{value} was dropped from VALID_MATTERED_MOST"
+
+
+# ---- Route-level contract ---------------------------------------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+
+    return TestClient(app)
+
+
+def test_route_accepts_a_shipped_chip_key(client):
+    """POST /feedback with the client's own chip value must not 422.
+
+    RED at eecd8bf9: 422 "Invalid mattered_most item: accurate."
+    """
+    with patch("app.services.feedback_service.get_supabase_client"):
+        resp = client.post(
+            "/api/v1/feedback",
+            json={"useful": True, "mattered_most": ["accurate"]},
+        )
+    assert resp.status_code == 200, (
+        f"expected the shipped chip to be accepted, got {resp.status_code}: "
+        f"{resp.text}"
+    )
+
+
+def test_route_still_accepts_an_existing_allowlisted_value(client):
+    """Pin: the seven pre-existing values keep working after the widening."""
+    with patch("app.services.feedback_service.get_supabase_client"):
+        resp = client.post(
+            "/api/v1/feedback",
+            json={"useful": True, "mattered_most": ["price"]},
+        )
+    assert resp.status_code == 200, resp.text
+
+
+def test_route_still_rejects_an_unknown_value(client):
+    """Pin: this widens the allowlist, it does NOT remove validation.
+
+    The 422 fires in the pydantic validator before the handler runs, but the
+    patch is still here so that under a validator mutation this test cannot
+    reach a real Supabase client (adversary finding: without it, M3 produced a
+    live `getaddrinfo` attempt from feedback_service).
+    """
+    with patch("app.services.feedback_service.get_supabase_client"):
+        resp = client.post(
+            "/api/v1/feedback",
+            json={"useful": True, "mattered_most": ["bogus"]},
+        )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## W3-1 — the feedback chips the app sends are the ones the server accepts

Finding `MB-NETWORK-CONTRACT-01`. **Backend only, no flag.** Reaches every phone WITHOUT an OTA, which is why it ships ahead of the W3 client wave.

### The defect, measured at `eecd8bf9`

`FeedbackCard.tsx` renders three chips — `accurate`, `detailed`, `fast` — and sends the tapped one as `mattered_most: [chipKey]`. `feedback_routes.VALID_MATTERED_MOST` held `price, specs, reviews, brand, value, warranty, ratings`. **The two sets had zero overlap.** The route 422s the WHOLE submission on any unknown value and `FeedbackCard` swallows that error (`catch {}`, fire-and-forget), so every in-app feedback tap on the current build has been silently dropped server-side. The review said "three missing"; it is every chip the client can send.

### The fix

One hunk in `app/api/feedback_routes.py`: the three chip keys appended to `VALID_MATTERED_MOST`. The seven existing values are kept (nothing proves no caller still sends them; removing an accepted value is a breaking change with no upside) and the validator is untouched — an unknown value still 422s.

### The durable half

`tests/test_feedback_allowlist_superset.py` mirrors `test_events_allowlist_superset.py`: it scans the client tree and asserts the allowlist is a superset of what the client can send. The grep target is deliberately the chip DEFINITIONS in `FeedbackCard.tsx`, not the send site — the client sends `mattered_most: [chipKey]` dynamically, so a grep for that literal would pass vacuously. The regex is brace-bounded and DOTALL so a reordered `{ i18nKey, key }` chip and a prettier-wrapped multi-line chip are both seen (adversary finding; mutation-proven — injecting one of each reddens the test and names both). Anti-vacuity guards pin that the component exists, that it still sends `chipKey` as `mattered_most`, and that at least three chips are discovered. **This is a backend test that scans `SmartCompareApp/`, so it belongs in the mobile comm set even when no client file changes** (`grep -rl SmartCompareApp tests/` finds it).

### Gates

- Comm gate (module-reference set: `feedback_routes` referencers ∪ `SmartCompareApp` scanners ∪ this file — 10 files): **1273 passed, 0 failed**.
- Full CI-mirrored suite at HEAD (`-m "not (live_unit or live_db or integration)"`, `--ignore=tests/test_integration.py`, `--timeout=60`, the 11 baseline nodes deselected): **17,258 passed / 0 failed / 51 skipped / 123 deselected / 37 xfailed**, exit 0.
- ruff blocking tier `E9,F63,F7,F82` + `py_compile` clean on both files.
- Adversary verdict **SOUND**; its two minor findings are fixed in this PR: (1) the regex false-negative on reordered / multi-line chips, (2) `test_route_still_rejects_an_unknown_value` now patches `get_supabase_client` like its two siblings so a validator mutation cannot reach a real Supabase client (under mutation it had produced a live `getaddrinfo` attempt).
- Mutation checks, every one reddened then restored byte-identical: remove each of the three keys (5 failed / 6 passed, identical node set), remove all three, `if item not in VALID_MATTERED_MOST` → `if False` (the rejects-unknown pin reddens), regex shape (reordered + multi-line chips), plus the adversary's independent re-run of all six with a sha256-verified restore harness.

### Honest limits

- This makes the server accept what the app sends for `mattered_most` only. Whether the app's other feedback fields survive the route is not this unit's claim.
- Local `fastapi 0.115.0` / `pydantic 2.7.0` vs pinned `0.141.1` / `2.13.4` (CI and Railway install the pins): the route tests assert on status codes only, never on the 422 body shape, so the drift cannot flip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
