### PR TITLE
test(security): assert the 404 envelope's fields, not a "403" substring of the raw body

### DIFF
--- a/tests/test_security_regression.py
+++ b/tests/test_security_regression.py
@@ -125,7 +125,13 @@ class TestHistoryRouteHardening:
             headers={"Authorization": "Bearer test-token"}
         )
         assert response.status_code == 404
-        assert "403" not in response.text
+        # Assert on the envelope FIELDS, not the raw body: the body carries a
+        # random request_id UUID, and one containing "403" flaked CI on #157
+        # (2026-09-11). The contract is "no 403 leaks through the code/error".
+        body = response.json()
+        assert body["code"] == "NOT_FOUND"
+        assert "403" not in body["code"] and "403" not in body["error"]
+        assert "forbidden" not in body["error"].lower()
 
     @patch("app.api.auth_routes.verify_token", new_callable=AsyncMock)
     @patch("app.api.history_routes.get_comparison_by_id", new_callable=AsyncMock)


### PR DESCRIPTION
## test: harden the one body-substring assertion that flaked CI

`tests/test_security_regression.py::TestHistoryRouteHardening::test_unauthorized_comparison_returns_404_not_403` asserted `"403" not in response.text`. The 404 envelope carries a random `request_id` UUID; on #157's first CI run it was `173e5836-7324-4030-8b95-68ba17cb3537` and the assertion failed while the route answered 404 with `code: NOT_FOUND` correctly (~0.7 % per run). The test now asserts `code == "NOT_FOUND"`, no `403` in `code`/`error`, and no "forbidden" wording — the contract it was written for. The 404 status assertion is unchanged.

The suite's other three `not in resp.text` asserts (`test_m13_26_image_error_envelope.py`) check a secret, a Postgres SQLSTATE and a dotted string — none can collide with a UUID; left alone.

Test file: 104 passed. No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
