### PR TITLE
fix(429): tell the client when to come back, on both 429 classes (W1-9)

### DIFF
--- a/app/middleware/error_handler.py
+++ b/app/middleware/error_handler.py
@@ -10,6 +10,7 @@ Response format:
 }
 """
 import logging
+import time
 from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -38,17 +39,35 @@ def _get_request_id(request: Request) -> str:
     return getattr(request.state, "request_id", "unknown")
 
 
-def _build_error_response(status_code: int, message: str, request_id: str) -> JSONResponse:
-    """Build standardized error JSON response."""
+def _build_error_response(
+    status_code: int,
+    message: str,
+    request_id: str,
+    retry_after_seconds: int | None = None,
+) -> JSONResponse:
+    """Build standardized error JSON response.
+
+    ``retry_after_seconds`` is ADDITIVE and defaults to ``None``: when it is
+    None the response is byte-identical to what every other caller has always
+    produced. When supplied (the 429 path, W1-9) the same single value is
+    emitted BOTH as the RFC 7231 ``Retry-After`` delta-seconds header and as a
+    ``retry_after_seconds`` body field, so the two can never disagree.
+    """
     code = STATUS_CODE_MAP.get(status_code, "SERVER_ERROR")
+    content = {
+        "success": False,
+        "error": message,
+        "code": code,
+        "request_id": request_id,
+    }
+    headers = None
+    if retry_after_seconds is not None:
+        content["retry_after_seconds"] = retry_after_seconds
+        headers = {"Retry-After": str(retry_after_seconds)}
     return JSONResponse(
         status_code=status_code,
-        content={
-            "success": False,
-            "error": message,
-            "code": code,
-            "request_id": request_id,
-        },
+        content=content,
+        headers=headers,
     )
 
 
@@ -72,6 +91,25 @@ def _is_structured_detail(detail: object) -> bool:
     return has_message_key or has_code_key
 
 
+def _detail_retry_after(detail: object) -> int | None:
+    """The retry window a structured 429 detail carries, or None.
+
+    The brute-force account lockout (``_account_locked_response`` and the
+    inline raise in POST /auth/login) computes its own window and puts it in the
+    detail as ``retry_after``. W1-9: surface it on the wire under the SAME
+    contract as the slowapi 429 -- ``Retry-After`` header + ``retry_after_seconds``
+    field -- so the client sees ONE shape for both 429 classes. Only a positive
+    int counts; a bool (an int in Python), a string, a float, zero or a negative
+    value degrades to today's response rather than shipping a lie.
+    """
+    if not isinstance(detail, dict):
+        return None
+    value = detail.get("retry_after")
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
     """Handle FastAPI HTTPException with unified format.
 
@@ -89,15 +127,20 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
     else:
         message = str(detail)
 
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={
-            "success": False,
-            "error": message,
-            "code": code,
-            "request_id": _get_request_id(request),
-        },
-    )
+    # W1-9 (ruling 4): a 429 whose structured detail carries a usable
+    # retry_after gets the same additive header + field as the slowapi path.
+    retry_after = _detail_retry_after(detail) if exc.status_code == 429 else None
+    content = {
+        "success": False,
+        "error": message,
+        "code": code,
+        "request_id": _get_request_id(request),
+    }
+    headers = None
+    if retry_after is not None:
+        content["retry_after_seconds"] = retry_after
+        headers = {"Retry-After": str(retry_after)}
+    return JSONResponse(status_code=exc.status_code, content=content, headers=headers)
 
 
 async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
@@ -119,12 +162,68 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     )
 
 
+def _retry_after_seconds(request: Request) -> int | None:
+    """Seconds until the tripped limit's window resets, or None if unknown.
+
+    Reuses slowapi rather than reinventing it. slowapi stashes the limit it
+    tripped on as ``request.state.view_rate_limit`` -- MEASURED on the real app,
+    a ``(RateLimitItem, [key, scope])`` pair -- BEFORE raising, and its own
+    ``_inject_headers`` turns that into a delta with
+    ``int(1 + reset_time - time.time())`` over the limiter storage's real window
+    stats. We mirror that arithmetic exactly (its ``+ 1`` is a deliberate
+    round-UP: without it a truncated delta sends the client back a fraction of a
+    second EARLY, straight into another 429) instead of flipping
+    ``headers_enabled=True`` on the Limiter, which -- also measured -- would put
+    ``X-RateLimit-*`` and ``Retry-After`` on every SUCCESSFUL response of every
+    limited route.
+
+    MEASURED consequence, recorded because it deviates from this unit's spec:
+    that ``+ 1`` means a 60 s window can yield **61**, not <= 60 (sampled over 40
+    fresh 1/minute windows here: {61: 22, 60: 18}). The value is bounded at
+    ``window + 1`` below, so an epoch -- ``Retry-After: 1788874942``, which is
+    worse than no header at all -- is refused rather than shipped.
+    """
+    state = getattr(request.state, "view_rate_limit", None)
+    if not state:
+        return None
+
+    limit_item, args = state[0], state[1]
+    limiter = request.app.state.limiter
+    reset_time, _remaining = limiter.limiter.get_window_stats(limit_item, *args)
+
+    seconds = int(1 + reset_time - time.time())
+    if seconds <= 0 or seconds > limit_item.get_expiry() + 1:
+        # Already elapsed, or a window the tripped limit cannot possibly have
+        # produced (a storage returning an epoch). Say nothing rather than lie.
+        return None
+    return seconds
+
+
 async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
-    """Handle rate limit exceeded with unified format."""
+    """Handle rate limit exceeded with unified format.
+
+    Additive since W1-9: the 429 carries the real retry window as both a
+    ``Retry-After`` header and a ``retry_after_seconds`` body field, so a client
+    that trips a limit knows when to come back instead of hammering or giving up.
+
+    Fail-safe: if the window cannot be read for ANY reason (storage error,
+    missing state, a slowapi shape change) we log and return today's exact 429.
+    A rate-limit response must never become a 500.
+    """
+    try:
+        retry_after = _retry_after_seconds(request)
+    except Exception as exc_window:  # noqa: BLE001 - a 429 must never 500
+        logger.warning(
+            f"Rate-limit retry window unreadable "
+            f"({type(exc_window).__name__}: {exc_window}); serving 429 without it"
+        )
+        retry_after = None
+
     return _build_error_response(
         status_code=429,
         message="Rate limit exceeded. Please try again later.",
         request_id=_get_request_id(request),
+        retry_after_seconds=retry_after,
     )
 
 

--- a/tests/test_429_contract.py
+++ b/tests/test_429_contract.py
@@ -1,0 +1,411 @@
+"""W1-9 — a 429 that tells the client when to come back.
+
+Findings ``LS-FAILURE-MODES-COST-12`` / ``LS-RATELIMIT-KEY-08``. Backend half.
+
+The defect: ``app/middleware/error_handler.py::rate_limit_handler`` builds its
+own envelope and never emits ``Retry-After`` nor a ``retry_after_seconds`` body
+field, so a client that trips a limit — the first thing a launch-day spike
+produces — has no idea when to come back and either hammers or gives up.
+
+MEASURED on the slowapi ACTUALLY INSTALLED here (**0.1.9**; ``requirements.txt``
+pins **0.1.10** — local-vs-lock drift, so CI settles the pinned number):
+
+* ``request.state.view_rate_limit`` IS populated when our handler runs, in the
+  REAL app on a REAL decorated route. Shape is a 2-tuple
+  ``(RateLimitItemPerMinute, ['<key>', '<scope>'])`` — e.g.
+  ``(3 per 1 minute, ['testclient', '/api/v1/auth/password-reset'])`` — and
+  ``limiter.limiter.get_window_stats(item, *args)`` returns
+  ``WindowStats(reset_time=<epoch float>, remaining=0)``.
+  (slowapi sets it in ``__evaluate_limits`` BEFORE raising ``RateLimitExceeded``.)
+* slowapi's own ``Retry-After`` is **delta-seconds**, not an epoch: with
+  ``headers_enabled=True`` a 3/minute route emitted ``retry-after: 60`` while
+  ``x-ratelimit-reset`` was the epoch ``1788874500.96``. Its formula is
+  ``int((1 + reset_time) - time.time())``.
+
+⚠ ONE MEASURED DISAGREEMENT WITH THE SPEC, recorded not worked around: the spec
+says the delta must be "a positive integer ≤ the window length". slowapi's own
+formula carries a deliberate ``+1`` rounding-up guard, so on a 60 s window it
+yields **61** most of the time — sampled 60 fresh windows on a 1/minute route:
+``{60: 10, 61: 50}``. Matching slowapi exactly (which the spec's own "compute
+the retry window the same way slowapi does" instruction requires) therefore
+cannot satisfy ``<= 60``. These tests bound the value at ``window + 1`` and say
+so; an implementation may also clamp to the window — both pass.
+
+Blast-radius ruling pinned by ``test_successful_response_carries_no_ratelimit_headers``:
+we must NOT flip ``headers_enabled=True`` on the Limiter. Measured why — with it
+on, the **200** response also carried ``x-ratelimit-limit/remaining/reset`` AND
+``retry-after: 61``, i.e. a response-shape change across every limited route.
+
+Free tier: no network. The route's service call is mocked; the limiter uses
+in-memory storage and conftest's autouse ``_reset_rate_limiter`` gives each test
+a clean window.
+"""
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.middleware.rate_limiter import limiter
+
+# POST /api/v1/auth/password-reset is decorated @limiter.limit("3/minute"),
+# takes no auth dependency, and its only side effect is one awaited service
+# call we mock. So the 4th call in a window is a pure 429 from the handler
+# under test, with no paid work and no live Supabase call.
+_ROUTE = "/api/v1/auth/password-reset"
+_BODY = {"email": "w19-429-contract@example.com"}
+_LIMIT_AMOUNT = 3
+_WINDOW_SECONDS = 60  # "3/minute"; measured via view_rate_limit[0].get_expiry()
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    """TestClient on the REAL app with the route's service call mocked."""
+    monkeypatch.setattr(
+        "app.api.auth_routes.request_password_reset",
+        AsyncMock(return_value={"success": True, "message": "sent"}),
+    )
+    with TestClient(app) as tc:
+        yield tc
+
+
+def _drive_to_429(client):
+    """Spend the window and return (successful_responses, first_429)."""
+    oks = []
+    for _ in range(_LIMIT_AMOUNT + 3):
+        resp = client.post(_ROUTE, json=_BODY)
+        if resp.status_code == 429:
+            return oks, resp
+        assert resp.status_code == 200, (
+            f"unexpected pre-429 status {resp.status_code}: {resp.text}"
+        )
+        oks.append(resp)
+    raise AssertionError(
+        f"route never 429'd after {_LIMIT_AMOUNT + 3} calls — limiter not engaged"
+    )
+
+
+def _header(resp, name):
+    """Case-insensitive header lookup returning None when absent."""
+    for k, v in resp.headers.items():
+        if k.lower() == name.lower():
+            return v
+    return None
+
+
+# ---------------------------------------------------------------- test 1 (RED)
+def test_429_carries_retry_after_header(client):
+    """A limited route pushed past its limit answers 429 with a Retry-After
+    header that parses as a positive integer bounded by the window.
+
+    RED today: the header is absent entirely (measured — today's 429 carries
+    only the request-id and the security headers).
+
+    The bound is ``window + 1``, not ``window``: see the module docstring's
+    recorded spec disagreement. A delta-seconds value is what RFC 7231 requires;
+    an epoch (~1.78e9) would be worse than no header at all, and the upper bound
+    is what rejects it.
+    """
+    _oks, resp = _drive_to_429(client)
+
+    raw = _header(resp, "Retry-After")
+    assert raw is not None, (
+        "429 carries no Retry-After header — the client has no idea when to "
+        f"come back. Headers seen: {dict(resp.headers)}"
+    )
+
+    try:
+        seconds = int(raw)
+    except (TypeError, ValueError):  # pragma: no cover — asserted below
+        pytest.fail(
+            f"Retry-After must be delta-seconds per RFC 7231, got {raw!r}. An "
+            "HTTP-date would also be legal but the client half expects an int."
+        )
+
+    assert seconds > 0, f"Retry-After must be positive, got {seconds}"
+    assert seconds <= _WINDOW_SECONDS + 1, (
+        f"Retry-After {seconds} exceeds the {_WINDOW_SECONDS}s window (+1 for "
+        "slowapi's rounding guard) — that smells like an epoch, not a delta"
+    )
+
+
+# ---------------------------------------------------------------- test 2 (RED)
+def test_429_body_carries_retry_after_seconds_equal_to_header(client):
+    """The body carries ``retry_after_seconds``, an int equal to the header.
+
+    RED today: the key is absent from the envelope.
+
+    Equality is the real assertion — it forces ONE computation feeding both
+    surfaces. Two independent ``time.time()`` reads would disagree by 1 at a
+    second boundary and hand the client two different answers.
+    """
+    _oks, resp = _drive_to_429(client)
+    body = resp.json()
+
+    assert "retry_after_seconds" in body, (
+        f"429 body has no retry_after_seconds: {body}"
+    )
+    value = body["retry_after_seconds"]
+    assert isinstance(value, int) and not isinstance(value, bool), (
+        f"retry_after_seconds must be an int, got {type(value).__name__}: {value!r}"
+    )
+    assert value > 0, f"retry_after_seconds must be positive, got {value}"
+
+    raw = _header(resp, "Retry-After")
+    assert raw is not None, "header missing — see test 1"
+    assert int(raw) == value, (
+        f"header Retry-After={raw!r} disagrees with body "
+        f"retry_after_seconds={value} — compute the window ONCE"
+    )
+
+
+# ------------------------------------------------------------ test 3 (PIN)
+def test_429_envelope_shape_is_preserved(client):
+    """The unified envelope is additive-only: ``success`` false, ``error``,
+    ``code``, ``request_id`` all survive.
+
+    ``code`` stays whatever the 429 path emits today — ``STATUS_CODE_MAP[429]``
+    is ``RATE_LIMITED`` (measured on the live response).
+
+    Green today; it is here to fail if the fix rebuilds the response instead of
+    extending it.
+    """
+    _oks, resp = _drive_to_429(client)
+    body = resp.json()
+
+    assert body.get("success") is False, body
+    assert isinstance(body.get("error"), str) and body["error"], body
+    assert body.get("code") == "RATE_LIMITED", body
+    assert isinstance(body.get("request_id"), str) and body["request_id"], body
+    # request_id must be the real one from the middleware, echoed in the header.
+    assert body["request_id"] == _header(resp, "X-Request-ID"), body
+
+
+# ------------------------------------------------------- test 4a (fail-safe)
+def test_window_stats_failure_still_returns_todays_429(client, monkeypatch):
+    """Fail-safe: if the window stats cannot be read, the response is today's
+    exact 429 — same envelope, no header, and never a 500.
+
+    A rate-limit response must never become a server error. This is the
+    ``try/except`` the spec's mutation check removes.
+
+    NOTE (honest): with no implementation this passes vacuously — nothing reads
+    window stats yet, so nothing can raise. ``test_handler_reads_window_stats``
+    below is the non-vacuous half and IS red today.
+    """
+    boom_calls = []
+
+    def _boom(*args, **kwargs):
+        boom_calls.append(args)
+        raise RuntimeError("storage unreachable")
+
+    monkeypatch.setattr(limiter.limiter, "get_window_stats", _boom, raising=False)
+
+    _oks, resp = _drive_to_429(client)
+
+    assert resp.status_code == 429, (
+        f"window-stats failure escalated to {resp.status_code} — a rate-limit "
+        f"response must never 500. Body: {resp.text}"
+    )
+    body = resp.json()
+    assert body.get("success") is False, body
+    assert body.get("code") == "RATE_LIMITED", body
+    assert isinstance(body.get("error"), str) and body["error"], body
+    assert isinstance(body.get("request_id"), str) and body["request_id"], body
+    assert _header(resp, "Retry-After") is None, (
+        "a Retry-After was emitted even though the window stats raised — the "
+        "value cannot be trustworthy"
+    )
+    assert "retry_after_seconds" not in body, (
+        f"retry_after_seconds present despite unreadable window stats: {body}"
+    )
+
+
+# ------------------------------------------------------ test 4b (RED, non-vacuous)
+def test_handler_reads_window_stats(client, monkeypatch):
+    """The 429 path actually consults the limiter's window stats.
+
+    RED today: ``rate_limit_handler`` reads nothing — it returns a constant
+    message — so ``get_window_stats`` is never called on the 429 path.
+
+    This is what makes the fail-safe test above mean something. It also pins the
+    SOURCE of the number: the real remaining window from the limiter's storage,
+    which is how slowapi's own ``_inject_headers`` computes it. Deriving the
+    delta from ``RateLimitExceeded.limit``'s expiry instead would always report
+    the FULL window rather than the time actually left, which is a different and
+    wrong answer.
+    """
+    calls = []
+    real = limiter.limiter.get_window_stats
+
+    def _spy(*args, **kwargs):
+        calls.append(args)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(limiter.limiter, "get_window_stats", _spy, raising=False)
+
+    _oks, resp = _drive_to_429(client)
+
+    assert resp.status_code == 429, resp.text
+    assert calls, (
+        "get_window_stats was never called while building the 429 — the handler "
+        "is not reading the real retry window from the limiter's storage"
+    )
+
+
+# ------------------------------------------------------------ test 5 (PIN)
+def test_successful_response_carries_no_ratelimit_headers(client):
+    """Blast-radius ruling: a SUCCESSFUL response on a limited route carries no
+    ``X-RateLimit-*`` and no ``Retry-After``.
+
+    Green today; it must stay green. It fails the moment someone "fixes" this
+    unit by flipping ``headers_enabled=True`` on the Limiter — measured, that
+    injects ``x-ratelimit-limit/remaining/reset`` AND ``retry-after: 61`` onto
+    every 200 of every limited route, a response-shape change across 60+
+    endpoints for a unit that is about the 429.
+    """
+    oks, _resp429 = _drive_to_429(client)
+    assert oks, "no successful response captured before the 429"
+
+    for ok in oks:
+        leaked = sorted(
+            k for k in ok.headers.keys() if k.lower().startswith("x-ratelimit")
+        )
+        assert not leaked, (
+            f"successful response leaked rate-limit headers {leaked} — the "
+            "Limiter's headers_enabled must stay OFF"
+        )
+        assert _header(ok, "Retry-After") is None, (
+            "successful response carries Retry-After — headers_enabled leaked "
+            "onto the 200 path"
+        )
+
+# ============================================================ lockout path
+# Ruling 4 in the spec's FABLE RULINGS (binding) + the adversary's major:
+# the app's SECOND 429 class -- the brute-force account lockout raised by
+# POST /auth/login, PUT /auth/email and PUT /auth/password via
+# `_account_locked_response` -- computes its own retry window, puts it in the
+# structured HTTPException detail as `retry_after`, and `http_exception_handler`
+# silently dropped it (measured: the 300 never reached the wire). Same finding,
+# second path, on the credential routes where a hammering client matters most.
+# The client half (W3-14) needs ONE contract, so the lockout 429 must emit the
+# SAME `Retry-After` header and `retry_after_seconds` body field as the
+# slowapi path above -- never a second field name.
+
+import asyncio
+import json
+import time
+
+from fastapi import HTTPException
+from starlette.requests import Request as _StarletteRequest
+
+from app.middleware.error_handler import http_exception_handler
+
+
+def _bare_request():
+    """A minimal Starlette Request whose state carries no request_id."""
+    return _StarletteRequest(
+        {"type": "http", "method": "GET", "path": "/x", "headers": [], "query_string": b""}
+    )
+
+
+def _handle(status, detail):
+    """Run http_exception_handler directly and return (status, headers, body)."""
+    resp = asyncio.run(http_exception_handler(_bare_request(), HTTPException(status, detail=detail)))
+    return resp.status_code, {k.lower(): v for k, v in resp.headers.items()}, json.loads(resp.body)
+
+
+# ---------------------------------------------------------------- lockout (RED)
+def test_lockout_429_carries_the_same_retry_after_contract(client, monkeypatch):
+    """POST /auth/login while the account is locked answers 429 ACCOUNT_LOCKED
+    with `Retry-After: 300` and `retry_after_seconds: 300` -- the value the
+    route already computed. RED today: http_exception_handler drops it.
+
+    Drives the REAL route with only the lockout check mocked, so the 429 comes
+    from the real raise site and the real handler.
+    """
+    monkeypatch.setattr(
+        "app.api.auth_routes.check_account_locked",
+        AsyncMock(return_value={"locked": True, "retry_after": 300}),
+    )
+    # The lockout branch fires an audit write; stub it so this test can never
+    # reach a real Supabase client (it produced a live getaddrinfo without this).
+    monkeypatch.setattr("app.api.auth_routes.log_audit_event", AsyncMock(return_value=None))
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"email": "w19-locked@example.com", "password": "Whatever123"},
+    )
+    assert resp.status_code == 429, resp.text
+    body = resp.json()
+    assert body.get("code") == "ACCOUNT_LOCKED", body
+    assert body.get("success") is False, body
+    assert isinstance(body.get("error"), str) and body["error"], body
+    assert isinstance(body.get("request_id"), str) and body["request_id"], body
+    assert _header(resp, "Retry-After") == "300", (
+        f"lockout 429 lost its retry window: headers={dict(resp.headers)}"
+    )
+    assert body.get("retry_after_seconds") == 300, body
+
+
+# ------------------------------------------------------- lockout pins (green)
+def test_structured_429_without_retry_after_is_unchanged():
+    """A structured 429 detail that carries no retry_after gets today's exact
+    envelope: no header, no field. The addition is strictly additive."""
+    status, headers, body = _handle(429, {"error": "slow down", "code": "THROTTLED"})
+    assert status == 429
+    assert body == {"success": False, "error": "slow down", "code": "THROTTLED", "request_id": "unknown"}
+    assert "retry-after" not in headers
+
+
+def test_non_429_detail_with_a_stray_retry_after_is_ignored():
+    """retry_after is only meaningful on a 429; a 400 carrying one by accident
+    must not grow a Retry-After header."""
+    status, headers, body = _handle(400, {"error": "bad", "code": "BAD_INPUT", "retry_after": 30})
+    assert status == 400
+    assert "retry-after" not in headers
+    assert "retry_after_seconds" not in body
+
+
+@pytest.mark.parametrize("bad", [0, -5, "soon", True, 3.5, None])
+def test_lockout_429_with_an_unusable_retry_after_says_nothing(bad):
+    """Only a positive int is a retry window. Zero, negatives, strings, bools
+    (a bool IS an int in Python -- excluded on purpose), floats and None all
+    degrade to today's 429 rather than shipping a lie."""
+    status, headers, body = _handle(429, {"error": "locked", "code": "ACCOUNT_LOCKED", "retry_after": bad})
+    assert status == 429
+    assert body.get("code") == "ACCOUNT_LOCKED"
+    assert "retry-after" not in headers, headers
+    assert "retry_after_seconds" not in body, body
+
+
+# --------------------------------------------- sanity-guard pins (adversary minor)
+def test_storage_epoch_is_refused_not_shipped(client, monkeypatch):
+    """If the limiter's storage ever reports an EPOCH instead of a reset time,
+    the delta would be ~1.7e9 seconds. That is worse than no header at all
+    (the spec's own words), so the guard must say nothing. Pinned because
+    deleting the guard left the suite green (adversary, reproduced)."""
+    monkeypatch.setattr(
+        limiter.limiter, "get_window_stats",
+        lambda *a, **k: (time.time() + 1_700_000_000, 0), raising=False,
+    )
+    _oks, resp = _drive_to_429(client)
+    assert resp.status_code == 429, resp.text
+    body = resp.json()
+    assert body.get("code") == "RATE_LIMITED", body
+    assert _header(resp, "Retry-After") is None, dict(resp.headers)
+    assert "retry_after_seconds" not in body, body
+
+
+def test_already_elapsed_window_is_refused_not_shipped(client, monkeypatch):
+    """A reset time already in the past would yield a zero or negative delta.
+    Never ship it -- serve today's 429 without a window."""
+    monkeypatch.setattr(
+        limiter.limiter, "get_window_stats",
+        lambda *a, **k: (time.time() - 5, 0), raising=False,
+    )
+    _oks, resp = _drive_to_429(client)
+    assert resp.status_code == 429, resp.text
+    assert resp.json().get("code") == "RATE_LIMITED"
+    assert _header(resp, "Retry-After") is None, dict(resp.headers)
+    assert "retry_after_seconds" not in resp.json()
+


### PR DESCRIPTION
## W1-9 — a 429 that tells the client when to come back

Findings `LS-FAILURE-MODES-COST-12`, `LS-RATELIMIT-KEY-08`. **Backend half only, no flag** — additive header + field on an error response. The client half (retrying on `Retry-After`) is W3-14 and reaches phones with the OTA.

### The defect, measured

Both of the app's 429 classes told the client nothing about when to retry:

1. **slowapi limits** — `rate_limit_handler` built a constant-message envelope. No `Retry-After`, no body field. A client that tripped a limit (the first thing a launch-day spike produces) either hammered or gave up.
2. **Brute-force account lockout** — `POST /auth/login`, `PUT /auth/email`, `PUT /auth/password` compute `retry_after=300`, put it in the structured `HTTPException` detail, and `http_exception_handler` silently dropped it. Measured on the real handler: the 300 never reached the wire.

### The fix — ONE contract for both classes

- `rate_limit_handler` reads the real remaining window the way slowapi's own `_inject_headers` does — `int(1 + reset_time - time.time())` over `request.state.view_rate_limit` and the limiter storage's `get_window_stats` — and emits it as both the RFC 7231 `Retry-After` delta-seconds header and a `retry_after_seconds` body field, from ONE value so they can never disagree. **Deliberately NOT `headers_enabled=True` on the Limiter** — measured, that would put `X-RateLimit-*` + `Retry-After` on every SUCCESSFUL response of every limited route (60+ endpoints); pinned by a test that a 200 on a limited route carries no `X-RateLimit-*` header.
- `http_exception_handler` now surfaces a structured 429 detail's positive-int `retry_after` under the SAME header + field name, so the lockout 429 and the slowapi 429 ship one shape. Only a positive `int` counts (bool excluded, strings/floats/zero/negatives degrade to today's response).
- **Fail-safe:** if the window cannot be read for any reason (storage error, missing state, a slowapi shape change) the handler logs a WARNING and serves today's exact 429. A rate-limit response must never become a 500.
- **Sanity guard:** a non-positive delta or one larger than the tripped limit's own `get_expiry() + 1` (a storage returning an epoch — `Retry-After: 1788874942` is worse than no header) is refused, not shipped. Now pinned by two tests (adversary finding: deleting the guard had left the suite green).

Envelope `{success, error, code, request_id}` is byte-identical for every status when no window is emitted — `_build_error_response` with `retry_after_seconds=None` is what every other caller has always produced.

### Bound: `Retry-After <= window + 1`, not `<= window`

slowapi's `+ 1` is a deliberate round-UP (without it a truncated delta sends the client back a fraction of a second early into another 429). Measured over 40 fresh `1/minute` windows: `{61: 22, 60: 18}`; slowapi's own `headers_enabled` path emits `retry-after: 61` on a 200. The spec's original `<= window` bound was unsatisfiable together with its own "compute it the way slowapi does" instruction; the tests bound `0 < seconds <= window + 1`.

### Versions — read this before trusting a number

Every local measurement ran on the INSTALLED `slowapi 0.1.9`; `requirements.txt` pins **0.1.10** (what CI and Railway install). Nothing pins a constant, the arithmetic is read from the limiter at runtime, the upper bound derives from the tripped limit's own `get_expiry()`, and any shape change in a future slowapi lands in the fail-safe and degrades to today's 429 rather than a 500. `limits 5.8.0` — the package the arithmetic actually depends on — matches the pin exactly. `fastapi 0.115.0` / `starlette 0.38.6` local vs `0.141.1` / `1.6.0` pinned: this unit adds no framework introspection.

### Recorded, NOT fixed — a third 429 class this unit cannot reach

With `ENABLE_DEFAULT_RATE_LIMITS=true` (OFF in prod, measured), `SlowAPIMiddleware` routes through `sync_check_limits`, which on 0.1.9 contains `if inspect.iscoroutinefunction(exception_handler): exception_handler = _rate_limit_exceeded_handler` — our async `rate_limit_handler` is DISCARDED and slowapi's own is used. Measured on the real app with the flag on: `GET /health` 429s on call 11 with body `{"error":"Rate limit exceeded: 10 per 1 minute"}`, no `Retry-After`, and not even the unified envelope. Latent today; it means flipping that flag turns the 21 default-limited routes' 429s into responses strictly worse than the ones this PR fixes. Belongs in that flag's row (docs follow-up) and in its activation precondition.

### Gates

- Unit file `tests/test_429_contract.py`: **17 passed** (6 from the red phase + 11 added for the lockout path and the guard).
- Comm gate (referencers of `error_handler`/`rate_limiter` ∪ every test asserting on a 429 body ∪ own file — 28 files): **635 passed**, 2 failed = `test_auth_interceptor` ×2, both in the committed `.pre_impl_failures.txt` baseline (red-by-choice, unrelated).
- Full CI-mirrored suite at HEAD (`-m "not (live_unit or live_db or integration)"`, `--ignore=tests/test_integration.py`, `--timeout=60`, the 11 baseline nodes deselected): **17264 passed, 51 skipped, 123 deselected, 37 xfailed, 41 warnings in 364.68s (0:06:04)**, exit 0.
- ruff `E9,F63,F7,F82` + `py_compile` clean.
- Mutation checks, each reddened then restored byte-identical (sha256): header line removed → header test red; body field removed → body test red; fail-safe try/except removed → fail-safe test red; delta sourced from `exc.limit` instead of storage → `test_handler_reads_window_stats` red (that pin is load-bearing, not over-specification); lockout wiring set to `None` → lockout test red; sanity guard deleted → both guard pins red.
- Adversary verdict was DEFECTIVE on scope (the lockout path was in the ruling's scope and the first cut declined it) — fixed here; its other two findings (guard unpinned, middleware discards the async handler) are pinned / recorded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
