### PR TITLE
feat(price): sample/decant guard reads title-or-name behind ENABLE_SHOWABLE_NAME_IDENTITY (W4-5)

### DIFF
--- a/app/services/price_service.py
+++ b/app/services/price_service.py
@@ -1839,7 +1839,11 @@ def is_price_showable(
         return False
     if is_implausible_high_value_price(product_name, amount):
         return False
-    if _is_sample_or_decant_listing(product_name, title, amount):
+    if _is_sample_or_decant_listing(
+        product_name,
+        (title or price.get("name")) if showable_name_identity_enabled() else title,
+        amount,
+    ):
         return False
     # --- correctness backstop (CARDINAL RULE) — OPT-IN via enforce_correctness ---
     # Defense-in-depth at the RESPONSE CHOKEPOINT only (response_builder + streaming
@@ -4235,6 +4239,27 @@ def price_parse_offload_enabled() -> bool:
     async site keeps its existing inline call, so the rollback is
     byte-identical."""
     return os.getenv("ENABLE_PRICE_PARSE_OFFLOAD", "false").strip().lower() in (
+        "true", "1", "yes", "on",
+    )
+
+
+def showable_name_identity_enabled() -> bool:
+    """True iff W4-5 (PO-PRICE-TRUTH-04) is active (default OFF).
+
+    ``is_price_showable`` feeds the sample/decant guard the ``title`` key only,
+    but every ``extract_price_from_html`` rung (JSON-LD / OG / microdata /
+    WooCommerce / RSC) stamps the listing identity under ``name`` and never
+    writes ``title``, so a decant listing arriving through the page-scrape
+    family is invisible to the guard and ships as the full-bottle price. With
+    the flag ON the guard receives ``title or name`` (the same precedence the
+    correctness backstop already uses) as an ARGUMENT -- never written into
+    ``price["title"]``.
+
+    Read PER CALL from ``os.getenv`` (copying ``price_parse_offload_enabled``)
+    so Railway flips it without a restart. With the flag OFF the guard's
+    argument is ``title``, the identical value it receives today, so the
+    rollback is byte-identical at the function level."""
+    return os.getenv("ENABLE_SHOWABLE_NAME_IDENTITY", "false").strip().lower() in (
         "true", "1", "yes", "on",
     )
 

--- a/tests/test_showable_name_identity.py
+++ b/tests/test_showable_name_identity.py
@@ -1,0 +1,264 @@
+"""W4-5 (PO-PRICE-TRUTH-04) -- the sample/decant guard must read the identity the
+page-scrape branches actually stamp.
+
+``is_price_showable`` feeds ``_is_sample_or_decant_listing`` the ``title`` key ONLY.
+Every ``extract_price_from_html`` rung (JSON-LD / OG / microdata / WooCommerce / RSC)
+stamps the listing identity under ``name`` and never writes ``title``, so a decant
+listing that reaches the display chokepoint through the page-scrape family is
+invisible to the guard and ships as the full-bottle price.
+
+The fix is ONE argument at the guard call, behind ``ENABLE_SHOWABLE_NAME_IDENTITY``
+(default OFF, read per call):
+
+    _is_sample_or_decant_listing(
+        product_name,
+        (title or price.get("name")) if showable_name_identity_enabled() else title,
+        amount,
+    )
+
+``title or name`` -- never ``name or title``, never ``name`` alone -- and the fallback
+is an ARGUMENT, never a write into ``price["title"]``.
+
+Tests 1-4 are RED at ed75dc70 (the guard genuinely ignores ``name``); tests 5-9 pin
+the rollback, the over-rejection boundary, the precedence, the no-dict-mutation
+contract and the flag reader. ``ENABLE_EXACT_PRICE_GATE`` is left at its code
+default (ON) throughout -- the ``name`` stamps in the page-scrape family are gated
+by it, so that is the state in which the defect is reachable in prod.
+"""
+
+import pytest
+
+import app.services.price_service as ps
+from app.services.price_service import is_price_showable
+
+FLAG = "ENABLE_SHOWABLE_NAME_IDENTITY"
+
+# The review's exact reproduction (measured at ed75dc70, see .qa-w4/W4_5_UNIT_SPEC.md).
+Q = "Xerjoff Ilm Eau de Parfum"
+SAMPLE = "'Ilm Sample & Decants by Xerjoff"
+TINY = "'Ilm 2ml Glass Spray by Xerjoff"
+GENUINE = "Xerjoff 'Ilm Eau de Parfum 50ml"
+
+# 94 BHD, not a low amount: at 40 the low-fragrance FLOOR already returns False for a
+# name-only listing (the size falls to the 100 ml basis), so a low amount would make
+# every red test pass vacuously through the floor instead of through the guard.
+AMOUNT = 94
+
+
+@pytest.fixture(autouse=True)
+def _flag_env_default(monkeypatch):
+    """Start every test with the unit's flag UNSET and the exact gate at its code
+    default (ON). Toggled per test with monkeypatch.setenv/delenv, the
+    tests/test_price_parse_offload.py idiom."""
+    monkeypatch.delenv(FLAG, raising=False)
+    monkeypatch.delenv("ENABLE_EXACT_PRICE_GATE", raising=False)
+    yield
+
+
+def _review_price(**overrides):
+    """The review's price dict: {amount: 94, source_method: converted_usd, ...}."""
+    price = {"amount": AMOUNT, "source_method": "converted_usd"}
+    price.update(overrides)
+    return price
+
+
+def _showable(price, q=Q, category=None, *, enforce=True):
+    return is_price_showable(q, price, category, enforce_correctness=enforce)
+
+
+# ------------------------------------------------------------------ RED 1 ---
+
+
+def test_1_review_call_name_keyed_sample_listing_not_showable_when_flag_on(monkeypatch):
+    """RED test 1 -- the review's exact call with the flag ON returns False.
+
+    RED at ed75dc70: True (the guard is fed ``title`` only, and there is none)."""
+    monkeypatch.setenv(FLAG, "true")
+    price = _review_price(name=SAMPLE)
+    assert _showable(price) is False
+
+
+# ------------------------------------------------------------------ RED 2 ---
+
+
+def test_2_tiny_size_half_under_name_not_showable_when_flag_on(monkeypatch):
+    """RED test 2 -- the tiny-size heuristic (<= 10 ml at >= 30 BHD) is ALSO blind
+    to ``name``: a 2 ml glass spray at 94 BHD is a decant priced like a bottle.
+
+    RED at ed75dc70: True."""
+    monkeypatch.setenv(FLAG, "true")
+    price = _review_price(name=TINY)
+    assert _showable(price) is False
+
+
+# ------------------------------------------------------------------ RED 3 ---
+
+
+def test_3_method_agnostic_page_scrape_jsonld_under_name_not_showable(monkeypatch):
+    """RED test 3 -- the defect is not ``converted_usd``-specific: the genuine
+    ``page_scrape_jsonld`` method reaches the chokepoint with the same ``name``-only
+    shape and must be caught the same way.
+
+    RED at ed75dc70: True."""
+    monkeypatch.setenv(FLAG, "true")
+    price = _review_price(source_method="page_scrape_jsonld", name=SAMPLE)
+    assert _showable(price) is False
+
+
+# ------------------------------------------------------------------ RED 4 ---
+
+_TF_Q = "Tom Ford Ombré Leather"
+_TF_SAMPLE_PRICE = {"amount": 60.0, "currency": "BHD", "source_method": "converted_usd"}
+_TF_GENUINE_PRICE = {"amount": 80.0, "currency": "BHD", "source_method": "local_bhd"}
+_SONY_Q = "Sony WH-1000XM5"
+_SONY_PRICE = {"amount": 120.0, "currency": "BHD", "source_method": "local_bhd"}
+
+# (query, category, identity string, price base, expected verdict under EITHER key)
+# The four token rows are tests/test_price_showable.py::TestSampleDecantListingNotShowable's
+# title pins carried across the key; the two genuine rows pin that parity does not
+# over-reject; the electronics row pins that the regex half is category-agnostic
+# (measured: title -> False, name -> True today) and the flag must not change that.
+_PARITY_ROWS = [
+    pytest.param(_TF_Q, None, f"{_TF_Q} sample 5ml", _TF_SAMPLE_PRICE, False, id="sample"),
+    pytest.param(_TF_Q, None, f"{_TF_Q} decant 5ml", _TF_SAMPLE_PRICE, False, id="decant"),
+    pytest.param(_TF_Q, None, f"{_TF_Q} tester 5ml", _TF_SAMPLE_PRICE, False, id="tester"),
+    pytest.param(_TF_Q, None, f"{_TF_Q} vial 5ml", _TF_SAMPLE_PRICE, False, id="vial"),
+    pytest.param(_TF_Q, None, f"{_TF_Q} EDP 100ml", _TF_GENUINE_PRICE, True, id="genuine-tf-100ml"),
+    pytest.param(Q, None, GENUINE, _review_price(), True, id="genuine-xerjoff-50ml"),
+    pytest.param(
+        _SONY_Q, "electronics", "Sony WH-1000XM5 Tester unit", _SONY_PRICE, False,
+        id="electronics-tester-unit",
+    ),
+]
+
+
+@pytest.mark.parametrize("enforce", [False, True], ids=["enforce=False", "enforce=True"])
+@pytest.mark.parametrize("q,category,identity,price_base,expected", _PARITY_ROWS)
+def test_4_key_parity_name_equals_title_when_flag_on(
+    monkeypatch, q, category, identity, price_base, expected, enforce,
+):
+    """RED test 4 -- with the flag ON, ``showable({name: s})`` equals
+    ``showable({title: s})`` for every ``s``, and the title-keyed side still gives
+    the pinned verdict (so parity is never satisfied vacuously).
+
+    RED at ed75dc70 on the four token rows and the electronics row (name -> True,
+    title -> False); the two genuine rows are True under both keys today."""
+    monkeypatch.setenv(FLAG, "true")
+    by_title = _showable({**price_base, "title": identity}, q=q, category=category, enforce=enforce)
+    by_name = _showable({**price_base, "name": identity}, q=q, category=category, enforce=enforce)
+    assert by_title is expected
+    assert by_name is by_title
+
+
+# ------------------------------------------------------------------ PIN 5 ---
+
+
+@pytest.mark.parametrize("flag_value", [None, "false"], ids=["unset", "false"])
+def test_5_flag_off_review_call_stays_showable(monkeypatch, flag_value):
+    """PIN test 5 -- flag OFF (unset, and the literal "false") is byte-identical at
+    the function level: the review's exact call returns True, exactly as today.
+
+    This is the rollback pin the corpus byte-identity harness cannot see
+    (``extract_price_from_html`` never calls ``is_price_showable``)."""
+    if flag_value is None:
+        monkeypatch.delenv(FLAG, raising=False)
+    else:
+        monkeypatch.setenv(FLAG, flag_value)
+    price = _review_price(name=SAMPLE)
+    assert _showable(price) is True
+
+
+# ------------------------------------------------------------------ PIN 6 ---
+
+
+@pytest.mark.parametrize("enforce", [True, False], ids=["enforce=True", "enforce=False"])
+def test_6_genuine_name_keyed_listing_stays_showable_when_flag_on(monkeypatch, enforce):
+    """PIN test 6 -- reading ``name`` must not over-reject: a genuine 50 ml listing
+    whose identity sits under ``name`` stays showable with the flag ON (case C).
+
+    No mutation target: it guards against over-rejection by construction."""
+    monkeypatch.setenv(FLAG, "true")
+    price = _review_price(name=GENUINE)
+    assert _showable(price, enforce=enforce) is True
+
+
+# ------------------------------------------------------------------ PIN 7 ---
+
+
+@pytest.mark.parametrize("enforce", [True, False], ids=["enforce=True", "enforce=False"])
+def test_7_precedence_title_wins_over_name(monkeypatch, enforce):
+    """PIN test 7 -- ``title or name``, never ``name or title``: a present ``title``
+    short-circuits the fallback, so the adapter rungs (which carry ``title``) are
+    unchanged in both flag states. Reddens under ``name or title``."""
+    monkeypatch.setenv(FLAG, "true")
+    assert _showable(_review_price(title=GENUINE, name=SAMPLE), enforce=enforce) is True
+    assert _showable(_review_price(title=SAMPLE, name=GENUINE), enforce=enforce) is False
+
+
+# ------------------------------------------------------------------ PIN 8 ---
+
+
+def test_8_list_typed_name_is_coerced_and_title_key_is_never_written(monkeypatch):
+    """PIN test 8 -- a list-typed ``name`` is coerced INSIDE
+    ``_is_sample_or_decant_listing`` (:1765-1767), so the raw value is safe to pass
+    as an argument, and the price dict has NO ``title`` key afterwards: the
+    fallback is an argument, not a dict mutation (design item 3 -- a mutated
+    shape would leak the flag into cache rows and responses).
+
+    ``enforce_correctness=False`` is deliberate: with it True and the exact gate
+    ON, a list-typed ``name`` raises ``TypeError: unhashable type: 'list'`` today
+    inside the backstop (Honest limit 3) -- pre-existing and outside this unit."""
+    monkeypatch.setenv(FLAG, "true")
+    price = _review_price(name=["'Ilm", "Sample & Decants"])
+    result = _showable(price, enforce=False)
+    assert "title" not in price
+    assert result is False
+
+
+# ------------------------------------------------------------------ PIN 9 ---
+
+# Resolved lazily INSIDE each test (never at module import) so a missing reader
+# reddens test 9 alone instead of erroring the whole file at collection -- tests
+# 1-4 must fail because the guard ignores ``name``, not because of an ImportError.
+
+
+def _reader():
+    reader = getattr(ps, "showable_name_identity_enabled", None)
+    assert reader is not None, "price_service.showable_name_identity_enabled is missing"
+    return reader
+
+
+def test_9a_reader_default_off_when_unset(monkeypatch):
+    """PIN test 9 -- unset -> False (default OFF)."""
+    monkeypatch.delenv(FLAG, raising=False)
+    assert _reader()() is False
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("true", True), ("1", True), ("yes", True), ("on", True),
+    ("false", False), ("0", False),
+    # Adversary (2026-09-11): the reader's ``.strip().lower()`` normalisation was
+    # unpinned -- a reader without it survived every node. Operators type TRUE.
+    ("TRUE", True), (" true ", True), ("ON", True), ("Yes", True),
+    ("off", False), ("no", False), ("", False), ("  ", False),
+])
+def test_9b_reader_truthy_set_matches_price_parse_offload_idiom(monkeypatch, value, expected):
+    """PIN test 9 -- the ``price_parse_offload_enabled`` truthy set
+    ("true", "1", "yes", "on"); "false"/"0" -> False."""
+    monkeypatch.setenv(FLAG, value)
+    assert _reader()() is expected
+
+
+def test_9c_reader_is_read_per_call_not_at_import(monkeypatch):
+    """PIN test 9 -- setenv AFTER import flips the NEXT call: the module was
+    imported at collection with the flag unset, so a reader that captured the
+    env into a module constant at import would stay False here."""
+    reader = _reader()
+    monkeypatch.delenv(FLAG, raising=False)
+    assert reader() is False
+    monkeypatch.setenv(FLAG, "true")
+    assert reader() is True
+    monkeypatch.setenv(FLAG, "false")
+    assert reader() is False
+    monkeypatch.delenv(FLAG, raising=False)
+    assert reader() is False


### PR DESCRIPTION
## W4-5 — the sample/decant guard reads the identity the page-scrape rungs actually stamp (PO-PRICE-TRUTH-04)

Flag `ENABLE_SHOWABLE_NAME_IDENTITY`, **default OFF**, read per call (`price_parse_offload_enabled` idiom, same file). OFF is byte-identical at the function level: the guard is handed exactly today's argument.

**The defect, measured at `ed75dc70`.** `is_price_showable` feeds `_is_sample_or_decant_listing` the `title` key ONLY (`price_service.py:1842`). Every page-scrape producer (JSON-LD, OG, microdata, WooCommerce, RSC — all six stamp sites, gated on `ENABLE_EXACT_PRICE_GATE`) stamps the listing identity under `name` and never `title`; only the direct adapters (`_match_shopify_product`, bolo, boutiqaat, nasser, iherb) stamp `title`. So a page-scraped `"'Ilm Sample & Decants by Xerjoff"` at 94 BHD is invisible to the guard and SHOWS as the product's price (reproduced: `True`, `guard_rejected=None`, with `enforce_correctness` True and False, `converted_usd` and `page_scrape_jsonld` alike). Every other identity read on the price path already takes `title or name` (`select_best`, `warmer_write_veto`, `should_cache_price`, the backstop at `:1867`, the cache read in `structured_comparison_service.py`); the guard was the odd one out.

**The fix: one argument, nothing else.** `:1842` becomes `_is_sample_or_decant_listing(product_name, (title or price.get("name")) if showable_name_identity_enabled() else title, amount)`. `title or name`, never `name or title` and never `name` alone: the adapter rungs' `title` stays authoritative (a present `title` short-circuits the fallback, so adapter-rung verdicts are unchanged in BOTH flag states — pinned both ways). No write into `price["title"]` (the dict shape reaches cache rows and responses); the `:1819-1824` coercion block is untouched; `_is_sample_or_decant_listing` already coerces a list/non-str, so a raw `name` is safe to pass.

### Ruled OUT of this unit (own follow-up rows)
- `structured_comparison_service.py:1882/:1970/:1773` — the Firecrawl/Scrape.do/fan-out L2 content-safety surface reads `title` only for `name`-only candidates. Same defect class, different guard, different blast radius → `PO-PRICE-TRUTH-04b`.
- The low-fragrance FLOOR at `:1833` still receives `title` only; for a `name`-only tiny listing the size falls to the 100 ml basis and an honestly priced small listing PENDS (the over-rejecting mirror; changes what is shown) → `PO-PRICE-TRUTH-04c`.
- The guard stays silent (no `guard_rejected` stamp on a sample pend, contrary to its docstring) — adding one changes response metadata on every sample pend → follow-up row.
- Pre-existing: a list-typed `name` with `enforce_correctness=True` and the exact gate ON raises `TypeError` in the backstop (`extract_variant_descriptor`); in-file producers cannot emit it, a cache row could. Not this unit.

### Activation
Flip `ENABLE_SHOWABLE_NAME_IDENTITY=true` immediately after merge — no ordering coupling found. With `ENABLE_EXACT_PRICE_GATE` OFF no identity is stamped and the fallback has nothing to read (prod state is gate ON).

### Files
- `app/services/price_service.py` (+26/-1): `showable_name_identity_enabled()` at `:4246` beside `price_parse_offload_enabled`; the guard call at `:1842-1846`.
- `tests/test_showable_name_identity.py` (new, 40 nodes): red tests 1–4 + 8 (name-keyed sample/decant/tester/vial and an electronics "Tester unit" row pend with the flag ON; key parity name == title on every row, with the title-side verdict asserted so parity is never vacuous); pins 5 (flag OFF/unset: today's `True`), 6 (genuine name-keyed listing stays showable), 7 (precedence: title wins over name), 8 (list-typed name, no `title` key written), 9a–c (reader default OFF, truthy set, per-call read).

### Gates
- Unit: 40 passed (32 + the adversary's normalisation rows). `tests/test_price_showable.py`: 19 passed.
- Mutations from sha-verified byte snapshots — green phase 7 + adversary 12: revert-to-`title` reddens 14; `name or title` reddens test 7; `name` alone reddens 12; reader always-True reddens 6; module-level constant reddens 19; dict mutation reddens test 8; unflagged fallback reddens test 5; default `"true"` reddens 3; inverted reader reddens 24; fall back to `url` reddens 14. Test 6 has no mutation target by design (over-rejection guard).
- **Adversary minor (applied):** a reader without `.strip().lower()` survived all 32 nodes; test 9b now carries `TRUE` / ` true ` / `ON` / `Yes` / `off` / `no` / `""` / `"  "` rows and that mutant reddens 4. Adversary verdict: SOUND.
- Comm gate (180-file module-reference set + the unit file, 15-id deselect = 11 baseline + 4 `NETWORK_FLAKY_EXCLUDE`, base→head like-for-like): base 0 FAILED, head 0 FAILED → branch-only-NEW = [].
- Flag-OFF corpus byte-identity (`scripts/verify_flag_byte_identity.py`, base → head → base2 from a detached `ed75dc70` scratch worktree, `results` arrays compared record-by-record): 1656/1656 records, 0 diffs on all three pairings; corpus manifest unchanged before and after. **Expected equal, observed equal, harness blind to `is_price_showable`** (`extract_price_from_html` never calls it) — the function-level rollback proof is pin 5 + `test_price_showable.py` + the golden suites.
- Full CI-mirrored free-tier suite on this tree: see the final commit's CI run. ruff `E9,F63,F7,F82` + py_compile clean. CLAUDE.md flag row lands in the batch docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
